### PR TITLE
Перенос банов, заметок и статистики на ORM

### DIFF
--- a/database.py
+++ b/database.py
@@ -50,8 +50,3 @@ def init_db() -> None:
                         user.is_admin = True
                 else:
                     session.add(User(telegram_id=admin_id, is_admin=True))
-
-
-def get_connection():
-    """Legacy compatibility stub for old sqlite-style code."""
-    raise RuntimeError("Use SQLAlchemy sessions via get_session() instead of direct connections")

--- a/handlers/checkout.py
+++ b/handlers/checkout.py
@@ -10,7 +10,7 @@ from services.cart import (
     clear_cart,
 )
 from services.promocodes import increment_usage, validate_promocode
-from services.user_admin import get_user_ban_status
+from services.bans import is_banned
 from services.orders import add_order
 from services.subscription import ensure_subscribed
 from utils.texts import format_cart, format_order_for_admin, format_price
@@ -206,7 +206,7 @@ async def process_comment(message: types.Message, state: FSMContext) -> None:
     discount_amount = int(data.get("discount_amount", 0) or 0)
     final_total = int(data.get("final_total", order_total) or order_total)
 
-    ban_status = get_user_ban_status(user_id)
+    ban_status = is_banned(user_id)
     if ban_status.get("is_banned"):
         await message.answer(
             "К сожалению, ваш аккаунт заблокирован. По вопросам обращайтесь к администратору."

--- a/models.py
+++ b/models.py
@@ -70,6 +70,45 @@ class User(Base):
     orders = relationship("Order", back_populates="user")
 
 
+class AdminNote(Base):
+    __tablename__ = "admin_notes"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        BigInteger, ForeignKey("users.telegram_id", ondelete="CASCADE"), nullable=False
+    )
+    admin_id = Column(BigInteger, nullable=True)
+    note = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class UserBan(Base):
+    __tablename__ = "user_bans"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        BigInteger, ForeignKey("users.telegram_id", ondelete="CASCADE"), nullable=False
+    )
+    reason = Column(Text, nullable=True)
+    banned_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    active = Column(Boolean, default=True, nullable=False)
+
+
+class UserStats(Base):
+    __tablename__ = "user_stats"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    orders_count = Column(Integer, default=0, nullable=False)
+    total_spent = Column(Integer, default=0, nullable=False)
+    last_order_at = Column(DateTime, nullable=True)
+
+
 class Favorite(Base):
     __tablename__ = "favorites"
 
@@ -144,6 +183,7 @@ class PromoCode(Base):
 
 __all__ = [
     "Base",
+    "AdminNote",
     "CartItem",
     "Favorite",
     "Order",
@@ -151,5 +191,7 @@ __all__ = [
     "PromoCode",
     "ProductBasket",
     "ProductCourse",
+    "UserBan",
+    "UserStats",
     "User",
 ]

--- a/services/admin_notes.py
+++ b/services/admin_notes.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import select
+
+from database import get_session
+from models import AdminNote
+
+
+def add_note(user_id: int, note: str, admin_id: int | None = None) -> AdminNote:
+    with get_session() as session:
+        record = AdminNote(
+            user_id=user_id,
+            admin_id=admin_id,
+            note=note,
+            created_at=datetime.utcnow(),
+        )
+        session.add(record)
+        session.flush()
+        session.refresh(record)
+        return record
+
+
+def list_notes(user_id: int, limit: int = 20) -> list[dict]:
+    with get_session() as session:
+        rows: List[AdminNote] = session.scalars(
+            select(AdminNote)
+            .where(AdminNote.user_id == user_id)
+            .order_by(AdminNote.created_at.desc(), AdminNote.id.desc())
+            .limit(limit)
+        ).all()
+        return [
+            {
+                "id": row.id,
+                "user_id": row.user_id,
+                "admin_id": row.admin_id,
+                "note": row.note,
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+            }
+            for row in rows
+        ]
+
+
+def delete_note(note_id: int) -> bool:
+    with get_session() as session:
+        record = session.get(AdminNote, note_id)
+        if not record:
+            return False
+        session.delete(record)
+        return True

--- a/services/bans.py
+++ b/services/bans.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import select
+
+from database import get_session
+from models import UserBan
+
+
+def ban_user(user_id: int, reason: str | None = None) -> UserBan:
+    with get_session() as session:
+        active_ban = session.scalar(
+            select(UserBan).where(UserBan.user_id == user_id, UserBan.active.is_(True))
+        )
+        if active_ban:
+            active_ban.reason = reason or active_ban.reason
+            active_ban.banned_at = datetime.utcnow()
+            session.flush()
+            session.refresh(active_ban)
+            return active_ban
+
+        record = UserBan(
+            user_id=user_id,
+            reason=reason,
+            banned_at=datetime.utcnow(),
+            active=True,
+        )
+        session.add(record)
+        session.flush()
+        session.refresh(record)
+        return record
+
+
+def unban_user(user_id: int) -> bool:
+    with get_session() as session:
+        bans: List[UserBan] = session.scalars(
+            select(UserBan).where(UserBan.user_id == user_id, UserBan.active.is_(True))
+        ).all()
+        if not bans:
+            return False
+        for ban in bans:
+            ban.active = False
+        return True
+
+
+def is_banned(user_id: int) -> dict:
+    with get_session() as session:
+        ban = session.scalar(
+            select(UserBan)
+            .where(UserBan.user_id == user_id, UserBan.active.is_(True))
+            .order_by(UserBan.banned_at.desc(), UserBan.id.desc())
+        )
+        if not ban:
+            return {
+                "is_banned": False,
+                "reason": None,
+                "ban_reason": None,
+                "banned_at": None,
+            }
+    return {
+        "is_banned": True,
+        "reason": ban.reason,
+        "ban_reason": ban.reason,
+        "banned_at": ban.banned_at.isoformat() if ban.banned_at else None,
+    }
+
+
+def list_banned(limit: int = 100) -> list[dict]:
+    with get_session() as session:
+        rows = session.scalars(
+            select(UserBan)
+            .where(UserBan.active.is_(True))
+            .order_by(UserBan.banned_at.desc(), UserBan.id.desc())
+            .limit(limit)
+        ).all()
+        return [
+            {
+                "id": row.id,
+                "user_id": row.user_id,
+                "reason": row.reason,
+                "banned_at": row.banned_at.isoformat() if row.banned_at else None,
+                "active": bool(row.active),
+            }
+            for row in rows
+        ]

--- a/services/orders.py
+++ b/services/orders.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from database import get_session
 from models import Order, OrderItem
 from services import products as products_service
+from services import stats as stats_service
 from services import users as users_service
 
 STATUS_NEW = "new"
@@ -15,6 +16,14 @@ STATUS_IN_PROGRESS = "in_progress"
 STATUS_PAID = "paid"
 STATUS_SENT = "sent"
 STATUS_ARCHIVED = "archived"
+
+STATUS_TITLES = {
+    STATUS_NEW: "Новый",
+    STATUS_IN_PROGRESS: "В работе",
+    STATUS_PAID: "Оплачен",
+    STATUS_SENT: "Отправлен",
+    STATUS_ARCHIVED: "Архив",
+}
 
 
 def _ensure_user(telegram_id: int, user_data: dict[str, Any] | None = None) -> None:
@@ -121,6 +130,8 @@ def add_order(
                 )
             )
 
+        stats_service.recalc_user_stats(user_id)
+
         return int(order.id)
 
 
@@ -149,6 +160,10 @@ def list_orders(limit: int = 100, status: str | None = None) -> list[dict[str, A
             query = query.where(Order.status == status)
         rows = session.scalars(query).all()
         return [_serialize_order_summary(row) for row in rows]
+
+
+def get_orders_for_admin(status: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    return list_orders(limit=limit, status=None if status == "all" else status)
 
 
 def get_order_by_id(order_id: int) -> Optional[dict[str, Any]]:
@@ -185,3 +200,119 @@ def get_order_by_id(order_id: int) -> Optional[dict[str, Any]]:
             "order_text": order.order_text,
             "items": serialized_items,
         }
+
+
+def set_order_status(order_id: int, status: str) -> bool:
+    with get_session() as session:
+        order = session.get(Order, order_id)
+        if not order:
+            return False
+        order.status = status
+        session.flush()
+        stats_service.recalc_user_stats(int(order.user_id))
+        return True
+
+
+def get_courses_from_order(order_id: int) -> list[dict[str, Any]]:
+    with get_session() as session:
+        items = session.scalars(
+            select(OrderItem).where(OrderItem.order_id == order_id, OrderItem.type == "course")
+        ).all()
+    result: list[dict[str, Any]] = []
+    for item in items:
+        product = products_service.get_course_by_id(item.product_id)
+        if product:
+            result.append(product)
+    return result
+
+
+def get_user_courses_with_access(user_id: int) -> list[dict[str, Any]]:
+    with get_session() as session:
+        items = session.execute(
+            select(OrderItem)
+            .join(Order, OrderItem.order_id == Order.id)
+            .where(Order.user_id == user_id, OrderItem.type == "course")
+        ).scalars().all()
+
+    seen: set[int] = set()
+    courses: list[dict[str, Any]] = []
+    for item in items:
+        if item.product_id in seen:
+            continue
+        product = products_service.get_course_by_id(item.product_id)
+        if not product:
+            continue
+        seen.add(item.product_id)
+        courses.append(product)
+    return courses
+
+
+def grant_course_access(user_id: int, course_id: int, *, admin_id: int | None = None) -> bool:
+    existing = [c for c in get_user_courses_with_access(user_id) if c.get("id") == course_id]
+    if existing:
+        return True
+
+    with get_session() as session:
+        order = Order(
+            user_id=user_id,
+            total_amount=0,
+            created_at=datetime.utcnow(),
+            status=STATUS_PAID,
+            comment="Access granted manually",
+        )
+        session.add(order)
+        session.flush()
+
+        session.add(
+            OrderItem(
+                order_id=order.id,
+                product_id=course_id,
+                qty=1,
+                price=0,
+                type="course",
+            )
+        )
+
+        stats_service.recalc_user_stats(user_id)
+    return True
+
+
+def revoke_course_access(user_id: int, course_id: int) -> bool:
+    changed = False
+    with get_session() as session:
+        items = session.scalars(
+            select(OrderItem)
+            .join(Order, OrderItem.order_id == Order.id)
+            .where(Order.user_id == user_id, OrderItem.type == "course", OrderItem.product_id == course_id)
+        ).all()
+        for item in items:
+            session.delete(item)
+            changed = True
+        if changed:
+            stats_service.recalc_user_stats(user_id)
+    return changed
+
+
+def get_course_users(course_id: int) -> list[int]:
+    with get_session() as session:
+        rows = session.execute(
+            select(Order.user_id)
+            .join(OrderItem, OrderItem.order_id == Order.id)
+            .where(OrderItem.product_id == course_id, OrderItem.type == "course")
+        ).all()
+    return [int(row[0]) for row in rows if row[0] is not None]
+
+
+def grant_courses_from_order(order_id: int, admin_id: int | None = None) -> int:
+    courses = get_courses_from_order(order_id)
+    if not courses:
+        return 0
+    order = get_order_by_id(order_id)
+    if not order:
+        return 0
+    user_id = int(order.get("user_id") or 0)
+    granted = 0
+    for course in courses:
+        if grant_course_access(user_id, int(course.get("id"))):
+            granted += 1
+    return granted

--- a/services/user_admin.py
+++ b/services/user_admin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from database import get_connection
+from services import admin_notes, bans
 
 
 def _now_iso() -> str:
@@ -13,92 +13,32 @@ def _now_iso() -> str:
 def set_user_ban_status(
     user_id: int, is_banned: bool, admin_id: int | None = None, reason: str | None = None
 ) -> None:
-    """Создать или обновить статус бана пользователя."""
-
-    conn = get_connection()
-    cur = conn.cursor()
-
-    cur.execute(
-        """
-        INSERT INTO user_status (user_id, is_banned, ban_reason, updated_at, updated_by)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(user_id) DO UPDATE SET
-            is_banned = excluded.is_banned,
-            ban_reason = excluded.ban_reason,
-            updated_at = excluded.updated_at,
-            updated_by = excluded.updated_by;
-        """,
-        (user_id, int(is_banned), reason, _now_iso(), admin_id),
-    )
-
-    conn.commit()
-    conn.close()
+    if is_banned:
+        bans.ban_user(user_id, reason=reason)
+    else:
+        bans.unban_user(user_id)
 
 
 def get_user_ban_status(user_id: int) -> dict[str, Any]:
-    """Получить статус бана пользователя. Если записи нет, считаем, что он активен."""
-
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute(
-        """
-        SELECT user_id, is_banned, ban_reason, updated_at, updated_by
-        FROM user_status
-        WHERE user_id = ?
-        """,
-        (user_id,),
-    )
-    row = cur.fetchone()
-    conn.close()
-
-    if not row:
+    status = bans.is_banned(user_id)
+    if status.get("is_banned"):
         return {
-            "is_banned": False,
-            "ban_reason": None,
-            "updated_at": None,
+            "is_banned": True,
+            "ban_reason": status.get("reason"),
+            "updated_at": status.get("banned_at"),
             "updated_by": None,
         }
-
     return {
-        "is_banned": bool(row["is_banned"]),
-        "ban_reason": row["ban_reason"],
-        "updated_at": row["updated_at"],
-        "updated_by": row["updated_by"],
+        "is_banned": False,
+        "ban_reason": None,
+        "updated_at": None,
+        "updated_by": None,
     }
 
 
 def add_user_note(user_id: int, admin_id: int, note: str) -> None:
-    """Добавить заметку по пользователю."""
-
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute(
-        """
-        INSERT INTO user_notes (user_id, admin_id, note, created_at)
-        VALUES (?, ?, ?, ?);
-        """,
-        (user_id, admin_id, note, _now_iso()),
-    )
-    conn.commit()
-    conn.close()
+    admin_notes.add_note(user_id=user_id, admin_id=admin_id, note=note)
 
 
 def get_user_notes(user_id: int, limit: int = 20) -> list[dict[str, Any]]:
-    """Получить заметки по пользователю, отсортированные по времени создания (DESC)."""
-
-    conn = get_connection()
-    cur = conn.cursor()
-    cur.execute(
-        """
-        SELECT id, user_id, admin_id, note, created_at
-        FROM user_notes
-        WHERE user_id = ?
-        ORDER BY created_at DESC, id DESC
-        LIMIT ?
-        """,
-        (user_id, limit),
-    )
-
-    notes = [dict(row) for row in cur.fetchall()]
-    conn.close()
-    return notes
+    return admin_notes.list_notes(user_id, limit=limit)

--- a/services/user_stats.py
+++ b/services/user_stats.py
@@ -8,6 +8,7 @@ from sqlalchemy import func, select
 from database import get_session, init_db
 from models import Order
 from services import orders as orders_service
+from services import stats as stats_service
 
 
 def get_user_order_stats(user_id: int) -> dict[str, Any]:
@@ -54,6 +55,11 @@ def get_user_order_stats(user_id: int) -> dict[str, Any]:
             result["last_order_id"] = int(last_order.id)
             if isinstance(last_order.created_at, datetime):
                 result["last_order_created_at"] = last_order.created_at.isoformat()
+
+    stats_summary = stats_service.get_user_stats(user_id)
+    result["orders_count"] = stats_summary.get("orders_count", result["total_orders"])
+    result["total_spent"] = stats_summary.get("total_spent", result["total_amount"])
+    result["last_order_at"] = stats_summary.get("last_order_at")
 
     return result
 

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -157,6 +157,53 @@
 
     <div id="status" class="message" style="display:none"></div>
 
+    <section class="card" id="stats-section" style="display:none">
+      <div class="section-header">
+        <h2>Статистика</h2>
+        <span class="muted">Данные по пользователям и заказам</span>
+      </div>
+      <div class="grid" id="stats-totals">
+        <div class="item-card"><div class="label">Пользователи</div><div class="value" id="stat-users">0</div></div>
+        <div class="item-card"><div class="label">Заказы</div><div class="value" id="stat-orders">0</div></div>
+        <div class="item-card"><div class="label">Сумма продаж</div><div class="value" id="stat-amount">0 ₽</div></div>
+        <div class="item-card"><div class="label">Избранное</div><div class="value" id="stat-favorites">0</div></div>
+      </div>
+      <div class="grid">
+        <div class="item-card">
+          <h3>Топ корзинок</h3>
+          <ul class="list" id="top-products"></ul>
+        </div>
+        <div class="item-card">
+          <h3>Топ курсов</h3>
+          <ul class="list" id="top-courses"></ul>
+        </div>
+        <div class="item-card">
+          <h3>Новые пользователи</h3>
+          <ul class="list" id="new-users"></ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="card" id="notes-section" style="display:none">
+      <div class="section-header">
+        <h2>Заметки администратора</h2>
+        <span class="muted">Быстрые заметки по пользователям</span>
+      </div>
+      <form class="form" id="note-form">
+        <label>Telegram ID пользователя
+          <input name="target_id" type="number" required />
+        </label>
+        <label style="grid-column:1 / -1">Текст заметки
+          <textarea name="note" required></textarea>
+        </label>
+        <div class="actions" style="grid-column:1 / -1">
+          <button type="submit" class="btn">Добавить</button>
+        </div>
+      </form>
+      <div class="muted" id="notes-loading" style="display:none">Загрузка заметок...</div>
+      <ul class="list" id="notes-list"></ul>
+    </section>
+
     <section class="card" id="admin-content" style="display:none">
       <div class="section-header">
         <h2>Товары</h2>
@@ -285,6 +332,18 @@
     const productsLoading = document.getElementById('products-loading');
     const productsEmpty = document.getElementById('products-empty');
     const productTabs = document.getElementById('product-tabs');
+    const statsSection = document.getElementById('stats-section');
+    const notesSection = document.getElementById('notes-section');
+    const statUsers = document.getElementById('stat-users');
+    const statOrders = document.getElementById('stat-orders');
+    const statAmount = document.getElementById('stat-amount');
+    const statFavorites = document.getElementById('stat-favorites');
+    const topProducts = document.getElementById('top-products');
+    const topCourses = document.getElementById('top-courses');
+    const newUsers = document.getElementById('new-users');
+    const notesList = document.getElementById('notes-list');
+    const notesLoading = document.getElementById('notes-loading');
+    const noteForm = document.getElementById('note-form');
     const productFormCard = document.getElementById('product-form-card');
     const productForm = document.getElementById('product-form');
     const productFormTitle = document.getElementById('product-form-title');
@@ -339,6 +398,59 @@
       } catch (e) {
         showStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
         throw e;
+      }
+    }
+
+    function renderList(listEl, items, formatter) {
+      listEl.innerHTML = '';
+      if (!items || !items.length) {
+        const li = document.createElement('li');
+        li.textContent = 'Нет данных';
+        listEl.appendChild(li);
+        return;
+      }
+      items.forEach((item) => {
+        const li = document.createElement('li');
+        li.textContent = formatter(item);
+        listEl.appendChild(li);
+      });
+    }
+
+    async function loadStats() {
+      try {
+        const data = await fetchJson(`${API_BASE}/admin/stats?user_id=${userId}`);
+        statUsers.textContent = data.totals?.users ?? 0;
+        statOrders.textContent = data.totals?.orders ?? 0;
+        statFavorites.textContent = data.totals?.favorites ?? 0;
+        statAmount.textContent = `${data.totals?.amount ?? 0} ₽`;
+
+        renderList(topProducts, data.top_products || [], (item) => `${item.name} — ${item.total_qty} шт / ${item.total_amount} ₽`);
+        renderList(topCourses, data.top_courses || [], (item) => `${item.name} — ${item.total_qty} шт / ${item.total_amount} ₽`);
+        renderList(newUsers, data.new_users || [], (user) => {
+          const name = [user.first_name, user.last_name].filter(Boolean).join(' ') || user.username || user.telegram_id;
+          const created = user.created_at ? new Date(user.created_at).toLocaleString('ru-RU') : '';
+          return `${name} — ${created}`;
+        });
+
+        statsSection.style.display = 'block';
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    async function loadNotes(targetId) {
+      if (!targetId) return;
+      notesLoading.style.display = 'block';
+      try {
+        const data = await fetchJson(`${API_BASE}/admin/notes?user_id=${userId}&target_id=${targetId}`);
+        renderList(notesList, data.items || [], (item) => {
+          const created = item.created_at ? new Date(item.created_at).toLocaleString('ru-RU') : '';
+          return `[${created}] ${item.note}`;
+        });
+      } catch (e) {
+        notesList.innerHTML = `<li>${e.message}</li>`;
+      } finally {
+        notesLoading.style.display = 'none';
       }
     }
 
@@ -543,6 +655,23 @@
       }
     });
 
+    noteForm?.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const data = Object.fromEntries(new FormData(noteForm).entries());
+      data.user_id = userId;
+      data.target_id = Number(data.target_id);
+      try {
+        await fetchJson(`${API_BASE}/admin/notes`, {
+          method: 'POST',
+          body: JSON.stringify(data),
+        });
+        await loadNotes(data.target_id);
+        noteForm.reset();
+      } catch (err) {
+        showStatus(err.message, true);
+      }
+    });
+
     async function init() {
       hideStatus();
       try {
@@ -556,9 +685,12 @@
         return;
       }
 
+      statsSection.style.display = 'block';
+      notesSection.style.display = 'block';
       adminContent.style.display = 'block';
       ordersSection.style.display = 'block';
       promosSection.style.display = 'block';
+      await loadStats();
       await loadProducts();
       await loadOrders();
       await loadPromocodes();

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -117,6 +117,16 @@
         <div class="label">Избранное</div>
         <ul class="list" id="favorites-list"></ul>
       </div>
+
+      <div class="card">
+        <div class="label">Статистика</div>
+        <ul class="list" id="stats-list"></ul>
+      </div>
+
+      <div class="card" id="admin-notes-card" style="display:none">
+        <div class="label">Заметки администратора</div>
+        <ul class="list" id="notes-list"></ul>
+      </div>
     </div>
   </main>
 
@@ -137,6 +147,9 @@
     const ordersList = document.getElementById('orders-list');
     const ordersCount = document.getElementById('orders-count');
     const favoritesList = document.getElementById('favorites-list');
+    const statsList = document.getElementById('stats-list');
+    const notesList = document.getElementById('notes-list');
+    const adminNotesCard = document.getElementById('admin-notes-card');
     const savePhoneBtn = document.getElementById('save-phone');
 
     let userId = null;
@@ -214,6 +227,38 @@
       });
     }
 
+    function renderStats(stats, ban) {
+      statsList.innerHTML = '';
+      const rows = [
+        `Всего заказов: ${stats?.orders_count ?? 0}`,
+        `Потрачено: ${stats?.total_spent ?? 0} ₽`,
+        stats?.last_order_at ? `Последний заказ: ${new Date(stats.last_order_at).toLocaleString('ru-RU')}` : null,
+        ban?.is_banned ? `Статус: заблокирован (${ban.ban_reason || 'без причины'})` : 'Статус: активен',
+      ].filter(Boolean);
+
+      rows.forEach((row) => {
+        const li = document.createElement('li');
+        li.textContent = row;
+        statsList.appendChild(li);
+      });
+    }
+
+    function renderNotes(notes) {
+      notesList.innerHTML = '';
+      if (!notes || !notes.length) {
+        const li = document.createElement('li');
+        li.textContent = 'Заметок нет';
+        notesList.appendChild(li);
+        return;
+      }
+      notes.forEach((note) => {
+        const li = document.createElement('li');
+        const created = note.created_at ? new Date(note.created_at).toLocaleString('ru-RU') : '';
+        li.textContent = `[${created}] ${note.note}`;
+        notesList.appendChild(li);
+      });
+    }
+
     async function loadProfile() {
       const data = await fetchJson(`${API_BASE}/me?telegram_id=${userId}`);
       const fullName = [data.first_name, data.last_name].filter(Boolean).join(' ') || '—';
@@ -223,6 +268,14 @@
       phoneInput.value = data.phone || '';
       renderOrders(data.orders || []);
       renderFavorites(data.favorites || []);
+      renderStats(data.stats || {}, data.ban || {});
+      if (data.notes && data.notes.length) {
+        adminNotesCard.style.display = 'block';
+        renderNotes(data.notes);
+      }
+      if (data.ban?.is_banned) {
+        setStatus('Ваш аккаунт заблокирован. Свяжитесь с администратором.', true);
+      }
       profileGrid.style.display = 'grid';
     }
 


### PR DESCRIPTION
## Summary
- add ORM models and services for admin notes, user bans, and user statistics
- update bot handlers, web API, and web pages to consume new PostgreSQL-based services
- remove legacy sqlite usage and refresh admin/user dashboards with unified stats

## Testing
- python -m compileall services handlers models.py webapi.py database.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692364a4bc948326860ef57766ae1b56)