### PR TITLE
Add PromoCode ORM and promo validation API

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,7 +1,17 @@
 from datetime import datetime
 from decimal import Decimal
 
-from sqlalchemy import Boolean, BigInteger, Column, DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy import (
+    Boolean,
+    BigInteger,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+)
 from sqlalchemy.orm import relationship
 
 from database import Base
@@ -103,20 +113,19 @@ class OrderItem(Base):
     order = relationship("Order", back_populates="items")
 
 
-class Promocode(Base):
+class PromoCode(Base):
     __tablename__ = "promocodes"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    code = Column(String, nullable=False, unique=True)
+    code = Column(String, nullable=False, unique=True, index=True)
     discount_type = Column(String, nullable=False)
-    discount_value = Column(Integer, nullable=False)
-    min_order_total = Column(Integer, default=0, nullable=False)
-    max_uses = Column(Integer, default=0, nullable=False)
+    value = Column(Integer, nullable=False)
+    min_order_total = Column(Integer, nullable=True)
+    max_uses = Column(Integer, nullable=True)
     used_count = Column(Integer, default=0, nullable=False)
-    is_active = Column(Integer, default=1, nullable=False)
-    valid_from = Column(String, nullable=True)
-    valid_to = Column(String, nullable=True)
-    description = Column(Text, nullable=True)
+    active = Column(Boolean, default=True, nullable=False)
+    expires_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
 __all__ = [
@@ -124,7 +133,7 @@ __all__ = [
     "CartItem",
     "Order",
     "OrderItem",
-    "Promocode",
+    "PromoCode",
     "ProductBasket",
     "ProductCourse",
     "User",

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -243,7 +243,7 @@
             </select>
           </label>
           <label>Значение
-            <input name="discount_value" type="number" min="1" required />
+            <input name="value" type="number" min="1" required />
           </label>
           <label>Мин. сумма заказа
             <input name="min_order_total" type="number" min="0" />
@@ -252,19 +252,10 @@
             <input name="max_uses" type="number" min="0" />
           </label>
           <label>Активен?
-            <select name="is_active">
+            <select name="active">
               <option value="1">Да</option>
               <option value="0">Нет</option>
             </select>
-          </label>
-          <label>Дата начала (ISO)
-            <input name="valid_from" placeholder="2024-01-01" />
-          </label>
-          <label>Дата окончания (ISO)
-            <input name="valid_to" placeholder="2024-12-31" />
-          </label>
-          <label style="grid-column: 1 / -1">Описание
-            <textarea name="description"></textarea>
           </label>
           <div class="actions" style="grid-column: 1 / -1">
             <button type="submit" class="btn">Создать промокод</button>
@@ -475,9 +466,9 @@
           tr.innerHTML = `
             <td>${p.code}</td>
             <td>${p.discount_type}</td>
-            <td>${p.discount_value}</td>
+            <td>${p.value}</td>
             <td class="muted">мин ${p.min_order_total || 0}; лимит ${p.max_uses || '∞'}</td>
-            <td>${p.is_active ? 'Активен' : 'Неактивен'}</td>
+            <td>${p.active ? 'Активен' : 'Неактивен'}</td>
           `;
           tbody.appendChild(tr);
         });
@@ -536,10 +527,10 @@
       e.preventDefault();
       const data = Object.fromEntries(new FormData(e.target).entries());
       data.user_id = userId;
-      data.discount_value = Number(data.discount_value || 0);
-      data.min_order_total = Number(data.min_order_total || 0);
-      data.max_uses = Number(data.max_uses || 0);
-      data.is_active = data.is_active === '1';
+      data.value = Number(data.value || 0);
+      data.min_order_total = data.min_order_total ? Number(data.min_order_total) : null;
+      data.max_uses = data.max_uses ? Number(data.max_uses) : null;
+      data.active = data.active === '1';
       try {
         await fetchJson(`${API_BASE}/admin/promocodes`, {
           method: 'POST',

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -107,9 +107,10 @@
 
     <div class="total-card">
       <div class="total-row"><span>Итого</span><span id="cart-total">0 ₽</span></div>
+      <div class="total-row" id="promo-info" style="display:none; color: var(--muted); font-weight:600;"></div>
       <div class="input-row">
-        <input type="text" placeholder="Промокод" disabled />
-        <button class="btn secondary" type="button" disabled>Применить</button>
+        <input type="text" placeholder="Промокод" id="promo-code" />
+        <button class="btn secondary" type="button" id="apply-promo">Применить</button>
       </div>
       <div class="input-row">
         <button class="btn secondary" type="button" id="clear-cart">Очистить корзину</button>
@@ -129,10 +130,17 @@
     let userId = null;
     let username = null;
     let isAdmin = false;
+    let currentCart = { items: [], total: 0 };
+    let appliedPromo = null;
+    let discountAmount = 0;
+    let finalTotal = 0;
 
     const noteEl = document.getElementById('note');
     const tbody = document.getElementById('cart-body');
     const totalEl = document.getElementById('cart-total');
+    const promoInfoEl = document.getElementById('promo-info');
+    const promoInput = document.getElementById('promo-code');
+    const applyPromoBtn = document.getElementById('apply-promo');
     const clearBtn = document.getElementById('clear-cart');
     const checkoutBtn = document.getElementById('checkout');
 
@@ -180,6 +188,7 @@
     }
 
     function renderCart(cart) {
+      currentCart = cart;
       tbody.innerHTML = '';
 
       if (!cart.items?.length) {
@@ -225,7 +234,17 @@
         tbody.appendChild(row);
       });
 
-      totalEl.textContent = formatPrice(cart.total || 0);
+      const totalToShow = appliedPromo ? finalTotal : cart.total;
+      totalEl.textContent = formatPrice(totalToShow || 0);
+      if (appliedPromo) {
+        promoInfoEl.style.display = 'flex';
+        promoInfoEl.textContent = `Скидка по промокоду ${appliedPromo}: -${formatPrice(discountAmount)}`;
+      } else {
+        promoInfoEl.style.display = 'none';
+        promoInfoEl.textContent = '';
+        discountAmount = 0;
+        finalTotal = cart.total || 0;
+      }
     }
 
     async function loadCart() {
@@ -255,6 +274,7 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ user_id: userId, product_id: productId, qty }),
         });
+        appliedPromo = null;
         await loadCart();
       } catch (e) {
         alert('Не удалось обновить количество. Попробуйте ещё раз.');
@@ -269,20 +289,62 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ user_id: userId }),
         });
+        appliedPromo = null;
         await loadCart();
       } catch (e) {
         alert('Не удалось очистить корзину. Попробуйте ещё раз.');
       }
     }
 
+    async function applyPromo() {
+      if (!userId) {
+        alert('Промокод можно применить только из Telegram.');
+        return;
+      }
+
+      const code = (promoInput.value || '').trim();
+      if (!code) {
+        alert('Введите промокод');
+        return;
+      }
+
+      try {
+        const result = await fetchJson(`${API_BASE}/promocode/validate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ telegram_id: userId, code, total: currentCart.total || 0 }),
+        });
+        appliedPromo = result.code;
+        discountAmount = result.discount_amount || 0;
+        finalTotal = result.final_total || currentCart.total || 0;
+        renderCart(currentCart);
+      } catch (e) {
+        appliedPromo = null;
+        discountAmount = 0;
+        finalTotal = currentCart.total || 0;
+        alert('Промокод не подошёл.');
+        renderCart(currentCart);
+      }
+    }
+
     function checkout() {
       if (tg) {
+        tg.sendData(
+          JSON.stringify({
+            action: 'checkout',
+            total: currentCart.total || 0,
+            final_total: appliedPromo ? finalTotal : currentCart.total || 0,
+            promocode_code: appliedPromo,
+            discount_amount: appliedPromo ? discountAmount : 0,
+          })
+        );
         tg.close();
       } else {
         alert('Вернитесь в Telegram-бот для оформления заказа.');
       }
     }
 
+    applyPromoBtn.addEventListener('click', applyPromo);
     clearBtn.addEventListener('click', clearCart);
     checkoutBtn.addEventListener('click', checkout);
 


### PR DESCRIPTION
## Summary
- add SQLAlchemy PromoCode model and replace promocode service with ORM-backed validation and usage tracking
- expose promo validation and admin CRUD endpoints while updating Telegram checkout to rely on new service
- integrate promo code application into the web app cart and admin UI

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235f90d444832691e4362cee04f518)