### PR TITLE
Update orders and profile handling

### DIFF
--- a/handlers/courses.py
+++ b/handlers/courses.py
@@ -7,6 +7,7 @@ from aiogram.types import (
 
 from services.products import get_courses, get_course_by_id
 from services.cart import add_to_cart
+from services import orders as orders_service
 from keyboards.catalog_keyboards import catalog_product_actions_kb
 
 router = Router()
@@ -55,7 +56,10 @@ async def _send_courses_page(
         - "free"  — только бесплатные
         - "paid"  — только платные
     """
+    user_id = message.from_user.id
     courses = _get_courses_for_type(payment_type)
+    courses_with_access = orders_service.get_user_courses_with_access(user_id)
+    access_ids = {c["id"] for c in courses_with_access}
 
     if not courses:
         text = (
@@ -92,7 +96,7 @@ async def _send_courses_page(
         price = int(item.get("price", 0))
         desc = item.get("description") or ""
         photo = item.get("image_file_id")
-        url = item.get("detail_url")
+        url = item.get("detail_url") if item_id in access_ids else None
 
         if price <= 0:
             price_text = "💰 Цена: <b>БЕСПЛАТНО</b>"

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -1,90 +1,129 @@
 from aiogram import Router, types, F
 from aiogram.filters import Command
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 from keyboards.main_menu import PROFILE_BUTTON_TEXT
-from services.orders import get_orders_by_user, STATUS_SENT, STATUS_TITLES
+from services import orders as orders_service
+from utils.texts import format_orders_list_text
 
 router = Router()
 
+ACTIVE_STATUSES = {orders_service.STATUS_NEW, orders_service.STATUS_IN_PROGRESS}
+FINISHED_STATUSES = {orders_service.STATUS_SENT, orders_service.STATUS_PAID}
 
-def _format_profile_text(user: types.User, orders: list[dict]) -> str:
-    """
-    Формируем красивый текст профиля и заказов.
-    """
-    full_name = user.full_name or "Без имени"
+
+def _build_profile_keyboard(active_cnt: int, finished_cnt: int, courses_cnt: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text=f"📦 Активные заказы ({active_cnt})",
+                    callback_data="profile:orders:active",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=f"🗂 Завершённые заказы ({finished_cnt})",
+                    callback_data="profile:orders:finished",
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    text=f"🎓 Мои курсы ({courses_cnt})",
+                    callback_data="profile:courses",
+                )
+            ],
+        ]
+    )
+
+
+def _format_profile_text(user: types.User, orders: list[dict], courses_cnt: int) -> str:
+    full_name = user.full_name or "—"
     username = f"@{user.username}" if user.username else "—"
     user_id = user.id
 
-    lines: list[str] = [
+    total_orders = len(orders)
+    active_cnt = len([o for o in orders if o.get("status") in ACTIVE_STATUSES])
+    finished_cnt = len([o for o in orders if o.get("status") in FINISHED_STATUSES])
+
+    lines = [
         "👤 <b>Ваш профиль</b>",
         "",
+        f"ID: <code>{user_id}</code>",
         f"Имя: <b>{full_name}</b>",
         f"Ник: <b>{username}</b>",
-        f"ID: <code>{user_id}</code>",
         "",
+        f"Всего заказов: <b>{total_orders}</b>",
+        f"Активные: <b>{active_cnt}</b>",
+        f"Завершённые: <b>{finished_cnt}</b>",
+        f"Курсов с доступом: <b>{courses_cnt}</b>",
     ]
 
-    if not orders:
-        lines.append("Пока нет оформленных заказов.")
-        return "\n".join(lines)
-
-    active: list[dict] = []
-    finished: list[dict] = []
-
-    for o in orders:
-        status = o.get("status")
-        if status == STATUS_SENT:
-            finished.append(o)
-        else:
-            active.append(o)
-
-    # Актуальные заказы
-    lines.append("📦 <b>Актуальные заказы</b>")
-    if not active:
-        lines.append("— нет активных заказов.")
-    else:
-        for o in active:
-            status = o.get("status")
-            status_title = STATUS_TITLES.get(status, status or "")
-            lines.append(
-                f"\nЗаказ №{o['id']} — <b>{status_title}</b>"
-                f"\nСумма: <b>{o['total']} ₽</b>"
-                f"\nОформлен: {o['created_at']}"
-            )
-
-    # История
-    lines.append("\n🗂 <b>История заказов</b>")
-    if not finished:
-        lines.append("— пока ещё нет завершённых заказов.")
-    else:
-        for o in finished:
-            status = o.get("status")
-            status_title = STATUS_TITLES.get(status, status or "")
-            lines.append(
-                f"\nЗаказ №{o['id']} — <b>{status_title}</b>"
-                f"\nСумма: <b>{o['total']} ₽</b>"
-                f"\nДата: {o['created_at']}"
-            )
-
-    lines.append(
-        "\nЕсли хотите уточнить статус или получить доступ к курсам — "
-        "просто напишите менеджеру в ответ на сообщение с заказом."
-    )
-
-    return "\n".join(lines).strip()
+    return "\n".join(lines)
 
 
 @router.message(Command("profile"))
 @router.message(F.text == PROFILE_BUTTON_TEXT)
 async def show_profile(message: types.Message) -> None:
-    """
-    Профиль пользователя:
-    - основная информация;
-    - активные заказы;
-    - история заказов.
-    """
     user = message.from_user
-    orders = get_orders_by_user(user.id, limit=30)
+    orders = orders_service.get_orders_by_user(user.id, limit=50)
+    courses = orders_service.get_user_courses_with_access(user.id)
 
-    text = _format_profile_text(user, orders)
-    await message.answer(text)
+    active_cnt = len([o for o in orders if o.get("status") in ACTIVE_STATUSES])
+    finished_cnt = len([o for o in orders if o.get("status") in FINISHED_STATUSES])
+    courses_cnt = len(courses)
+
+    text = _format_profile_text(user, orders, courses_cnt)
+    await message.answer(
+        text,
+        reply_markup=_build_profile_keyboard(active_cnt, finished_cnt, courses_cnt),
+    )
+
+
+@router.callback_query(F.data == "profile:orders:active")
+async def profile_orders_active(callback: types.CallbackQuery) -> None:
+    user_id = callback.from_user.id
+    orders = orders_service.get_orders_by_user(user_id, limit=50)
+    active_orders = [o for o in orders if o.get("status") in ACTIVE_STATUSES]
+
+    text = format_orders_list_text(active_orders)
+    await callback.message.answer(text)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "profile:orders:finished")
+async def profile_orders_finished(callback: types.CallbackQuery) -> None:
+    user_id = callback.from_user.id
+    orders = orders_service.get_orders_by_user(user_id, limit=50)
+    finished_orders = [o for o in orders if o.get("status") in FINISHED_STATUSES]
+
+    text = format_orders_list_text(finished_orders)
+    await callback.message.answer(text)
+    await callback.answer()
+
+
+@router.callback_query(F.data == "profile:courses")
+async def profile_courses(callback: types.CallbackQuery) -> None:
+    user_id = callback.from_user.id
+    courses = orders_service.get_user_courses_with_access(user_id)
+
+    if not courses:
+        await callback.message.answer("Пока нет доступных курсов. Оплатите заказ с курсом, чтобы открыть доступ.")
+        await callback.answer()
+        return
+
+    lines: list[str] = ["🎓 <b>Мои курсы</b>:\n"]
+    for idx, course in enumerate(courses, start=1):
+        name = course.get("name", "Курс")
+        desc = (course.get("description") or "").strip()
+        url = course.get("detail_url")
+
+        lines.append(f"{idx}. <b>{name}</b>")
+        if desc:
+            lines.append(desc)
+        if url:
+            lines.append(f"Ссылка: {url}")
+        lines.append("")
+
+    await callback.message.answer("\n".join(lines).strip())
+    await callback.answer()

--- a/services/products.py
+++ b/services/products.py
@@ -87,8 +87,8 @@ def _init_products_table_if_needed() -> None:
             (
                 item_id,
                 "basket",
-                price,
                 name,
+                price,
                 description,
                 detail_url,
             ),


### PR DESCRIPTION
## Summary
- revise orders service with paid status and course access helpers
- gate course links by paid orders and expand profile view
- fix product initialization ordering for seeded data

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f379dc8b48326bca9504f25dbdc01)