### PR TITLE
Add CRM client profile support for admins

### DIFF
--- a/services/user_stats.py
+++ b/services/user_stats.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any
+
+from database import get_connection
+from services import orders as orders_service
+
+
+def get_user_order_stats(user_id: int) -> dict[str, Any]:
+    """Подсчитать статистику по заказам пользователя для CRM."""
+
+    result: dict[str, Any] = {
+        "user_id": user_id,
+        "total_orders": 0,
+        "total_amount": 0,
+        "orders_by_status": {
+            orders_service.STATUS_NEW: 0,
+            orders_service.STATUS_IN_PROGRESS: 0,
+            orders_service.STATUS_PAID: 0,
+            orders_service.STATUS_SENT: 0,
+            orders_service.STATUS_ARCHIVED: 0,
+        },
+        "last_order_id": None,
+        "last_order_created_at": None,
+    }
+
+    conn = get_connection()
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        SELECT COUNT(*) AS cnt, COALESCE(SUM(total), 0) AS total_amount
+        FROM orders
+        WHERE user_id = ?
+        """,
+        (user_id,),
+    )
+    row = cur.fetchone()
+    if row:
+        result["total_orders"] = int(row["cnt"] or 0)
+        result["total_amount"] = int(row["total_amount"] or 0)
+
+    cur.execute(
+        """
+        SELECT status, COUNT(*) AS cnt
+        FROM orders
+        WHERE user_id = ?
+        GROUP BY status
+        """,
+        (user_id,),
+    )
+    for status_row in cur.fetchall():
+        status = status_row["status"]
+        count = int(status_row["cnt"] or 0)
+        if status in result["orders_by_status"]:
+            result["orders_by_status"][status] = count
+
+    cur.execute(
+        """
+        SELECT id, created_at
+        FROM orders
+        WHERE user_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+        """,
+        (user_id,),
+    )
+    last_order = cur.fetchone()
+    conn.close()
+
+    if last_order:
+        result["last_order_id"] = int(last_order["id"])
+        result["last_order_created_at"] = last_order["created_at"]
+
+    return result
+
+
+def get_user_courses_summary(user_id: int) -> dict[str, Any]:
+    """Сводка по курсам, к которым у пользователя есть доступ."""
+
+    courses = orders_service.get_user_courses_with_access(user_id)
+    return {
+        "count": len(courses),
+        "courses": courses,
+    }

--- a/utils/texts.py
+++ b/utils/texts.py
@@ -98,7 +98,7 @@ def format_order_for_admin(
     return "\n".join(lines).strip()
 
 
-def format_orders_list_text(order_list: list[dict]) -> str:
+def format_orders_list_text(order_list: list[dict], show_client_hint: bool = False) -> str:
     """
     Форматирование списка заказов для команды /orders.
     Показываем: №, статус, сумма, имя, контакт.
@@ -121,6 +121,11 @@ def format_orders_list_text(order_list: list[dict]) -> str:
             f"\n📞 Контакт: {order['contact']}"
             f"\n💰 Сумма: <b>{order['total']} ₽</b>"
             f"\n🕒 Время: {order.get('created_at', '—')}"
+        )
+
+    if show_client_hint:
+        lines.append(
+            "\nЧтобы открыть профиль клиента, отправьте: /client <telegram_id>"
         )
 
     return "\n".join(lines).strip()
@@ -183,5 +188,62 @@ def format_order_detail_text(order: dict) -> str:
 
     total = order.get("total", 0)
     lines.append(f"\n💰 <b>Итого: {total} ₽</b>")
+
+    return "\n".join(lines).strip()
+
+
+def format_admin_client_profile(
+    user_id: int, user_stats: dict, courses_summary: dict
+) -> str:
+    """Сформировать HTML-профиль клиента для администратора."""
+
+    lines: list[str] = []
+
+    lines.append("👤 <b>Профиль клиента</b>")
+    lines.append("")
+    lines.append(f"🧑‍💻 Telegram: id=<code>{user_id}</code>")
+
+    lines.append("")
+    lines.append("📊 <b>Статистика заказов</b>")
+    total_orders = user_stats.get("total_orders", 0)
+    total_amount = user_stats.get("total_amount", 0)
+    orders_by_status = user_stats.get("orders_by_status", {}) or {}
+
+    lines.append(f"Всего заказов: <b>{total_orders}</b>")
+    lines.append(f"Сумма всех заказов: <b>{total_amount} ₽</b>")
+
+    status_lines = {
+        orders_service.STATUS_NEW: "🆕 Новые",
+        orders_service.STATUS_IN_PROGRESS: "🕒 В работе",
+        orders_service.STATUS_PAID: "✅ Оплаченные",
+        orders_service.STATUS_SENT: "📤 Отправленные",
+        orders_service.STATUS_ARCHIVED: "📁 Архив",
+    }
+
+    for status, title in status_lines.items():
+        count = int(orders_by_status.get(status, 0) or 0)
+        if count > 0:
+            lines.append(f"{title}: {count}")
+
+    last_order_id = user_stats.get("last_order_id")
+    last_order_created_at = user_stats.get("last_order_created_at")
+    if last_order_id and last_order_created_at:
+        lines.append(f"Последний заказ: №{last_order_id} от {last_order_created_at}")
+
+    lines.append("")
+    lines.append("🎓 <b>Курсы с доступом</b>")
+    courses_count = courses_summary.get("count", 0)
+    courses = courses_summary.get("courses") or []
+    lines.append(f"Всего: <b>{courses_count}</b>")
+
+    if courses:
+        lines.append("")
+        for idx, course in enumerate(courses, start=1):
+            name = course.get("name", "Курс")
+            detail_url = course.get("detail_url")
+
+            lines.append(f"{idx}. <b>{name}</b>")
+            if detail_url:
+                lines.append(str(detail_url))
 
     return "\n".join(lines).strip()


### PR DESCRIPTION
## Summary
- add CRM user stats and course summary helpers for admin views
- format admin client profile output and include hint in orders list
- implement /client command for admins to view CRM profile

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f56ca7f08832694f14b97ca34591b)