### PR TITLE
Fix subscription env loading

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,21 +9,20 @@ load_dotenv()
 
 # 🔹 Канал для проверки обязательной подписки
 # Укажите username канала (с @) или установите в None, чтобы отключить проверку.
-REQUIRED_CHANNEL_USERNAME: str | None = (
-    os.getenv("REQUIRED_CHANNEL_USERNAME", "@miniden_channel").strip() or None
-)
+REQUIRED_CHANNEL_USERNAME = os.getenv("REQUIRED_CHANNEL_USERNAME")
+REQUIRED_CHANNEL_ID = os.getenv("REQUIRED_CHANNEL_ID")
 
-# Если известен числовой ID канала (начинается с -100...), укажите его здесь.
-raw_required_channel_id = os.getenv("REQUIRED_CHANNEL_ID", "").strip()
-REQUIRED_CHANNEL_ID: int | None = None
+if REQUIRED_CHANNEL_USERNAME:
+    REQUIRED_CHANNEL_USERNAME = REQUIRED_CHANNEL_USERNAME.strip() or None
 
-if raw_required_channel_id:
+if REQUIRED_CHANNEL_ID:
+    REQUIRED_CHANNEL_ID = REQUIRED_CHANNEL_ID.strip() or None
+
+if REQUIRED_CHANNEL_ID:
     try:
-        REQUIRED_CHANNEL_ID = int(raw_required_channel_id)
+        REQUIRED_CHANNEL_ID = int(REQUIRED_CHANNEL_ID)
     except ValueError:
-        # Если передали username через REQUIRED_CHANNEL_ID, используем его как username.
-        if not REQUIRED_CHANNEL_USERNAME:
-            REQUIRED_CHANNEL_USERNAME = raw_required_channel_id
+        REQUIRED_CHANNEL_ID = None
 
 
 @dataclass
@@ -107,12 +106,11 @@ def get_settings() -> Settings:
         break
 
     # 🔹 Канал, на который нужно быть подписанным
-    raw_channel_id = os.getenv("REQUIRED_CHANNEL_ID", "").strip()
     channel_link = os.getenv("REQUIRED_CHANNEL_LINK", "").strip() or None
 
     channel_id: str | None = None
-    if raw_channel_id:
-        channel_id = raw_channel_id
+    if REQUIRED_CHANNEL_ID is not None:
+        channel_id = str(REQUIRED_CHANNEL_ID)
     elif REQUIRED_CHANNEL_USERNAME:
         channel_id = REQUIRED_CHANNEL_USERNAME
 

--- a/services/subscription.py
+++ b/services/subscription.py
@@ -13,7 +13,10 @@ def _get_channel_identifier() -> Any:
 
     if REQUIRED_CHANNEL_ID is not None:
         return REQUIRED_CHANNEL_ID
-    return REQUIRED_CHANNEL_USERNAME
+    if REQUIRED_CHANNEL_USERNAME:
+        return REQUIRED_CHANNEL_USERNAME
+
+    return None
 
 
 def _get_channel_link() -> str | None:
@@ -51,7 +54,7 @@ def get_subscription_keyboard(
 async def is_user_subscribed(bot: Bot, user_id: int) -> bool:
     """Проверка статуса участника канала."""
 
-    if REQUIRED_CHANNEL_USERNAME is None and REQUIRED_CHANNEL_ID is None:
+    if not REQUIRED_CHANNEL_USERNAME and REQUIRED_CHANNEL_ID is None:
         return True
 
     chat_id = _get_channel_identifier()
@@ -61,8 +64,8 @@ async def is_user_subscribed(bot: Bot, user_id: int) -> bool:
 
     try:
         member = await bot.get_chat_member(chat_id=chat_id, user_id=user_id)
-    except Exception as exc:  # noqa: BLE001
-        logging.exception("Не удалось проверить подписку пользователя", exc_info=exc)
+    except Exception:  # noqa: BLE001
+        logging.exception("Не удалось проверить подписку")
         return False
 
     status = getattr(member, "status", None)


### PR DESCRIPTION
## Summary
- read required channel username and id strictly from .env and normalize values for settings
- use environment-driven channel selection in subscription checks and handle lookup errors gracefully

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f762b67e083268ac3e3eec5fa6c59)