### PR TITLE
Fix subscription verification and guard checkout commands

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,10 @@ REQUIRED_CHANNEL_USERNAME = os.getenv("REQUIRED_CHANNEL_USERNAME")
 REQUIRED_CHANNEL_ID = os.getenv("REQUIRED_CHANNEL_ID")
 
 if REQUIRED_CHANNEL_USERNAME:
-    REQUIRED_CHANNEL_USERNAME = REQUIRED_CHANNEL_USERNAME.strip() or None
+    normalized_username = REQUIRED_CHANNEL_USERNAME.strip()
+    if normalized_username.startswith("@"):
+        normalized_username = normalized_username[1:]
+    REQUIRED_CHANNEL_USERNAME = normalized_username or None
 
 if REQUIRED_CHANNEL_ID:
     REQUIRED_CHANNEL_ID = REQUIRED_CHANNEL_ID.strip() or None
@@ -34,7 +37,7 @@ class Settings:
     payments_provider_token: str | None = None
 
     # 🔹 Новые поля для проверки подписки на канал
-    required_channel_id: str | None = None       # @username или -1001234567890
+    required_channel_id: int | str | None = None  # username без @ или -1001234567890
     required_channel_link: str | None = None     # https://t.me/username
 
     # 🔹 Баннеры
@@ -110,14 +113,14 @@ def get_settings() -> Settings:
     # 🔹 Канал, на который нужно быть подписанным
     channel_link = os.getenv("REQUIRED_CHANNEL_LINK", "").strip() or None
 
-    channel_id: str | None = None
+    channel_id: int | str | None = None
     if REQUIRED_CHANNEL_ID is not None:
-        channel_id = str(REQUIRED_CHANNEL_ID)
+        channel_id = REQUIRED_CHANNEL_ID
     elif REQUIRED_CHANNEL_USERNAME:
         channel_id = REQUIRED_CHANNEL_USERNAME
 
     if not channel_link and REQUIRED_CHANNEL_USERNAME:
-        channel_link = f"https://t.me/{REQUIRED_CHANNEL_USERNAME.lstrip('@')}"
+        channel_link = f"https://t.me/{REQUIRED_CHANNEL_USERNAME}"
 
     # 🔹 Баннеры (file_id или URL)
     start_banner_id = os.getenv("START_BANNER_ID") or None

--- a/handlers/checkout.py
+++ b/handlers/checkout.py
@@ -18,6 +18,7 @@ from services.promocodes import (
 )
 from services.user_admin import get_user_ban_status
 from services.orders import add_order
+from services.subscription import ensure_subscribed
 from utils.texts import format_cart, format_order_for_admin, format_price
 
 router = Router()
@@ -82,6 +83,12 @@ async def start_checkout_flow(target_message: types.Message, state: FSMContext) 
 @router.message(Command(commands=["checkout", "order"]))
 async def start_checkout(message: types.Message, state: FSMContext) -> None:
     """Старт оформления заказа."""
+    user_id = message.from_user.id
+    is_admin = user_id in get_settings().admin_ids
+
+    if not await ensure_subscribed(message, message.bot, is_admin=is_admin):
+        return
+
     await start_checkout_flow(message, state)
 
 

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -5,6 +5,7 @@ from aiogram.types import CallbackQuery
 from config import ADMIN_IDS, get_settings
 from keyboards.main_menu import get_main_menu
 from services.subscription import (
+    ensure_subscribed,
     get_subscription_keyboard,
     is_user_subscribed,
 )
@@ -30,10 +31,8 @@ async def cmd_start(message: types.Message):
     user_id = message.from_user.id
     is_admin = user_id in ADMIN_IDS
 
-    if is_admin or await is_user_subscribed(message.bot, user_id):
+    if await ensure_subscribed(message, message.bot, is_admin=is_admin):
         await _send_start_screen(message, is_admin=is_admin)
-    else:
-        await _send_subscription_invite(message)
 
 
 # -------------------------------------------------------------------
@@ -53,11 +52,8 @@ async def start_button(message: types.Message):
     user_id = message.from_user.id
     is_admin = user_id in ADMIN_IDS
 
-    if is_admin or await is_user_subscribed(message.bot, user_id):
+    if await ensure_subscribed(message, message.bot, is_admin=is_admin):
         await _send_start_screen(message, is_admin=is_admin)
-    else:
-        # Пользователь НЕ подписан — просим подписаться.
-        await _send_subscription_invite(message)
 
 
 # -------------------------------------------------------------------

--- a/services/subscription.py
+++ b/services/subscription.py
@@ -11,6 +11,10 @@ from utils.texts import format_subscription_required_text
 def _get_channel_identifier() -> Any:
     """Вернёт chat_id/username для проверки подписки."""
 
+    settings = get_settings()
+
+    if settings.required_channel_id is not None:
+        return settings.required_channel_id
     if REQUIRED_CHANNEL_ID is not None:
         return REQUIRED_CHANNEL_ID
     if REQUIRED_CHANNEL_USERNAME:
@@ -25,8 +29,11 @@ def _get_channel_link() -> str | None:
     if settings.required_channel_link:
         return settings.required_channel_link
 
+    channel_identifier = settings.required_channel_id
+    if isinstance(channel_identifier, str) and channel_identifier:
+        return f"https://t.me/{channel_identifier}"
     if REQUIRED_CHANNEL_USERNAME:
-        return f"https://t.me/{REQUIRED_CHANNEL_USERNAME.lstrip('@')}"
+        return f"https://t.me/{REQUIRED_CHANNEL_USERNAME}"
 
     return None
 
@@ -65,7 +72,7 @@ async def is_user_subscribed(bot: Bot, user_id: int) -> bool:
     try:
         member = await bot.get_chat_member(chat_id=chat_id, user_id=user_id)
     except Exception:  # noqa: BLE001
-        logging.exception("Не удалось проверить подписку")
+        logging.exception("Не удалось проверить подписку для chat_id=%s", chat_id)
         return False
 
     status = getattr(member, "status", None)


### PR DESCRIPTION
## Summary
- normalize channel configuration from environment variables for consistent subscription checks
- stabilize subscription lookup and invitation link generation using unified settings
- enforce subscription gating for start actions and checkout commands

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920d3989774832698d35acd5b29e084)