### PR TITLE
Align orders service with unified user and cart model

### DIFF
--- a/api/routers/orders.py
+++ b/api/routers/orders.py
@@ -98,6 +98,11 @@ def api_checkout(payload: CheckoutPayload):
         contact=payload.contact,
         comment=payload.comment or "",
         order_text=order_text,
+        user_data={
+            "id": payload.user_id,
+            "username": payload.user_name,
+            "first_name": payload.customer_name,
+        },
     )
 
     cart_service.clear_cart(payload.user_id)

--- a/handlers/checkout.py
+++ b/handlers/checkout.py
@@ -273,6 +273,14 @@ async def process_comment(message: types.Message, state: FSMContext) -> None:
     )
 
     # Сохраняем заказ в БД
+    telegram_user = message.from_user
+    user_payload = {
+        "id": user_id,
+        "username": getattr(telegram_user, "username", None),
+        "first_name": getattr(telegram_user, "first_name", None),
+        "last_name": getattr(telegram_user, "last_name", None),
+    }
+
     order_id = add_order(
         user_id=user_id,
         user_name=user_name,
@@ -284,6 +292,7 @@ async def process_comment(message: types.Message, state: FSMContext) -> None:
         order_text=base_order_text,
         promocode_code=promo_code,
         discount_amount=discount_amount,
+        user_data=user_payload,
     )
 
     # Добавляем номер заказа

--- a/services/orders.py
+++ b/services/orders.py
@@ -1,17 +1,74 @@
 from __future__ import annotations
 
 from datetime import datetime
-from datetime import datetime
 from typing import Any, Optional
 
 from sqlalchemy import select
 
-from database import get_session, init_db
+from database import get_session
 from models import Order, OrderItem
-from services import users as users_service
 from services import products as products_service
+from services import users as users_service
 
 STATUS_NEW = "new"
+
+
+def _ensure_user(telegram_id: int, user_data: dict[str, Any] | None = None) -> None:
+    user = users_service.get_user_by_telegram_id(telegram_id)
+    if user:
+        return
+
+    payload: dict[str, Any] = {"id": telegram_id}
+    if user_data:
+        payload.update(user_data)
+    users_service.get_or_create_user_from_telegram(payload)
+
+
+def _normalize_order_items(items: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    normalized: list[dict[str, Any]] = []
+    total_amount = 0
+
+    for item in items:
+        try:
+            product_id = int(item.get("product_id") or 0)
+        except (TypeError, ValueError):
+            continue
+
+        try:
+            qty = int(item.get("qty") or 1)
+        except (TypeError, ValueError):
+            qty = 1
+
+        if qty <= 0:
+            continue
+
+        product_data = products_service.get_product_by_id(product_id) or {}
+
+        price_raw = item.get("price")
+        try:
+            price = int(price_raw) if price_raw is not None else int(product_data.get("price") or 0)
+        except (TypeError, ValueError):
+            price = int(product_data.get("price") or 0)
+
+        product_type = (
+            item.get("type")
+            or product_data.get("type")
+            or ("basket" if product_data else "basket")
+        )
+
+        normalized.append(
+            {
+                "product_id": product_id,
+                "qty": qty,
+                "price": price,
+                "type": product_type,
+                "product": product_data or None,
+            }
+        )
+
+        total_amount += price * qty
+
+    return normalized, total_amount
 
 
 def add_order(
@@ -26,82 +83,71 @@ def add_order(
     promocode_code: str | None = None,
     discount_amount: int | None = None,
     status: str | None = STATUS_NEW,
+    user_data: dict[str, Any] | None = None,
 ) -> int:
-    users_service.get_or_create_user_from_telegram({"id": user_id, "first_name": user_name})
-    init_db()
+    _ensure_user(user_id, user_data=user_data or {"first_name": user_name})
+
+    normalized_items, computed_total = _normalize_order_items(items)
+    order_total = computed_total if normalized_items else int(total)
 
     with get_session() as session:
         order = Order(
             user_id=user_id,
-            total_amount=total,
+            total_amount=order_total,
             created_at=datetime.utcnow(),
             customer_name=customer_name,
             contact=contact,
             comment=comment,
             promocode_code=promocode_code,
             discount_amount=discount_amount,
-            status=status,
+            status=status or STATUS_NEW,
             order_text=order_text,
         )
         session.add(order)
         session.flush()
 
-        for item in items:
-            price = item.get("price", 0)
-            qty = item.get("qty", 1)
-            product_type = item.get("type") or "basket"
+        for item in normalized_items:
             session.add(
                 OrderItem(
                     order_id=order.id,
-                    product_id=int(item.get("product_id") or 0),
-                    qty=int(qty),
-                    price=price,
-                    type=product_type,
+                    product_id=int(item["product_id"]),
+                    qty=int(item["qty"]),
+                    price=int(item["price"]),
+                    type=item.get("type") or "basket",
                 )
             )
 
         return int(order.id)
 
 
+def _serialize_order_summary(order: Order) -> dict[str, Any]:
+    return {
+        "id": order.id,
+        "user_id": order.user_id,
+        "total": int(order.total_amount or 0),
+        "status": order.status or STATUS_NEW,
+        "created_at": order.created_at.isoformat() if order.created_at else None,
+    }
+
+
 def get_orders_by_user(user_id: int, limit: int = 20) -> list[dict[str, Any]]:
-    init_db()
     with get_session() as session:
         rows = session.scalars(
             select(Order).where(Order.user_id == user_id).order_by(Order.id.desc()).limit(limit)
         ).all()
-        return [
-            {
-                "id": row.id,
-                "user_id": row.user_id,
-                "total": int(row.total_amount or 0),
-                "status": row.status or STATUS_NEW,
-                "created_at": row.created_at.isoformat(),
-            }
-            for row in rows
-        ]
+        return [_serialize_order_summary(row) for row in rows]
 
 
 def list_orders(limit: int = 100, status: str | None = None) -> list[dict[str, Any]]:
-    init_db()
     with get_session() as session:
         query = select(Order).order_by(Order.id.desc()).limit(limit)
         if status:
             query = query.where(Order.status == status)
         rows = session.scalars(query).all()
-        return [
-            {
-                "id": row.id,
-                "user_id": row.user_id,
-                "total": int(row.total_amount or 0),
-                "status": row.status or STATUS_NEW,
-                "created_at": row.created_at.isoformat(),
-            }
-            for row in rows
-        ]
+        return [_serialize_order_summary(row) for row in rows]
 
 
 def get_order_by_id(order_id: int) -> Optional[dict[str, Any]]:
-    init_db()
     with get_session() as session:
         order = session.get(Order, order_id)
         if not order:
@@ -124,7 +170,7 @@ def get_order_by_id(order_id: int) -> Optional[dict[str, Any]]:
             "user_id": order.user_id,
             "total": int(order.total_amount or 0),
             "status": order.status or STATUS_NEW,
-            "created_at": order.created_at.isoformat(),
+            "created_at": order.created_at.isoformat() if order.created_at else None,
             "customer_name": order.customer_name,
             "contact": order.contact,
             "comment": order.comment,

--- a/webapi.py
+++ b/webapi.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from config import get_settings
+from database import init_db
 from services import cart as cart_service
 from services import orders as orders_service
 from services import products as products_service
@@ -30,6 +31,11 @@ ALLOWED_TYPES = {"basket", "course"}
 
 SETTINGS = get_settings()
 BOT_TOKEN = SETTINGS.bot_token
+
+
+@app.on_event("startup")
+def _startup() -> None:
+    init_db()
 
 
 def _validate_type(product_type: str) -> str:
@@ -398,9 +404,9 @@ def admin_toggle_product(product_id: int, payload: AdminTogglePayload):
 
 
 @app.get("/api/admin/orders")
-def admin_orders(user_id: int, status: str | None = None):
+def admin_orders(user_id: int, status: str | None = None, limit: int = 100):
     _ensure_admin(user_id)
-    orders = orders_service.list_orders(status=status)
+    orders = orders_service.list_orders(status=status, limit=limit)
     return {"items": orders}
 
 


### PR DESCRIPTION
## Summary
- remove per-call database initialization from the orders service while normalizing order items and totals against product data
- ensure orders rely on the unified users service with richer Telegram payloads from bot and API checkout flows
- initialize the database on web API startup and extend admin order listing parameters

## Testing
- python -m compileall services/orders.py api/routers/orders.py handlers/checkout.py webapi.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235dd6aaac8326bb386d560c82daa5)