### PR TITLE
Add Telegram-based web auth and persistent users

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 from decimal import Decimal
-from datetime import datetime
 
-from sqlalchemy import BigInteger, Column, DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy import Boolean, BigInteger, Column, DateTime, ForeignKey, Integer, Numeric, String, Text
 from sqlalchemy.orm import relationship
 
 from database import Base
@@ -47,9 +46,13 @@ class ProductCourse(Base):
 class User(Base):
     __tablename__ = "users"
 
-    id = Column(BigInteger, primary_key=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    telegram_id = Column(BigInteger, unique=True, nullable=False, index=True)
     username = Column(String, nullable=True)
     first_name = Column(String, nullable=True)
+    last_name = Column(String, nullable=True)
+    phone = Column(String, nullable=True)
+    is_admin = Column(Boolean, default=False, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     cart_items = relationship("CartItem", back_populates="user", cascade="all, delete-orphan")
@@ -60,19 +63,19 @@ class CartItem(Base):
     __tablename__ = "cart_items"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(BigInteger, ForeignKey("users.telegram_id", ondelete="CASCADE"), nullable=False)
     product_id = Column(Integer, nullable=False)
     type = Column(String, nullable=False)
     qty = Column(Integer, nullable=False, default=1)
 
-    user = relationship("User", back_populates="cart_items")
+    user = relationship("User", back_populates="cart_items", foreign_keys=[user_id])
 
 
 class Order(Base):
     __tablename__ = "orders"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(BigInteger, ForeignKey("users.id", ondelete="SET NULL"))
+    user_id = Column(BigInteger, ForeignKey("users.telegram_id", ondelete="SET NULL"))
     total_amount = Column(Numeric(10, 2), nullable=False, default=0)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     customer_name = Column(String, nullable=True)
@@ -83,7 +86,7 @@ class Order(Base):
     status = Column(String, nullable=True)
     order_text = Column(Text, nullable=True)
 
-    user = relationship("User", back_populates="orders")
+    user = relationship("User", back_populates="orders", foreign_keys=[user_id])
     items = relationship("OrderItem", back_populates="order", cascade="all, delete-orphan")
 
 

--- a/services/cart.py
+++ b/services/cart.py
@@ -5,20 +5,8 @@ from typing import Any, Tuple
 from sqlalchemy import delete, select
 
 from database import get_session, init_db
-from models import CartItem, User
-
-
-def _ensure_user(user_id: int, username: str | None = None, first_name: str | None = None) -> None:
-    init_db()
-    with get_session() as session:
-        user = session.get(User, user_id)
-        if not user:
-            session.add(User(id=user_id, username=username, first_name=first_name))
-        else:
-            if username is not None:
-                user.username = username
-            if first_name is not None:
-                user.first_name = first_name
+from models import CartItem
+from services import users as users_service
 
 
 def get_cart_items(user_id: int) -> Tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -40,7 +28,7 @@ def get_cart_items(user_id: int) -> Tuple[list[dict[str, Any]], list[dict[str, A
 
 
 def add_to_cart(user_id: int, product_id: str, name: str, price: int, qty: int = 1, product_type: str = "basket") -> None:
-    _ensure_user(user_id)
+    users_service.get_or_create_user_from_telegram({"id": user_id})
     with get_session() as session:
         existing = session.scalar(
             select(CartItem).where(CartItem.user_id == user_id, CartItem.product_id == int(product_id), CartItem.type == product_type)

--- a/services/orders.py
+++ b/services/orders.py
@@ -1,26 +1,17 @@
 from __future__ import annotations
 
 from datetime import datetime
+from datetime import datetime
 from typing import Any, Optional
 
 from sqlalchemy import select
 
 from database import get_session, init_db
-from models import Order, OrderItem, User
+from models import Order, OrderItem
+from services import users as users_service
 from services import products as products_service
 
 STATUS_NEW = "new"
-
-
-def _ensure_user(user_id: int, username: str | None = None, first_name: str | None = None) -> User:
-    init_db()
-    with get_session() as session:
-        user = session.get(User, user_id)
-        if not user:
-            user = User(id=user_id, username=username, first_name=first_name)
-            session.add(user)
-            session.flush()
-        return user
 
 
 def add_order(
@@ -36,7 +27,7 @@ def add_order(
     discount_amount: int | None = None,
     status: str | None = STATUS_NEW,
 ) -> int:
-    _ensure_user(user_id, user_name)
+    users_service.get_or_create_user_from_telegram({"id": user_id, "first_name": user_name})
     init_db()
 
     with get_session() as session:

--- a/services/users.py
+++ b/services/users.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import select
+
+from config import ADMIN_IDS_SET
+from database import get_session, init_db
+from models import User
+
+
+def _extract_phone(data: dict[str, Any] | None) -> str | None:
+    if not data:
+        return None
+    phone = data.get("phone") or data.get("phone_number")
+    if phone:
+        return str(phone)
+    return None
+
+
+def get_or_create_user_from_telegram(data: dict[str, Any] | None) -> User:
+    if not data or "id" not in data:
+        raise ValueError("Telegram user data is required")
+
+    telegram_id = int(data["id"])
+    username = data.get("username")
+    first_name = data.get("first_name")
+    last_name = data.get("last_name")
+    phone = _extract_phone(data)
+    is_admin_flag = telegram_id in ADMIN_IDS_SET
+
+    init_db()
+    with get_session() as session:
+        user = session.scalar(select(User).where(User.telegram_id == telegram_id))
+        if user:
+            user.username = username or user.username
+            user.first_name = first_name or user.first_name
+            user.last_name = last_name or user.last_name
+            user.phone = phone or user.phone
+            user.is_admin = is_admin_flag or user.is_admin
+        else:
+            user = User(
+                telegram_id=telegram_id,
+                username=username,
+                first_name=first_name,
+                last_name=last_name,
+                phone=phone,
+                is_admin=is_admin_flag,
+                created_at=datetime.utcnow(),
+            )
+            session.add(user)
+            session.flush()
+        session.refresh(user)
+        return user
+
+
+def update_user_contact(telegram_id: int, phone: str | None) -> User:
+    init_db()
+    with get_session() as session:
+        user = session.scalar(select(User).where(User.telegram_id == telegram_id))
+        if not user:
+            raise ValueError("User not found")
+        user.phone = phone
+        session.refresh(user)
+        return user
+
+
+def get_user_by_telegram_id(telegram_id: int) -> User | None:
+    init_db()
+    with get_session() as session:
+        return session.scalar(select(User).where(User.telegram_id == telegram_id))
+
+
+def is_admin(telegram_id: int) -> bool:
+    user = get_user_by_telegram_id(int(telegram_id))
+    if not user:
+        return False
+    return bool(user.is_admin)

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -276,8 +276,10 @@
 
   <script>
     const tg = window.Telegram?.WebApp;
-    const userId = tg?.initDataUnsafe?.user?.id ?? null;
     const API_BASE = '/api';
+
+    let userId = null;
+    let isAdmin = false;
 
     const toggle = document.querySelector('.menu-toggle');
     const nav = document.querySelector('.nav-links');
@@ -331,6 +333,22 @@
         throw new Error(detail || resp.statusText);
       }
       return resp.json();
+    }
+
+    async function authorize() {
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      try {
+        const data = await fetchJson(`${API_BASE}/auth/telegram`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ initData }),
+        });
+        userId = data.telegram_id;
+        isAdmin = Boolean(data.is_admin);
+      } catch (e) {
+        showStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
+        throw e;
+      }
     }
 
     function renderProducts() {
@@ -536,10 +554,17 @@
 
     async function init() {
       hideStatus();
-      if (!userId) {
-        showStatus('Не удалось определить пользователя из Telegram WebApp', true);
+      try {
+        await authorize();
+      } catch (e) {
         return;
       }
+
+      if (!isAdmin) {
+        showStatus('Доступ только для администраторов', true);
+        return;
+      }
+
       adminContent.style.display = 'block';
       ordersSection.style.display = 'block';
       promosSection.style.display = 'block';

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -124,8 +124,11 @@
     toggle?.addEventListener('click', () => nav?.classList.toggle('open'));
 
     const tg = window.Telegram?.WebApp;
-    const userId = tg?.initDataUnsafe?.user?.id ?? null;
     const API_BASE = "/api";
+
+    let userId = null;
+    let username = null;
+    let isAdmin = false;
 
     const noteEl = document.getElementById('note');
     const tbody = document.getElementById('cart-body');
@@ -145,6 +148,23 @@
         throw new Error(text || 'Ошибка API');
       }
       return res.json();
+    }
+
+    async function authorize() {
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      try {
+        const data = await fetchJson(`${API_BASE}/auth/telegram`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ initData }),
+        });
+        userId = data.telegram_id;
+        username = data.username;
+        isAdmin = Boolean(data.is_admin);
+      } catch (e) {
+        document.querySelector('#summary').textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
+        throw e;
+      }
     }
 
     function renderEmpty(message) {
@@ -266,7 +286,16 @@
     clearBtn.addEventListener('click', clearCart);
     checkoutBtn.addEventListener('click', checkout);
 
-    loadCart();
+    async function initApp() {
+      try {
+        await authorize();
+        await loadCart();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    initApp();
   </script>
 </body>
 </html>

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -106,8 +106,11 @@
     toggle?.addEventListener('click', () => nav?.classList.toggle('open'));
 
     const tg = window.Telegram?.WebApp;
-    const userId = tg?.initDataUnsafe?.user?.id ?? null;
     const API_BASE = "/api";
+
+    let userId = null;
+    let username = null;
+    let isAdmin = false;
 
     const tabsEl = document.getElementById('tabs');
     const cardsEl = document.getElementById('cards');
@@ -135,6 +138,23 @@
         throw new Error(text || 'Ошибка API');
       }
       return res.json();
+    }
+
+    async function authorize() {
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      try {
+        const data = await fetchJson(`${API_BASE}/auth/telegram`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ initData }),
+        });
+        userId = data.telegram_id;
+        username = data.username;
+        isAdmin = Boolean(data.is_admin);
+      } catch (e) {
+        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
+        throw e;
+      }
     }
 
     function renderTabs() {
@@ -249,7 +269,17 @@
       }
     }
 
-    loadCategories().then(loadCourses);
+    async function initApp() {
+      try {
+        await authorize();
+        await loadCategories();
+        await loadCourses();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    initApp();
   </script>
 </body>
 </html>

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -126,8 +126,11 @@
     toggle?.addEventListener('click', () => nav?.classList.toggle('open'));
 
     const tg = window.Telegram?.WebApp;
-    const userId = tg?.initDataUnsafe?.user?.id ?? null;
     const API_BASE = "/api";
+
+    let userId = null;
+    let username = null;
+    let isAdmin = false;
 
     const tabsEl = document.getElementById('tabs');
     const cardsEl = document.getElementById('cards');
@@ -150,6 +153,23 @@
         throw new Error(text || 'Ошибка API');
       }
       return res.json();
+    }
+
+    async function authorize() {
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      try {
+        const data = await fetchJson(`${API_BASE}/auth/telegram`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ initData }),
+        });
+        userId = data.telegram_id;
+        username = data.username;
+        isAdmin = Boolean(data.is_admin);
+      } catch (e) {
+        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
+        throw e;
+      }
     }
 
     function renderTabs() {
@@ -261,7 +281,17 @@
       }
     }
 
-    loadCategories().then(loadProducts);
+    async function initApp() {
+      try {
+        await authorize();
+        await loadCategories();
+        await loadProducts();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    initApp();
   </script>
 </body>
 </html>

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -57,6 +57,11 @@
     .btn { cursor: pointer; border: none; border-radius: 12px; padding: 12px 14px; background: linear-gradient(135deg, #ffb800, #ff8f3f); color: #0b0c10; font-weight: 700; font-size: 15px; box-shadow: 0 10px 30px rgba(255, 184, 0, 0.25); transition: transform 0.1s ease, box-shadow 0.1s ease; margin-top: 10px; }
     .btn:hover { transform: translateY(-1px); box-shadow: 0 12px 32px rgba(255, 184, 0, 0.35); }
 
+    .message { padding: 12px; border-radius: 12px; background: rgba(255, 255, 255, 0.08); border: 1px solid rgba(255, 255, 255, 0.12); color: var(--text); margin-bottom: 14px; }
+    .error { border-color: rgba(255, 99, 99, 0.6); color: #ffc0c0; }
+    .form-group { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
+    .input { padding: 10px; border-radius: 12px; border: 1px solid rgba(255, 255, 255, 0.14); background: rgba(255, 255, 255, 0.08); color: var(--text); font-family: inherit; }
+
     @media (max-width: 780px) {
       .nav-links { display: none; }
       .nav-links.open { display: flex; flex-direction: column; align-items: flex-start; width: 100%; margin-top: 10px; }
@@ -81,30 +86,31 @@
 
   <main>
     <h1>Профиль</h1>
-    <p>Здесь появятся данные из Telegram-бота и истории заказов. Пока — демо-блоки.</p>
+    <p>Данные берутся из вашего Telegram-профиля MiniDeN и заказов.</p>
 
-    <div class="grid">
+    <div id="status" class="message" style="display:none"></div>
+
+    <div class="grid" id="profile-grid" style="display:none">
       <div class="card">
         <div class="label">Имя</div>
-        <div class="value">Ирина MiniDeN</div>
+        <div class="value" id="full-name">—</div>
         <div class="label" style="margin-top: 12px;">Telegram</div>
-        <div class="value">@miniden_demo</div>
+        <div class="value" id="username">—</div>
         <div class="label" style="margin-top: 12px;">Телефон</div>
-        <div class="value">+7 (900) 000-00-00</div>
-        <button class="btn" type="button">Редактировать позже через бота</button>
+        <div class="value" id="phone">—</div>
+
+        <div class="form-group">
+          <label class="label" for="phone-input">Обновить телефон</label>
+          <input id="phone-input" class="input" type="tel" placeholder="+7 (900) 000-00-00" />
+          <button class="btn" type="button" id="save-phone">Сохранить телефон</button>
+        </div>
       </div>
 
       <div class="card">
         <div class="label">Мои заказы</div>
-        <ul class="list">
-          <li>🧺 Домашний уют — 2 100 ₽ (в обработке)</li>
-          <li>👜 Шоппер «Ваниль» — 2 300 ₽ (доставлен)</li>
-        </ul>
-        <div class="label" style="margin-top: 12px;">Мои мастер-классы</div>
-        <ul class="list">
-          <li>🎓 Корзинка с крышкой — доступ открыт</li>
-          <li>🎓 Компактная корзинка — бесплатно</li>
-        </ul>
+        <ul class="list" id="orders-list"></ul>
+        <div class="label" style="margin-top: 12px;">Всего заказов</div>
+        <div class="value" id="orders-count">0</div>
       </div>
     </div>
   </main>
@@ -113,6 +119,111 @@
     const toggle = document.querySelector('.menu-toggle');
     const nav = document.querySelector('.nav-links');
     toggle?.addEventListener('click', () => nav?.classList.toggle('open'));
+
+    const tg = window.Telegram?.WebApp;
+    const API_BASE = "/api";
+
+    const statusEl = document.getElementById('status');
+    const profileGrid = document.getElementById('profile-grid');
+    const fullNameEl = document.getElementById('full-name');
+    const usernameEl = document.getElementById('username');
+    const phoneEl = document.getElementById('phone');
+    const phoneInput = document.getElementById('phone-input');
+    const ordersList = document.getElementById('orders-list');
+    const ordersCount = document.getElementById('orders-count');
+    const savePhoneBtn = document.getElementById('save-phone');
+
+    let userId = null;
+
+    function setStatus(message, isError = false) {
+      if (!message) {
+        statusEl.style.display = 'none';
+        statusEl.textContent = '';
+        statusEl.classList.remove('error');
+        return;
+      }
+      statusEl.textContent = message;
+      statusEl.classList.toggle('error', isError);
+      statusEl.style.display = 'block';
+    }
+
+    async function fetchJson(url, options) {
+      const res = await fetch(url, options);
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || 'Ошибка API');
+      }
+      return res.json();
+    }
+
+    async function authorize() {
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      try {
+        const data = await fetchJson(`${API_BASE}/auth/telegram`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ initData }),
+        });
+        userId = data.telegram_id;
+        setStatus('');
+      } catch (e) {
+        setStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
+        throw e;
+      }
+    }
+
+    function renderOrders(orders) {
+      ordersList.innerHTML = '';
+      if (!orders || !orders.length) {
+        const li = document.createElement('li');
+        li.textContent = 'Заказов пока нет';
+        ordersList.appendChild(li);
+        ordersCount.textContent = '0';
+        return;
+      }
+
+      orders.forEach((order) => {
+        const li = document.createElement('li');
+        li.textContent = `Заказ #${order.id} — ${order.total} ₽ (${order.status})`;
+        ordersList.appendChild(li);
+      });
+      ordersCount.textContent = String(orders.length);
+    }
+
+    async function loadProfile() {
+      const data = await fetchJson(`${API_BASE}/me?telegram_id=${userId}`);
+      const fullName = [data.first_name, data.last_name].filter(Boolean).join(' ') || '—';
+      fullNameEl.textContent = fullName;
+      usernameEl.textContent = data.username ? `@${data.username}` : '—';
+      phoneEl.textContent = data.phone || '—';
+      phoneInput.value = data.phone || '';
+      renderOrders(data.orders || []);
+      profileGrid.style.display = 'grid';
+    }
+
+    savePhoneBtn?.addEventListener('click', async () => {
+      if (!userId) return;
+      try {
+        await fetchJson(`${API_BASE}/me/contact`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ telegram_id: userId, phone: phoneInput.value.trim() || null }),
+        });
+        phoneEl.textContent = phoneInput.value.trim() || '—';
+        setStatus('Телефон обновлён');
+      } catch (e) {
+        setStatus('Не удалось сохранить телефон', true);
+      }
+    });
+
+    (async function initApp() {
+      try {
+        await authorize();
+        await loadProfile();
+      } catch (e) {
+        console.error(e);
+      }
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a normalized users table with Telegram attributes and admin flag propagated from configuration
- implement Telegram WebApp auth, profile, and contact endpoints with database-backed admin checks
- update WebApp pages to authorize through /api/auth/telegram and use stored user data for cart, profile, and admin flows

## Testing
- python -m compileall .


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923579298b48326a65a44290af41da2)