### PR TITLE
Add command maps and admin menus

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -14,7 +14,8 @@ from keyboards.admin_inline import (
     course_access_list_kb,
     course_access_actions_kb,
 )
-from keyboards.main_menu import get_main_menu
+from keyboards.main_menu import get_admin_menu, get_main_menu
+from utils.commands_map import get_admin_commands, get_user_commands
 from utils.texts import (
     format_admin_client_profile,
     format_orders_list_text,
@@ -103,18 +104,44 @@ async def open_admin_panel(message: types.Message, state: FSMContext):
 
     await state.clear()
 
-    kb = types.ReplyKeyboardMarkup(
-        resize_keyboard=True,
-        keyboard=[
-            [types.KeyboardButton(text="📋 Товары: корзинки")],
-            [types.KeyboardButton(text="📋 Товары: курсы")],
-            [types.KeyboardButton(text="🎓 Доступ к курсам")],
-            [types.KeyboardButton(text="📦 Заказы")],
-            [types.KeyboardButton(text="⬅️ В главное меню")],
-        ],
+    await message.answer(
+        "⚙️ Админ-панель.\nВыберите категорию:", reply_markup=get_admin_menu()
     )
 
-    await message.answer("⚙️ Админ-панель.\nВыберите категорию:", reply_markup=kb)
+
+@router.message(F.text == "👤 Клиент (CRM)")
+async def admin_client_menu_hint(message: types.Message):
+    if not _is_admin(message.from_user.id):
+        return
+
+    await message.answer(
+        "Отправьте команду <code>/client &lt;telegram_id&gt;</code>, "
+        "чтобы открыть профиль нужного клиента."
+    )
+
+
+@router.message(F.text == "🚫 Бан / ✅ Разбан")
+async def admin_ban_menu_hint(message: types.Message):
+    if not _is_admin(message.from_user.id):
+        return
+
+    await message.answer(
+        "Используйте команды:\n"
+        "• <code>/ban &lt;user_id&gt; [причина]</code>\n"
+        "• <code>/unban &lt;user_id&gt;</code>"
+    )
+
+
+@router.message(F.text == "📝 Заметки")
+async def admin_notes_menu_hint(message: types.Message):
+    if not _is_admin(message.from_user.id):
+        return
+
+    await message.answer(
+        "Работа с заметками:\n"
+        "• <code>/note &lt;user_id&gt; &lt;текст&gt;</code> — добавить заметку\n"
+        "• <code>/notes &lt;user_id&gt;</code> — посмотреть заметки"
+    )
 
 
 # =====================================================================
@@ -933,6 +960,39 @@ async def admin_course_access_revoke_user(message: types.Message, state: FSMCont
         await _send_course_access_info(message, course_id)
     else:
         await message.answer("Не удалось отозвать доступ. Возможно, его и так не было.")
+
+
+# =====================================================================
+#                          ДЕБАГ СПИСКА КОМАНД
+# =====================================================================
+
+
+@router.message(Command("debug_commands"))
+async def admin_debug_commands(message: types.Message) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+
+    user_cmds = get_user_commands()
+    admin_cmds = get_admin_commands()
+
+    lines: list[str] = ["🧩 <b>Команды бота</b>", "", "👥 Пользовательские:"]
+
+    if user_cmds:
+        for name, desc in sorted(user_cmds.items()):
+            lines.append(f"/{name} — {desc}")
+    else:
+        lines.append("(нет пользовательских команд)")
+
+    lines.append("")
+    lines.append("🛠 Админские:")
+
+    if admin_cmds:
+        for name, desc in sorted(admin_cmds.items()):
+            lines.append(f"/{name} — {desc}")
+    else:
+        lines.append("(нет админских команд)")
+
+    await message.answer("\n".join(lines))
 
 
 # =====================================================================

--- a/keyboards/main_menu.py
+++ b/keyboards/main_menu.py
@@ -1,4 +1,6 @@
-from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+from aiogram.types import KeyboardButton, ReplyKeyboardMarkup
+
+from utils.commands_map import get_admin_commands, get_user_commands
 
 PROFILE_BUTTON_TEXT = "👤 Профиль"
 
@@ -25,19 +27,21 @@ def get_main_menu(is_admin: bool = False) -> ReplyKeyboardMarkup:
     Кнопка «🔵 Старт» остаётся, чтобы всегда можно было
     перепроверять подписку.
     """
-    keyboard = [
-        [
-            KeyboardButton(text="🔵 Старт")
-        ],
-        [
-            KeyboardButton(text="🧺 Корзинки"),
-            KeyboardButton(text="🎓 Онлайн-курсы"),
-        ],
-        [
-            KeyboardButton(text="🛒 Корзина"),
-            KeyboardButton(text=PROFILE_BUTTON_TEXT),
-        ],
+
+    user_commands = get_user_commands()
+
+    keyboard: list[list[KeyboardButton]] = [
+        [KeyboardButton(text="🔵 Старт")],
+        [KeyboardButton(text="🧺 Корзинки"), KeyboardButton(text="🎓 Онлайн-курсы")],
     ]
+
+    row: list[KeyboardButton] = [KeyboardButton(text="🛒 Корзина")]
+    if "profile" in user_commands:
+        row.append(KeyboardButton(text=PROFILE_BUTTON_TEXT))
+    keyboard.append(row)
+
+    if "help" in user_commands:
+        keyboard.append([KeyboardButton(text="❓ Помощь")])
 
     if is_admin:
         keyboard.append([KeyboardButton(text="⚙️ Админка")])
@@ -46,4 +50,41 @@ def get_main_menu(is_admin: bool = False) -> ReplyKeyboardMarkup:
         keyboard=keyboard,
         resize_keyboard=True,
         input_field_placeholder="Выберите раздел…",
+    )
+
+
+def get_admin_menu() -> ReplyKeyboardMarkup:
+    """Клавиатура админского меню, собранная из ADMIN_COMMANDS."""
+
+    admin_commands = get_admin_commands()
+
+    keyboard: list[list[KeyboardButton]] = []
+
+    if "orders" in admin_commands:
+        keyboard.append([KeyboardButton(text="📦 Заказы")])
+
+    keyboard.append(
+        [
+            KeyboardButton(text="📋 Товары: корзинки"),
+            KeyboardButton(text="📋 Товары: курсы"),
+        ]
+    )
+
+    if "client" in admin_commands:
+        keyboard.append([KeyboardButton(text="👤 Клиент (CRM)")])
+
+    if {"ban", "unban"} & admin_commands.keys():
+        keyboard.append([KeyboardButton(text="🚫 Бан / ✅ Разбан")])
+
+    if {"note", "notes"} & admin_commands.keys():
+        keyboard.append([KeyboardButton(text="📝 Заметки")])
+
+    keyboard.append([KeyboardButton(text="🎓 Доступ к курсам")])
+
+    keyboard.append([KeyboardButton(text="⬅️ В главное меню")])
+
+    return ReplyKeyboardMarkup(
+        keyboard=keyboard,
+        resize_keyboard=True,
+        input_field_placeholder="Выберите действие…",
     )

--- a/utils/commands_map.py
+++ b/utils/commands_map.py
@@ -1,0 +1,33 @@
+"""Карта пользовательских и админских команд бота."""
+
+from __future__ import annotations
+
+USER_COMMANDS: dict[str, str] = {
+    "start": "Запуск бота",
+    "profile": "Мой профиль и заказы",
+    "checkout": "Начать оформление заказа",
+    "order": "Оформить заказ через корзину",
+    "clear_cart": "Очистить корзину",
+}
+
+ADMIN_COMMANDS: dict[str, str] = {
+    "orders": "Список заказов и фильтры",
+    "client": "CRM-профиль клиента",
+    "ban": "Забанить пользователя",
+    "unban": "Разбанить пользователя",
+    "note": "Добавить заметку по клиенту",
+    "notes": "Список заметок по клиенту",
+    "debug_commands": "Показать все команды бота",
+}
+
+
+def get_user_commands() -> dict[str, str]:
+    """Вернуть карту пользовательских команд."""
+
+    return USER_COMMANDS
+
+
+def get_admin_commands() -> dict[str, str]:
+    """Вернуть карту админских команд."""
+
+    return ADMIN_COMMANDS


### PR DESCRIPTION
## Summary
- add a shared commands map module for user and admin command descriptions
- update main and admin reply keyboards to build from the command maps
- wire admin handlers to the new menu, add helper prompts, and expose /debug_commands

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5e30c13c832685ebc840ebc56a8d)