### PR TITLE
Add TT5 child theme with unified global styles for shop and courses

### DIFF
--- a/wp-content/themes/tt5-child/assets/css/custom.css
+++ b/wp-content/themes/tt5-child/assets/css/custom.css
@@ -1,0 +1,31 @@
+:root {
+  --radius: 14px;
+  --shadow: 0 8px 24px rgba(0,0,0,.08);
+}
+body {
+  background: var(--wp--preset--color--bg);
+  color: var(--wp--preset--color--text);
+  font-family: var(--wp--preset--font-family--inter);
+}
+.btn-animate {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  transition: transform .25s ease, box-shadow .25s ease;
+}
+.btn-animate:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(0,0,0,.12);
+}
+.card {
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  background: #fff;
+  overflow: hidden;
+  transition: transform .25s ease;
+}
+.card:hover {
+  transform: translateY(-3px);
+}

--- a/wp-content/themes/tt5-child/functions.php
+++ b/wp-content/themes/tt5-child/functions.php
@@ -1,0 +1,8 @@
+<?php
+add_action('wp_enqueue_scripts', function(){
+  wp_enqueue_style('tt5-child-style', get_stylesheet_uri(), [], '1.0');
+  wp_enqueue_style('tt5-child-custom', get_stylesheet_directory_uri().'/assets/css/custom.css', ['tt5-child-style'], '1.0');
+});
+add_action('after_setup_theme', function(){
+  add_theme_support('woocommerce');
+});

--- a/wp-content/themes/tt5-child/patterns/hero.php
+++ b/wp-content/themes/tt5-child/patterns/hero.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Title: Hero — Miniden
+ * Slug: tt5-child/hero
+ * Categories: banner
+ */
+?>
+<!-- wp:cover {"url":"https://source.unsplash.com/1600x900/?handmade,basket,studio","dimRatio":30,"overlayColor":"bg","minHeight":60,"minHeightUnit":"vh"} -->
+<div class="wp-block-cover" style="min-height:60vh">
+  <span aria-hidden="true" class="wp-block-cover__background has-bg-background-color has-background-dim-30 has-background-dim"></span>
+  <div class="wp-block-cover__inner-container">
+    <!-- wp:heading {"fontFamily":"playfair","textColor":"text"} -->
+    <h1 class="has-playfair-font-family has-text-color">Корзины ручной работы</h1>
+    <!-- /wp:heading -->
+    <!-- wp:paragraph {"textColor":"text"} -->
+    <p class="has-text-color">Магазин и курсы ремесла — вдохновение и уют в каждом изделии.</p>
+    <!-- /wp:paragraph -->
+    <!-- wp:buttons -->
+    <div class="wp-block-buttons">
+      <!-- wp:button {"className":"btn-animate"} -->
+      <div class="wp-block-button btn-animate"><a class="wp-block-button__link wp-element-button" href="/shop">В каталог</a></div>
+      <!-- /wp:button -->
+      <!-- wp:button {"backgroundColor":"accent","className":"btn-animate"} -->
+      <div class="wp-block-button btn-animate"><a class="wp-block-button__link has-accent-background-color has-background wp-element-button" href="/courses">К курсам</a></div>
+      <!-- /wp:button -->
+    </div>
+    <!-- /wp:buttons -->
+  </div>
+</div>
+<!-- /wp:cover -->

--- a/wp-content/themes/tt5-child/style.css
+++ b/wp-content/themes/tt5-child/style.css
@@ -1,0 +1,6 @@
+/*
+ Theme Name: TT5 Child — Miniden
+ Template: twentytwentyfive
+ Version: 1.0.0
+ Text Domain: tt5-child
+*/

--- a/wp-content/themes/tt5-child/templates/archive-product.html
+++ b/wp-content/themes/tt5-child/templates/archive-product.html
@@ -1,0 +1,8 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"24px","bottom":"24px"}}}} -->
+<div class="wp-block-group" style="padding-top:24px;padding-bottom:24px">
+  <!-- wp:heading {"level":1} --><h1>Каталог</h1><!-- /wp:heading -->
+  <!-- wp:woocommerce/product-collection {"queryId":1,"displayLayout":{"type":"grid","columns":3}} /-->
+</div>
+<!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/tt5-child/templates/single-product.html
+++ b/wp-content/themes/tt5-child/templates/single-product.html
@@ -1,0 +1,8 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"24px","bottom":"24px"}}}} -->
+<div class="wp-block-group" style="padding-top:24px;padding-bottom:24px">
+  <!-- wp:woocommerce/product-template /-->
+  <!-- wp:pattern {"slug":"tt5-child/hero"} /-->
+</div>
+<!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/tt5-child/theme.json
+++ b/wp-content/themes/tt5-child/theme.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
+  "version": 3,
+  "settings": {
+    "color": {
+      "palette": [
+        {"slug": "bg", "name": "Background", "color": "#f8f4f0"},
+        {"slug": "text", "name": "Text", "color": "#2a241e"},
+        {"slug": "primary", "name": "Primary", "color": "#7c5a3a"},
+        {"slug": "accent", "name": "Accent", "color": "#d4a373"},
+        {"slug": "muted", "name": "Muted", "color": "#bdb5ac"}
+      ]
+    },
+    "typography": {
+      "fontFamilies": [
+        {"fontFamily": "Inter, sans-serif", "name": "Inter", "slug": "inter"},
+        {"fontFamily": "'Playfair Display', serif", "name": "Playfair", "slug": "playfair"}
+      ]
+    },
+    "spacing": {
+      "units": ["px", "em", "rem"]
+    }
+  },
+  "styles": {
+    "color": {"background": "var(--wp--preset--color--bg)", "text": "var(--wp--preset--color--text)"},
+    "typography": {"fontFamily": "var(--wp--preset--font-family--inter)", "lineHeight": "1.5"},
+    "elements": {
+      "button": {
+        "border": {"radius": "14px"},
+        "color": {"background": "var(--wp--preset--color--primary)", "text": "#fff"},
+        "spacing": {"padding": {"top": "10px", "right": "18px", "bottom": "10px", "left": "18px"}},
+        "typography": {"fontWeight": "600"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create a Twenty Twenty-Five child theme with shared palette, typography, and WooCommerce support
- add custom CSS utilities and reusable hero pattern with animated buttons
- include WooCommerce archive and single product templates aligned with the new design

## Testing
- not run (WordPress CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f833e98bc83269137078bcae7dd23)