### PR TITLE
Escape admin command placeholders for HTML parse

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -947,13 +947,17 @@ async def admin_ban_user(message: types.Message) -> None:
 
     parts = (message.text or "").split(maxsplit=2)
     if len(parts) < 2:
-        await message.answer("Использование: /ban <user_id> [причина]")
+        await message.answer(
+            "Использование: <code>/ban &lt;user_id&gt; [причина]</code>"
+        )
         return
 
     try:
         target_user_id = int(parts[1])
     except ValueError:
-        await message.answer("Использование: /ban <user_id> [причина]")
+        await message.answer(
+            "Использование: <code>/ban &lt;user_id&gt; [причина]</code>"
+        )
         return
 
     reason = parts[2].strip() if len(parts) == 3 else None
@@ -976,13 +980,13 @@ async def admin_unban_user(message: types.Message) -> None:
 
     parts = (message.text or "").split(maxsplit=1)
     if len(parts) < 2:
-        await message.answer("Использование: /unban <user_id>")
+        await message.answer("Использование: <code>/unban &lt;user_id&gt;</code>")
         return
 
     try:
         target_user_id = int(parts[1])
     except ValueError:
-        await message.answer("Использование: /unban <user_id>")
+        await message.answer("Использование: <code>/unban &lt;user_id&gt;</code>")
         return
 
     user_admin_service.set_user_ban_status(
@@ -999,13 +1003,17 @@ async def admin_add_note(message: types.Message) -> None:
 
     parts = (message.text or "").split(maxsplit=2)
     if len(parts) < 3:
-        await message.answer("Использование: /note <user_id> <текст заметки>")
+        await message.answer(
+            "Использование: <code>/note &lt;user_id&gt; &lt;текст заметки&gt;</code>"
+        )
         return
 
     try:
         target_user_id = int(parts[1])
     except ValueError:
-        await message.answer("Использование: /note <user_id> <текст заметки>")
+        await message.answer(
+            "Использование: <code>/note &lt;user_id&gt; &lt;текст заметки&gt;</code>"
+        )
         return
 
     note_text = parts[2].strip()
@@ -1027,13 +1035,13 @@ async def admin_show_notes(message: types.Message) -> None:
 
     parts = (message.text or "").split(maxsplit=1)
     if len(parts) < 2:
-        await message.answer("Использование: /notes <user_id>")
+        await message.answer("Использование: <code>/notes &lt;user_id&gt;</code>")
         return
 
     try:
         target_user_id = int(parts[1])
     except ValueError:
-        await message.answer("Использование: /notes <user_id>")
+        await message.answer("Использование: <code>/notes &lt;user_id&gt;</code>")
         return
 
     notes = user_admin_service.get_user_notes(target_user_id)
@@ -1061,7 +1069,7 @@ async def admin_client_profile(message: types.Message) -> None:
     if not _is_admin(message.from_user.id):
         return
 
-    usage_text = "Использование: /client <telegram_id_пользователя>"
+    usage_text = "Использование: <code>/client &lt;telegram_id_пользователя&gt;</code>"
     parts = (message.text or "").split(maxsplit=1)
     if len(parts) < 2:
         await message.answer(usage_text)

--- a/utils/texts.py
+++ b/utils/texts.py
@@ -142,7 +142,8 @@ def format_orders_list_text(order_list: list[dict], show_client_hint: bool = Fal
 
     if show_client_hint:
         lines.append(
-            "\nЧтобы открыть профиль клиента, отправьте: /client <telegram_id>"
+            "\nЧтобы открыть профиль клиента, отправьте:"
+            " <code>/client &lt;telegram_id&gt;</code>"
         )
 
     return "\n".join(lines).strip()


### PR DESCRIPTION
## Summary
- escape admin command placeholders in text responses to avoid HTML tag parsing
- wrap command usage examples in code tags for clarity

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5cba55608326ad854b3b8caf8842)