### PR TITLE
Improve cart validation during checkout

### DIFF
--- a/handlers/cart.py
+++ b/handlers/cart.py
@@ -31,10 +31,10 @@ async def _update_cart_message(callback: CallbackQuery) -> None:
         notice = "Некоторые товары больше недоступны и были удалены из вашей корзины."
 
     if not items:
+        empty_text = "🛒 Ваша корзина пока пуста."
         if notice:
-            await callback.message.edit_text(notice)
-        else:
-            await callback.message.edit_text("🛒 Ваша корзина пока пуста.")
+            empty_text = f"{notice}\n\n{empty_text}"
+        await callback.message.edit_text(empty_text)
         return
 
     text = format_cart(items)


### PR DESCRIPTION
## Summary
- normalize product identifiers in cart cleanup and keep valid items while tracking removed entries
- clarify cart update messaging when items were removed as unavailable
- rely on checkout flow to handle empty-cart checks while surfacing notices about unavailable items

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921645c319c8326887831c892d52a99)