### PR TITLE
Connect WebApp add-to-cart data flow

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,7 @@ from handlers import (
     payments,
     admin,
     profile,
+    webapp,
 )
 
 
@@ -55,6 +56,7 @@ async def main() -> None:
     dp.include_router(payments.router)
     dp.include_router(admin.router)
     dp.include_router(profile.router)
+    dp.include_router(webapp.router)
 
     # Старт поллинга
     await bot.delete_webhook(drop_pending_updates=True)

--- a/handlers/webapp.py
+++ b/handlers/webapp.py
@@ -1,0 +1,64 @@
+import json
+import logging
+
+from aiogram import F, Router
+from aiogram.types import Message
+
+from services.cart import add_to_cart
+from services.products import get_product_by_id
+
+router = Router()
+
+
+@router.message(F.web_app_data)
+async def handle_webapp_data(message: Message) -> None:
+    """
+    Обработка данных, пришедших из Telegram WebApp (sendData).
+    Ожидается JSON: {"action": "add_to_cart", "product_id": ..., "source": "..."}.
+    """
+
+    if not message.web_app_data or not message.web_app_data.data:
+        return
+
+    raw = message.web_app_data.data
+    try:
+        data = json.loads(raw)
+    except Exception:
+        logging.exception("Не удалось разобрать web_app_data: %s", raw)
+        return
+
+    if data.get("action") != "add_to_cart":
+        return
+
+    product_id = data.get("product_id")
+    if product_id is None:
+        return
+
+    try:
+        product_id_int = int(str(product_id))
+    except (TypeError, ValueError):
+        logging.warning("Некорректный product_id в web_app_data: %s", product_id)
+        return
+
+    product = get_product_by_id(product_id_int)
+    if not product:
+        logging.warning("Товар с id=%s не найден для web_app_data", product_id_int)
+        return
+
+    name = product.get("name", "Товар")
+    price = int(product.get("price", 0) or 0)
+
+    try:
+        add_to_cart(
+            user_id=message.from_user.id,
+            product_id=str(product_id_int),
+            name=name,
+            price=price,
+            qty=1,
+        )
+    except Exception:
+        logging.exception("Ошибка при добавлении товара из WebApp в корзину")
+        return
+
+    # Можно не отправлять ответ, чтобы не спамить в чат
+    # await message.answer("✅ Товар добавлен в корзину")

--- a/webapp/baskets.html
+++ b/webapp/baskets.html
@@ -203,6 +203,7 @@
 
     const baskets = [
       {
+        id: 1,
         title: "Утренний плед",
         price: "2 100 ₽",
         badge: "Хит",
@@ -210,6 +211,7 @@
         image: "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80",
       },
       {
+        id: 2,
         title: "Чайный вечер",
         price: "1 790 ₽",
         badge: "Новинка",
@@ -217,6 +219,7 @@
         image: "https://images.unsplash.com/photo-1452251889946-8ff5ea7b27ab?auto=format&fit=crop&w=900&q=80",
       },
       {
+        id: 3,
         title: "Спа-день",
         price: "2 490 ₽",
         badge: "Relax",
@@ -224,6 +227,7 @@
         image: "https://images.unsplash.com/photo-1506617420156-8e4536971650?auto=format&fit=crop&w=900&q=80",
       },
       {
+        id: 4,
         title: "Сырная радость",
         price: "2 900 ₽",
         badge: "Гастро",
@@ -283,6 +287,16 @@
     }
 
     function handleAdd(item) {
+      if (tg?.sendData) {
+        tg.sendData(
+          JSON.stringify({
+            action: "add_to_cart",
+            source: "baskets",
+            product_id: item.id,
+          })
+        );
+      }
+
       if (tg?.showPopup) {
         tg.showPopup({
           title: "В корзину",

--- a/webapp/courses.html
+++ b/webapp/courses.html
@@ -217,6 +217,7 @@
 
     const courses = [
       {
+        id: 1,
         title: "Пряники с нуля",
         price: "1 200 ₽",
         status: "Старт — сегодня",
@@ -225,6 +226,7 @@
         image: "https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?auto=format&fit=crop&w=900&q=80",
       },
       {
+        id: 2,
         title: "Мини-кондитер",
         price: "1 990 ₽",
         status: "Самостоятельно",
@@ -233,6 +235,7 @@
         image: "https://images.unsplash.com/photo-1481391032119-d89fee407e44?auto=format&fit=crop&w=900&q=80",
       },
       {
+        id: 3,
         title: "Съёмка для маркетплейсов",
         price: "1 590 ₽",
         status: "Новый поток",
@@ -241,6 +244,7 @@
         image: "https://images.unsplash.com/photo-1452251889946-8ff5ea7b27ab?auto=format&fit=crop&w=900&q=80",
       },
       {
+        id: 4,
         title: "Базовая упаковка",
         price: "Бесплатно",
         status: "Демо",
@@ -305,6 +309,16 @@
     }
 
     function handleAdd(item) {
+      if (tg?.sendData) {
+        tg.sendData(
+          JSON.stringify({
+            action: "add_to_cart",
+            source: "courses",
+            product_id: item.id,
+          })
+        );
+      }
+
       if (tg?.showPopup) {
         tg.showPopup({
           title: "Курс в корзине",


### PR DESCRIPTION
## Summary
- send Telegram WebApp add_to_cart payloads from baskets and courses pages while keeping existing UI
- add handler for web_app_data that validates payloads and stores products in the bot cart
- wire new webapp router into bot startup

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692186d553ac8326b2f10a47f1d4d271)