### PR TITLE
Fix checkout cart handling

### DIFF
--- a/handlers/cart.py
+++ b/handlers/cart.py
@@ -55,6 +55,7 @@ async def show_cart(message: types.Message) -> None:
         return
 
     items, removed = get_cart_items(user_id)
+    print(f"[DEBUG] show_cart items={len(items)} user={user_id}")
     text = format_cart(items)
 
     if removed:
@@ -196,5 +197,5 @@ async def cart_checkout_cb(callback: CallbackQuery, state: FSMContext):
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await start_checkout_flow(callback.message, state)
+    await start_checkout_flow(callback.message, state, user_id)
     await callback.answer()

--- a/handlers/checkout.py
+++ b/handlers/checkout.py
@@ -52,11 +52,13 @@ async def _ask_for_name(message: types.Message, state: FSMContext) -> None:
     await state.set_state(CheckoutState.waiting_for_name)
 
 
-async def start_checkout_flow(target_message: types.Message, state: FSMContext) -> None:
-    """Общий старт оформления заказа с шагом ввода промокода."""
+async def start_checkout_flow(
+    target_message: types.Message, state: FSMContext, user_id: int
+) -> None:
+    """Общий старт оформления заказа с шагом ввода промокода для user_id."""
 
-    user_id = target_message.from_user.id
     items, removed = get_cart_items(user_id)
+    print(f"[DEBUG] checkout items={len(items)} user={user_id}")
 
     notice_text = None
     if removed:
@@ -98,7 +100,7 @@ async def start_checkout(message: types.Message, state: FSMContext) -> None:
     if not await ensure_subscribed(message, message.bot, is_admin=is_admin):
         return
 
-    await start_checkout_flow(message, state)
+    await start_checkout_flow(message, state, user_id)
 
 
 @router.callback_query(F.data == "checkout:promo_skip")

--- a/services/cart.py
+++ b/services/cart.py
@@ -12,9 +12,9 @@ def _normalize_product_id(raw_product_id: Any) -> str:
 
 def get_cart_items(user_id: int) -> Tuple[List[dict[str, Any]], List[dict[str, Any]]]:
     """
-    Вернуть список товаров в корзине пользователя и список удалённых позиций.
+    Вернуть содержимое корзины пользователя и список удалённых позиций.
 
-    Возвращает кортеж (items, removed_items):
+    Всегда возвращает кортеж (items, removed_items):
     - items: валидные товары {product_id, name, price, qty};
     - removed_items: позиции, удалённые из корзины (битый id, qty <= 0).
       Каждая запись: {product_id, name?, reason}.


### PR DESCRIPTION
## Summary
- clarify the stable tuple interface of services.cart.get_cart_items
- ensure checkout flow uses the requesting user when loading cart items
- add debug logging to compare cart contents during view and checkout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69216ca441dc83268ea9b3fb84d92c0a)