### PR TITLE
Migrate favorites and profile to ORM-backed API

### DIFF
--- a/handlers/baskets.py
+++ b/handlers/baskets.py
@@ -49,7 +49,7 @@ async def _send_baskets_page(
         item_id = item["id"]
         photo = item.get("image_file_id")
 
-        is_fav = is_favorite(user_id, item_id)
+        is_fav = is_favorite(user_id, item_id, "basket")
 
         card_text = format_basket_card(item)
         keyboard = build_product_card_kb(
@@ -183,7 +183,8 @@ async def add_to_favorites(callback: CallbackQuery) -> None:
         await callback.answer("Товар не найден 😢", show_alert=True)
         return
 
-    add_favorite(user_id, product_id)
+    product_type = product.get("type") or "basket"
+    add_favorite(user_id, product_id, product_type)
 
     await callback.answer("Добавлено в избранное ❤️")
 
@@ -224,7 +225,8 @@ async def remove_from_favorites(callback: CallbackQuery) -> None:
         await callback.answer("Товар не найден 😢", show_alert=True)
         return
 
-    remove_favorite(user_id, product_id)
+    product_type = product.get("type") or "basket"
+    remove_favorite(user_id, product_id, product_type)
 
     await callback.answer("Удалено из избранного 💔")
 

--- a/handlers/courses.py
+++ b/handlers/courses.py
@@ -78,7 +78,7 @@ async def _send_courses_page(
     for item in page_items:
         item_id = item["id"]
         photo = item.get("image_file_id")
-        is_fav = is_favorite(user_id, item_id)
+        is_fav = is_favorite(user_id, item_id, "course")
 
         has_access = item_id in access_ids
         card_text = format_course_card(item, has_access=has_access)

--- a/models.py
+++ b/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     Numeric,
     String,
@@ -67,6 +68,19 @@ class User(Base):
 
     cart_items = relationship("CartItem", back_populates="user", cascade="all, delete-orphan")
     orders = relationship("Order", back_populates="user")
+
+
+class Favorite(Base):
+    __tablename__ = "favorites"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, ForeignKey("users.telegram_id", ondelete="CASCADE"), nullable=False)
+    product_id = Column(Integer, nullable=False)
+    type = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+Index("ix_favorites_user_product_type", Favorite.user_id, Favorite.product_id, Favorite.type, unique=True)
 
 
 class CartItem(Base):
@@ -131,6 +145,7 @@ class PromoCode(Base):
 __all__ = [
     "Base",
     "CartItem",
+    "Favorite",
     "Order",
     "OrderItem",
     "PromoCode",

--- a/services/orders.py
+++ b/services/orders.py
@@ -11,6 +11,10 @@ from services import products as products_service
 from services import users as users_service
 
 STATUS_NEW = "new"
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_PAID = "paid"
+STATUS_SENT = "sent"
+STATUS_ARCHIVED = "archived"
 
 
 def _ensure_user(telegram_id: int, user_data: dict[str, Any] | None = None) -> None:

--- a/services/stats.py
+++ b/services/stats.py
@@ -1,176 +1,140 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import List
 
-from database import get_connection
+from sqlalchemy import func, select
+
+from database import get_session, init_db
+from models import Order, OrderItem
+from services import products as products_service
 
 
-def _build_date_filters(date_from: str | None, date_to: str | None) -> tuple[str, list[str]]:
-    conditions: list[str] = []
-    params: list[str] = []
-
-    if date_from:
-        conditions.append("created_at >= ?")
-        params.append(date_from)
-    if date_to:
-        conditions.append("created_at <= ?")
-        params.append(date_to)
-
-    where_clause = ""
-    if conditions:
-        where_clause = " WHERE " + " AND ".join(conditions)
-
-    return where_clause, params
+def _parse_date(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
 
 
 def get_orders_stats_summary(date_from: str | None = None, date_to: str | None = None) -> dict:
-    conn = get_connection()
-    try:
-        cur = conn.cursor()
-        where_clause, params = _build_date_filters(date_from, date_to)
+    init_db()
+    filters = []
+    dt_from = _parse_date(date_from)
+    dt_to = _parse_date(date_to)
+    if dt_from:
+        filters.append(Order.created_at >= dt_from)
+    if dt_to:
+        filters.append(Order.created_at <= dt_to)
 
-        cur.execute(
-            f"""
-            SELECT COUNT(*) AS total_orders, COALESCE(SUM(total), 0) AS total_amount
-            FROM orders
-            {where_clause}
-            """,
-            params,
-        )
-        row = cur.fetchone() or {}
+    with get_session() as session:
+        count_row = session.execute(
+            select(
+                func.count(Order.id),
+                func.coalesce(func.sum(Order.total_amount), 0),
+            ).where(*filters)
+        ).first()
 
-        cur.execute(
-            f"""
-            SELECT status, COUNT(*) AS cnt
-            FROM orders
-            {where_clause}
-            GROUP BY status
-            """,
-            params,
-        )
-        status_rows = cur.fetchall() or []
-    finally:
-        conn.close()
+        status_rows = session.execute(
+            select(Order.status, func.count(Order.id)).where(*filters).group_by(Order.status)
+        ).all()
 
-    by_status: dict[str, int] = {row["status"]: int(row["cnt"]) for row in status_rows if row["status"]}
+    by_status = {status: int(cnt or 0) for status, cnt in status_rows if status}
+    total_orders = int(count_row[0] or 0) if count_row else 0
+    total_amount = int(count_row[1] or 0) if count_row else 0
 
     return {
-        "total_orders": int(row.get("total_orders", 0) or 0),
-        "total_amount": int(row.get("total_amount", 0) or 0),
+        "total_orders": total_orders,
+        "total_amount": total_amount,
         "by_status": by_status,
     }
 
 
-def get_orders_stats_by_day(limit_days: int = 7) -> list[dict]:
+def get_orders_stats_by_day(limit_days: int = 7) -> List[dict]:
     if limit_days <= 0:
         return []
 
     today = datetime.now().date()
-    date_from = (today - timedelta(days=limit_days - 1)).isoformat()
+    date_from = today - timedelta(days=limit_days - 1)
 
-    conn = get_connection()
-    try:
-        cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT SUBSTR(created_at, 1, 10) AS day,
-                   COUNT(*) AS orders_count,
-                   COALESCE(SUM(total), 0) AS total_amount
-            FROM orders
-            WHERE created_at >= ?
-            GROUP BY day
-            ORDER BY day DESC
-            LIMIT ?
-            """,
-            (date_from, limit_days),
-        )
-        rows = cur.fetchall() or []
-    finally:
-        conn.close()
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                func.date(Order.created_at),
+                func.count(Order.id),
+                func.coalesce(func.sum(Order.total_amount), 0),
+            )
+            .where(Order.created_at >= datetime.combine(date_from, datetime.min.time()))
+            .group_by(func.date(Order.created_at))
+            .order_by(func.date(Order.created_at).desc())
+            .limit(limit_days)
+        ).all()
 
     return [
         {
-            "date": row["day"],
-            "orders_count": int(row["orders_count"] or 0),
-            "total_amount": int(row["total_amount"] or 0),
+            "date": row[0].isoformat() if hasattr(row[0], "isoformat") else str(row[0]),
+            "orders_count": int(row[1] or 0),
+            "total_amount": int(row[2] or 0),
         }
         for row in rows
     ]
+
+
+def _serialize_top_item(row, product_type: str | None = None) -> dict:
+    product_id = int(row.product_id)
+    if product_type:
+        loader = (
+            products_service.get_basket_by_id
+            if product_type == "basket"
+            else products_service.get_course_by_id
+        )
+        product = loader(product_id)
+    else:
+        product = products_service.get_product_by_id(product_id)
+    name = (product or {}).get("name") or f"Товар #{product_id}"
+    return {
+        "product_id": product_id,
+        "name": name,
+        "total_qty": int(row.total_qty or 0),
+        "total_amount": int(row.total_amount or 0),
+    }
 
 
 def get_top_products(limit: int = 5) -> list[dict]:
     if limit <= 0:
         return []
 
-    conn = get_connection()
-    try:
-        cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT
-                oi.product_id AS product_id,
-                COALESCE(p.name, oi.product_name) AS name,
-                SUM(COALESCE(oi.qty, 0)) AS total_qty,
-                SUM(COALESCE(oi.qty, 0) * COALESCE(oi.price, 0)) AS total_amount
-            FROM order_items oi
-            LEFT JOIN products p ON p.id = oi.product_id
-            WHERE oi.product_id IS NOT NULL OR oi.product_name IS NOT NULL
-            GROUP BY oi.product_id, name
-            HAVING name IS NOT NULL AND TRIM(name) != ''
-            ORDER BY total_amount DESC, total_qty DESC
-            LIMIT ?
-            """,
-            (limit,),
-        )
-        rows = cur.fetchall() or []
-    finally:
-        conn.close()
-
-    return [
-        {
-            "product_id": row["product_id"],
-            "name": row["name"],
-            "total_qty": int(row["total_qty"] or 0),
-            "total_amount": int(row["total_amount"] or 0),
-        }
-        for row in rows
-    ]
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                OrderItem.product_id.label("product_id"),
+                func.sum(OrderItem.qty).label("total_qty"),
+                func.sum(OrderItem.qty * OrderItem.price).label("total_amount"),
+            )
+            .where(OrderItem.type == "basket")
+            .group_by(OrderItem.product_id)
+            .order_by(func.sum(OrderItem.qty * OrderItem.price).desc())
+            .limit(limit)
+        ).all()
+    return [_serialize_top_item(row, "basket") for row in rows]
 
 
 def get_top_courses(limit: int = 5) -> list[dict]:
     if limit <= 0:
         return []
 
-    conn = get_connection()
-    try:
-        cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT
-                oi.product_id AS product_id,
-                COALESCE(p.name, oi.product_name) AS name,
-                SUM(COALESCE(oi.qty, 0)) AS total_qty,
-                SUM(COALESCE(oi.qty, 0) * COALESCE(oi.price, 0)) AS total_amount
-            FROM order_items oi
-            JOIN products p ON p.id = oi.product_id
-            WHERE p.type = 'course'
-            GROUP BY oi.product_id, name
-            HAVING name IS NOT NULL AND TRIM(name) != ''
-            ORDER BY total_amount DESC, total_qty DESC
-            LIMIT ?
-            """,
-            (limit,),
-        )
-        rows = cur.fetchall() or []
-    finally:
-        conn.close()
-
-    return [
-        {
-            "product_id": row["product_id"],
-            "name": row["name"],
-            "total_qty": int(row["total_qty"] or 0),
-            "total_amount": int(row["total_amount"] or 0),
-        }
-        for row in rows
-    ]
+    with get_session() as session:
+        rows = session.execute(
+            select(
+                OrderItem.product_id.label("product_id"),
+                func.sum(OrderItem.qty).label("total_qty"),
+                func.sum(OrderItem.qty * OrderItem.price).label("total_amount"),
+            )
+            .where(OrderItem.type == "course")
+            .group_by(OrderItem.product_id)
+            .order_by(func.sum(OrderItem.qty * OrderItem.price).desc())
+            .limit(limit)
+        ).all()
+    return [_serialize_top_item(row, "course") for row in rows]

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -57,6 +57,7 @@
     .card h3 { margin: 0; letter-spacing: -0.01em; }
     .card p { margin: 0; color: var(--muted); line-height: 1.5; flex: 1; }
     .meta { font-size: 13px; color: var(--muted); }
+    .fav-btn { position: absolute; top: 10px; right: 10px; border: none; background: rgba(0, 0, 0, 0.3); color: #c1e9ff; border-radius: 50%; width: 38px; height: 38px; font-size: 18px; cursor: pointer; box-shadow: 0 6px 20px rgba(0,0,0,0.25); }
     .footer { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
     .price { font-weight: 800; color: #c1e9ff; }
     .btn { cursor: pointer; border: none; border-radius: 12px; padding: 12px 14px; background: linear-gradient(135deg, #7bd8ff, #4dc3ff); color: #0b0c10; font-weight: 700; font-size: 15px; width: 100%; box-shadow: 0 10px 30px rgba(123, 216, 255, 0.25); transition: transform 0.1s ease, box-shadow 0.1s ease; }
@@ -111,6 +112,7 @@
     let userId = null;
     let username = null;
     let isAdmin = false;
+    let favorites = new Set();
 
     const tabsEl = document.getElementById('tabs');
     const cardsEl = document.getElementById('cards');
@@ -129,6 +131,42 @@
       const num = Number(value) || 0;
       if (num === 0) return 'Бесплатно';
       return `${num.toLocaleString('ru-RU')} ₽`;
+    }
+
+    async function loadFavorites() {
+      if (!userId) return;
+      try {
+        const data = await fetchJson(`${API_BASE}/favorites?telegram_id=${userId}`);
+        favorites = new Set((data || []).filter((fav) => fav.type === 'course').map((fav) => Number(fav.product_id)));
+      } catch (e) {
+        console.warn('Не удалось загрузить избранное', e);
+      }
+    }
+
+    function isFavorite(id) {
+      return favorites.has(Number(id));
+    }
+
+    async function toggleFavorite(course) {
+      if (!userId) {
+        alert('Чтобы добавить в избранное, откройте сайт из Telegram-бота.');
+        return;
+      }
+      try {
+        const res = await fetchJson(`${API_BASE}/favorites/toggle`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ telegram_id: userId, product_id: course.id, type: 'course' }),
+        });
+        if (res.is_favorite) {
+          favorites.add(course.id);
+        } else {
+          favorites.delete(course.id);
+        }
+        renderCards();
+      } catch (e) {
+        alert('Не удалось обновить избранное. Попробуйте ещё раз.');
+      }
     }
 
     async function fetchJson(url, options) {
@@ -190,6 +228,16 @@
         const cover = document.createElement('div');
         cover.className = 'cover';
         cover.textContent = item.category_name || 'Мастер-классы';
+
+        const favBtn = document.createElement('button');
+        favBtn.type = 'button';
+        favBtn.className = 'fav-btn';
+        favBtn.textContent = isFavorite(item.id) ? '⭐' : '☆';
+        favBtn.addEventListener('click', (evt) => {
+          evt.stopPropagation();
+          toggleFavorite(item);
+        });
+        cover.appendChild(favBtn);
 
         const title = document.createElement('h3');
         title.textContent = item.name;
@@ -272,6 +320,7 @@
     async function initApp() {
       try {
         await authorize();
+        await loadFavorites();
         await loadCategories();
         await loadCourses();
       } catch (e) {

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -82,6 +82,7 @@
     .cover span { font-weight: 800; letter-spacing: -0.01em; color: #0b0c10; }
     .card h3 { margin: 0; letter-spacing: -0.01em; }
     .card p { margin: 0; color: var(--muted); line-height: 1.5; flex: 1; }
+    .fav-btn { position: absolute; top: 10px; right: 10px; border: none; background: rgba(0, 0, 0, 0.3); color: #ffdf80; border-radius: 50%; width: 38px; height: 38px; font-size: 18px; cursor: pointer; box-shadow: 0 6px 20px rgba(0,0,0,0.25); }
     .footer { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
     .price { font-weight: 800; color: #ffdf80; }
     .btn { cursor: pointer; border: none; border-radius: 12px; padding: 12px 14px; background: linear-gradient(135deg, #ffb800, #ff8f3f); color: #0b0c10; font-weight: 700; font-size: 15px; width: 100%; box-shadow: 0 10px 30px rgba(255, 184, 0, 0.25); transition: transform 0.1s ease, box-shadow 0.1s ease; }
@@ -131,6 +132,7 @@
     let userId = null;
     let username = null;
     let isAdmin = false;
+    let favorites = new Set();
 
     const tabsEl = document.getElementById('tabs');
     const cardsEl = document.getElementById('cards');
@@ -144,6 +146,42 @@
       const num = Number(value) || 0;
       if (num === 0) return 'Бесплатно';
       return `${num.toLocaleString('ru-RU')} ₽`;
+    }
+
+    async function loadFavorites() {
+      if (!userId) return;
+      try {
+        const data = await fetchJson(`${API_BASE}/favorites?telegram_id=${userId}`);
+        favorites = new Set((data || []).filter((fav) => fav.type === 'basket').map((fav) => Number(fav.product_id)));
+      } catch (e) {
+        console.warn('Не удалось загрузить избранное', e);
+      }
+    }
+
+    function isFavorite(id) {
+      return favorites.has(Number(id));
+    }
+
+    async function toggleFavorite(item) {
+      if (!userId) {
+        alert('Чтобы добавить в избранное, откройте сайт из Telegram-бота.');
+        return;
+      }
+      try {
+        const res = await fetchJson(`${API_BASE}/favorites/toggle`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ telegram_id: userId, product_id: item.id, type: 'basket' }),
+        });
+        if (res.is_favorite) {
+          favorites.add(item.id);
+        } else {
+          favorites.delete(item.id);
+        }
+        renderCards();
+      } catch (e) {
+        alert('Не удалось обновить избранное. Попробуйте ещё раз.');
+      }
     }
 
     async function fetchJson(url, options) {
@@ -216,6 +254,16 @@
         cover.className = 'cover';
         cover.innerHTML = `<span>${item.category_name || 'Товары'}</span>`;
 
+        const favBtn = document.createElement('button');
+        favBtn.type = 'button';
+        favBtn.className = 'fav-btn';
+        favBtn.textContent = isFavorite(item.id) ? '⭐' : '☆';
+        favBtn.addEventListener('click', (evt) => {
+          evt.stopPropagation();
+          toggleFavorite(item);
+        });
+        cover.appendChild(favBtn);
+
         const title = document.createElement('h3');
         title.textContent = item.name;
 
@@ -284,6 +332,7 @@
     async function initApp() {
       try {
         await authorize();
+        await loadFavorites();
         await loadCategories();
         await loadProducts();
       } catch (e) {

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -112,6 +112,11 @@
         <div class="label" style="margin-top: 12px;">Всего заказов</div>
         <div class="value" id="orders-count">0</div>
       </div>
+
+      <div class="card">
+        <div class="label">Избранное</div>
+        <ul class="list" id="favorites-list"></ul>
+      </div>
     </div>
   </main>
 
@@ -131,6 +136,7 @@
     const phoneInput = document.getElementById('phone-input');
     const ordersList = document.getElementById('orders-list');
     const ordersCount = document.getElementById('orders-count');
+    const favoritesList = document.getElementById('favorites-list');
     const savePhoneBtn = document.getElementById('save-phone');
 
     let userId = null;
@@ -184,10 +190,28 @@
 
       orders.forEach((order) => {
         const li = document.createElement('li');
-        li.textContent = `Заказ #${order.id} — ${order.total} ₽ (${order.status})`;
+        const dateText = order.created_at ? new Date(order.created_at).toLocaleString('ru-RU') : '';
+        li.textContent = `Заказ #${order.id} — ${order.total} ₽ (${order.status || 'в обработке'}) ${dateText ? '• ' + dateText : ''}`;
         ordersList.appendChild(li);
       });
       ordersCount.textContent = String(orders.length);
+    }
+
+    function renderFavorites(favorites) {
+      favoritesList.innerHTML = '';
+      if (!favorites || !favorites.length) {
+        const li = document.createElement('li');
+        li.textContent = 'Избранных товаров пока нет';
+        favoritesList.appendChild(li);
+        return;
+      }
+
+      favorites.forEach((fav) => {
+        const li = document.createElement('li');
+        const prefix = fav.type === 'course' ? '🎓' : '🧺';
+        li.textContent = `${prefix} ${fav.name || 'Товар'} — ${fav.price ?? 0} ₽`;
+        favoritesList.appendChild(li);
+      });
     }
 
     async function loadProfile() {
@@ -198,6 +222,7 @@
       phoneEl.textContent = data.phone || '—';
       phoneInput.value = data.phone || '';
       renderOrders(data.orders || []);
+      renderFavorites(data.favorites || []);
       profileGrid.style.display = 'grid';
     }
 


### PR DESCRIPTION
## Summary
- add Favorite ORM model and refactor favorites services and bot handlers to use PostgreSQL sessions
- expose favorites and enriched profile data via web API and update WebApp pages to show orders and favorites
- convert stats/user stats utilities to SQLAlchemy to remove legacy sqlite usage

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692361153f908326911fa4c13c6b4ce8)