### PR TITLE
Add promocodes admin entry and checkout promo step

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,7 +45,7 @@ class Settings:
     banner_profile: str | None = None
 
 
-def _load_admin_ids() -> Set[int]:
+def _load_admin_ids() -> list[int]:
     """
     Считывает админов из переменных окружения:
     - ADMIN_CHAT_ID=123
@@ -74,11 +74,13 @@ def _load_admin_ids() -> Set[int]:
             except ValueError:
                 continue
 
-    return ids
+    return list(ids)
 
 
-# Глобальный набор админов — удобно использовать в хендлерах
-ADMIN_IDS: Set[int] = _load_admin_ids()
+# Глобальный список админов — удобно использовать в хендлерах
+ADMIN_IDS: list[int] = _load_admin_ids()
+# Для быстрого поиска оставляем и множество
+ADMIN_IDS_SET: Set[int] = set(ADMIN_IDS)
 
 
 def get_settings() -> Settings:
@@ -97,7 +99,7 @@ def get_settings() -> Settings:
 
     payments_token = os.getenv("PAYMENTS_PROVIDER_TOKEN") or None
 
-    admin_ids = ADMIN_IDS or _load_admin_ids()
+    admin_ids = set(ADMIN_IDS) or set(_load_admin_ids())
 
     # Для обратной совместимости: берём первого админа из множества
     admin_chat_id: int | None = None

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -5,7 +5,7 @@ from aiogram.filters import Command
 from aiogram.fsm.state import StatesGroup, State
 from aiogram.fsm.context import FSMContext
 
-from config import ADMIN_IDS
+from config import ADMIN_IDS, ADMIN_IDS_SET
 from services import products as products_service
 from services import stats as stats_service
 from services import orders as orders_service
@@ -37,7 +37,7 @@ router = Router()
 
 
 def _is_admin(user_id: int | None) -> bool:
-    return bool(user_id) and user_id in ADMIN_IDS
+    return bool(user_id) and user_id in ADMIN_IDS_SET
 
 
 def _build_order_actions_kb(order_id: int, user_id: int) -> types.InlineKeyboardMarkup:

--- a/handlers/cart.py
+++ b/handlers/cart.py
@@ -12,7 +12,7 @@ from services.cart import (
 )
 from utils.texts import format_cart
 from keyboards.cart_keyboards import cart_kb
-from .checkout import CheckoutState  # из checkout.py
+from .checkout import CheckoutState, start_checkout_flow  # из checkout.py
 from config import ADMIN_IDS
 from services.subscription import ensure_subscribed
 
@@ -187,13 +187,5 @@ async def cart_checkout_cb(callback: CallbackQuery, state: FSMContext):
         await callback.answer("🛒 Корзина пуста.", show_alert=True)
         return
 
-    total = get_cart_total(user_id)
-    text = format_cart(items)
-
-    await callback.message.answer(
-        text
-        + "\n\nДавайте оформим заказ. Как вас зовут? 🙂"
-    )
-
-    await state.set_state(CheckoutState.waiting_for_name)
+    await start_checkout_flow(callback.message, state)
     await callback.answer()

--- a/keyboards/main_menu.py
+++ b/keyboards/main_menu.py
@@ -68,6 +68,8 @@ def get_admin_menu() -> ReplyKeyboardMarkup:
     if "stats" in admin_commands:
         keyboard.append([KeyboardButton(text="📊 Статистика")])
 
+    keyboard.append([KeyboardButton(text="🎟 Промокоды")])
+
     keyboard.append(
         [
             KeyboardButton(text="📋 Товары: корзинки"),


### PR DESCRIPTION
## Summary
- ensure admin configuration exposes ADMIN_IDS as a list and reuse a set for quick checks
- add the 🎟 Промокоды button to the admin reply keyboard and guard its handler with the admin check
- standardize checkout flow to always include the promo code step with skip option and preserve discount data in orders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ba4d9e188326a2e161e6eab85bfe)