### PR TITLE
Add GitHub Actions workflow for REG.RU deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to REG.RU
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Upload files via SFTP
+        uses: wlixcc/SFTP-Deploy-Action@v1.2
+        with:
+          server: ${{ secrets.SFTP_HOST }}
+          port: ${{ secrets.SFTP_PORT }}
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          local_path: "./"
+          remote_path: ${{ secrets.REMOTE_PATH }}
+          exclude: ".git*,.github*,node_modules*,*.zip"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys to REG.RU via SFTP
- configure the job to run on pushes to the main branch and upload project files

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f98dd03908326aed74cc23263e3a2)