### PR TITLE
Refactor bot to use ORM catalog and cart

### DIFF
--- a/api/routers/cart.py
+++ b/api/routers/cart.py
@@ -96,9 +96,7 @@ def api_cart_add(payload: CartItemPayload):
 
     cart_service.add_to_cart(
         user_id=payload.user_id,
-        product_id=str(payload.product_id),
-        name=product["name"],
-        price=int(product.get("price") or 0),
+        product_id=int(payload.product_id),
         qty=qty,
         product_type=payload.type,
     )
@@ -109,10 +107,9 @@ def api_cart_add(payload: CartItemPayload):
 @router.post("/update")
 def api_cart_update(payload: CartUpdatePayload):
     qty = payload.qty or 0
-    product_id_str = str(payload.product_id)
 
     if qty <= 0:
-        cart_service.remove_from_cart(payload.user_id, product_id_str, payload.type)
+        cart_service.remove_from_cart(payload.user_id, int(payload.product_id), payload.type)
         return {"ok": True}
 
     product = (
@@ -128,7 +125,7 @@ def api_cart_update(payload: CartUpdatePayload):
         (
             i
             for i in current_items
-            if i.get("product_id") == product_id_str and i.get("type") == payload.type
+            if int(i.get("product_id")) == int(payload.product_id) and i.get("type") == payload.type
         ),
         None,
     )
@@ -136,13 +133,11 @@ def api_cart_update(payload: CartUpdatePayload):
     if existing:
         delta = qty - int(existing.get("qty") or 0)
         if delta != 0:
-            cart_service.change_qty(payload.user_id, product_id_str, delta, payload.type)
+            cart_service.change_qty(payload.user_id, int(payload.product_id), delta, payload.type)
     else:
         cart_service.add_to_cart(
             user_id=payload.user_id,
-            product_id=product_id_str,
-            name=product["name"],
-            price=int(product.get("price") or 0),
+            product_id=int(payload.product_id),
             qty=qty,
             product_type=payload.type,
         )
@@ -152,7 +147,7 @@ def api_cart_update(payload: CartUpdatePayload):
 
 @router.post("/remove")
 def api_cart_remove(payload: CartRemovePayload):
-    cart_service.remove_from_cart(payload.user_id, str(payload.product_id), payload.type)
+    cart_service.remove_from_cart(payload.user_id, int(payload.product_id), payload.type)
     return {"ok": True}
 
 

--- a/api/routers/orders.py
+++ b/api/routers/orders.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from services import cart as cart_service
 from services import orders as orders_service
+from services import users as users_service
 from services import products as products_service
 from utils.texts import format_order_for_admin
 
@@ -89,6 +90,14 @@ def api_checkout(payload: CheckoutPayload):
         comment=payload.comment or "",
     )
 
+    users_service.get_or_create_user_from_telegram(
+        {
+            "id": payload.user_id,
+            "username": payload.user_name,
+            "first_name": payload.customer_name,
+        }
+    )
+
     order_id = orders_service.add_order(
         user_id=payload.user_id,
         user_name=user_name,
@@ -98,11 +107,6 @@ def api_checkout(payload: CheckoutPayload):
         contact=payload.contact,
         comment=payload.comment or "",
         order_text=order_text,
-        user_data={
-            "id": payload.user_id,
-            "username": payload.user_name,
-            "first_name": payload.customer_name,
-        },
     )
 
     cart_service.clear_cart(payload.user_id)

--- a/database.py
+++ b/database.py
@@ -1,5 +1,7 @@
 import os
 from contextlib import contextmanager
+import os
+from contextlib import contextmanager
 from typing import Iterator
 
 from sqlalchemy import create_engine, select

--- a/handlers/baskets.py
+++ b/handlers/baskets.py
@@ -1,7 +1,7 @@
 from aiogram import Router, types, F
 from aiogram.types import CallbackQuery
 
-from services.products import get_baskets, get_basket_by_id, get_product_by_id
+from services.products import get_basket_by_id, get_product_by_id, list_products
 from services import orders as orders_service
 from services.cart import add_to_cart
 from services.favorites import add_favorite, is_favorite, remove_favorite
@@ -27,7 +27,7 @@ async def _send_baskets_page(
         if banner:
             await message.answer_photo(photo=banner, caption="🧺 Наши корзинки")
 
-    baskets = get_baskets()
+    baskets = list_products("basket", is_active=True)
     if not baskets:
         await message.answer("Список корзинок пока пуст. Попробуйте позже 🙈")
         return
@@ -46,7 +46,7 @@ async def _send_baskets_page(
 
     # Карточки товаров
     for item in page_items:
-        item_id = item["id"]
+        item_id = int(item["id"])
         photo = item.get("image_file_id")
 
         is_fav = is_favorite(user_id, item_id, "basket")
@@ -146,16 +146,7 @@ async def add_basket_to_cart(callback: CallbackQuery) -> None:
         return
 
     user_id = callback.from_user.id
-    name = item.get("name", "Корзинка")
-    price = int(item.get("price", 0))
-
-    add_to_cart(
-        user_id=user_id,
-        product_id=str(item_id),
-        name=name,
-        price=price,
-        qty=1,
-    )
+    add_to_cart(user_id=user_id, product_id=item_id, product_type="basket", qty=1)
 
     await callback.answer("Добавлено в корзину 🛒")
 

--- a/handlers/cart.py
+++ b/handlers/cart.py
@@ -130,7 +130,7 @@ async def cart_inc_cb(callback: CallbackQuery):
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    change_qty(user_id, product_id, delta=+1)
+    change_qty(user_id, int(product_id), delta=+1)
     await callback.answer("Добавлено")
     await _update_cart_message(callback)
 
@@ -156,7 +156,7 @@ async def cart_dec_cb(callback: CallbackQuery):
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    change_qty(user_id, product_id, delta=-1)
+    change_qty(user_id, int(product_id), delta=-1)
     await callback.answer("Убрано")
     await _update_cart_message(callback)
 
@@ -182,7 +182,7 @@ async def cart_remove_cb(callback: CallbackQuery):
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    remove_from_cart(user_id, product_id)
+    remove_from_cart(user_id, int(product_id))
     await callback.answer("Удалено")
     await _update_cart_message(callback)
 

--- a/handlers/checkout.py
+++ b/handlers/checkout.py
@@ -12,6 +12,7 @@ from services.cart import (
 from services.promocodes import increment_usage, validate_promocode
 from services.bans import is_banned
 from services.orders import add_order
+from services import users as users_service
 from services.subscription import ensure_subscribed
 from utils.texts import format_cart, format_order_for_admin, format_price
 
@@ -255,6 +256,8 @@ async def process_comment(message: types.Message, state: FSMContext) -> None:
         "last_name": getattr(telegram_user, "last_name", None),
     }
 
+    users_service.get_or_create_user_from_telegram(user_payload)
+
     order_id = add_order(
         user_id=user_id,
         user_name=user_name,
@@ -266,7 +269,6 @@ async def process_comment(message: types.Message, state: FSMContext) -> None:
         order_text=base_order_text,
         promocode_code=promo_code,
         discount_amount=discount_amount,
-        user_data=user_payload,
     )
 
     # Добавляем номер заказа

--- a/handlers/webapp.py
+++ b/handlers/webapp.py
@@ -45,15 +45,11 @@ async def handle_webapp_data(message: Message) -> None:
         logging.warning("Товар с id=%s не найден для web_app_data", product_id_int)
         return
 
-    name = product.get("name", "Товар")
-    price = int(product.get("price", 0) or 0)
-
     try:
         add_to_cart(
             user_id=message.from_user.id,
-            product_id=str(product_id_int),
-            name=name,
-            price=price,
+            product_id=product_id_int,
+            product_type=product.get("type") or "basket",
             qty=1,
         )
     except Exception:

--- a/services/cart.py
+++ b/services/cart.py
@@ -6,45 +6,77 @@ from sqlalchemy import delete, select
 
 from database import get_session, init_db
 from models import CartItem
+from services import products as products_service
 from services import users as users_service
 
 
-def get_cart_items(user_id: int) -> Tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+def _normalize_product(item: CartItem) -> tuple[dict[str, Any] | None, bool]:
+    product = (
+        products_service.get_basket_by_id(item.product_id)
+        if item.type == "basket"
+        else products_service.get_course_by_id(item.product_id)
+    )
+    if not product:
+        return None, True
+
+    return (
+        {
+            "product_id": int(item.product_id),
+            "name": product.get("name"),
+            "price": int(product.get("price", 0)),
+            "qty": int(item.qty),
+            "type": item.type,
+        },
+        False,
+    )
+
+
+def get_cart_items(user_id: int) -> Tuple[list[dict[str, Any]], list[int]]:
     init_db()
     with get_session() as session:
         items = session.scalars(select(CartItem).where(CartItem.user_id == user_id).order_by(CartItem.id)).all()
-        result: list[dict[str, Any]] = []
-        for item in items:
-            result.append(
-                {
-                    "product_id": str(item.product_id),
-                    "name": None,
-                    "price": 0,
-                    "qty": item.qty,
-                    "type": item.type,
-                }
-            )
-        return result, []
+
+    result: list[dict[str, Any]] = []
+    removed: list[int] = []
+
+    for item in items:
+        normalized, was_removed = _normalize_product(item)
+        if was_removed:
+            remove_from_cart(user_id, int(item.product_id), item.type)
+            removed.append(int(item.product_id))
+            continue
+        if normalized:
+            result.append(normalized)
+
+    return result, removed
 
 
-def add_to_cart(user_id: int, product_id: str, name: str, price: int, qty: int = 1, product_type: str = "basket") -> None:
+def add_to_cart(user_id: int, product_id: int, product_type: str, qty: int = 1) -> None:
+    qty = max(int(qty), 1)
     users_service.get_or_create_user_from_telegram({"id": user_id})
     with get_session() as session:
         existing = session.scalar(
-            select(CartItem).where(CartItem.user_id == user_id, CartItem.product_id == int(product_id), CartItem.type == product_type)
+            select(CartItem).where(
+                CartItem.user_id == user_id,
+                CartItem.product_id == int(product_id),
+                CartItem.type == product_type,
+            )
         )
         if existing:
             existing.qty = existing.qty + qty
         else:
-            session.add(
-                CartItem(user_id=user_id, product_id=int(product_id), qty=qty, type=product_type)
-            )
+            session.add(CartItem(user_id=user_id, product_id=int(product_id), qty=qty, type=product_type))
 
 
-def change_qty(user_id: int, product_id: str, delta: int, product_type: str = "basket") -> None:
+def change_qty(user_id: int, product_id: int, delta: int, product_type: str = "basket") -> None:
+    init_db()
     with get_session() as session:
         item = session.scalar(
-            select(CartItem).where(CartItem.user_id == user_id, CartItem.product_id == int(product_id), CartItem.type == product_type)
+            select(CartItem).where(
+                CartItem.user_id == user_id,
+                CartItem.product_id == int(product_id),
+                CartItem.type == product_type,
+            )
         )
         if not item:
             return
@@ -55,16 +87,22 @@ def change_qty(user_id: int, product_id: str, delta: int, product_type: str = "b
             item.qty = new_qty
 
 
-def remove_from_cart(user_id: int, product_id: str, product_type: str = "basket") -> None:
+def remove_from_cart(user_id: int, product_id: int, product_type: str = "basket") -> None:
+    init_db()
     with get_session() as session:
         item = session.scalar(
-            select(CartItem).where(CartItem.user_id == user_id, CartItem.product_id == int(product_id), CartItem.type == product_type)
+            select(CartItem).where(
+                CartItem.user_id == user_id,
+                CartItem.product_id == int(product_id),
+                CartItem.type == product_type,
+            )
         )
         if item:
             session.delete(item)
 
 
 def clear_cart(user_id: int) -> None:
+    init_db()
     with get_session() as session:
         session.execute(delete(CartItem).where(CartItem.user_id == user_id))
 
@@ -73,5 +111,5 @@ def get_cart_total(user_id: int) -> int:
     items, _ = get_cart_items(user_id)
     total = 0
     for item in items:
-        total += int(item["price"]) * int(item["qty"])
+        total += int(item.get("price", 0)) * int(item.get("qty", 0))
     return total

--- a/services/orders.py
+++ b/services/orders.py
@@ -26,14 +26,14 @@ STATUS_TITLES = {
 }
 
 
-def _ensure_user(telegram_id: int, user_data: dict[str, Any] | None = None) -> None:
+def _ensure_user(telegram_id: int, user_name: str | None = None) -> None:
     user = users_service.get_user_by_telegram_id(telegram_id)
     if user:
         return
 
     payload: dict[str, Any] = {"id": telegram_id}
-    if user_data:
-        payload.update(user_data)
+    if user_name:
+        payload["first_name"] = user_name
     users_service.get_or_create_user_from_telegram(payload)
 
 
@@ -96,9 +96,8 @@ def add_order(
     promocode_code: str | None = None,
     discount_amount: int | None = None,
     status: str | None = STATUS_NEW,
-    user_data: dict[str, Any] | None = None,
 ) -> int:
-    _ensure_user(user_id, user_data=user_data or {"first_name": user_name})
+    _ensure_user(user_id, user_name=user_name)
 
     normalized_items, computed_total = _normalize_order_items(items)
     order_total = computed_total if normalized_items else int(total)

--- a/services/users.py
+++ b/services/users.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import select


### PR DESCRIPTION
## Summary
- replace legacy JSON helpers with ORM-based product listing and optional seeding
- align bot and API cart/order flows with PostgreSQL-backed cart items and consistent payloads
- update checkout and documentation to reflect unified database architecture

## Testing
- python -m compileall services handlers api webapi.py bot.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236a9e057483268325f2a09715fd4b)