### PR TITLE
Fix WebApp categories and cart responses

### DIFF
--- a/services/cart.py
+++ b/services/cart.py
@@ -26,6 +26,7 @@ def _normalize_product(item: CartItem) -> tuple[dict[str, Any] | None, bool]:
             "price": int(product.get("price", 0)),
             "qty": int(item.qty),
             "type": item.type,
+            "category_name": product.get("category_name"),
         },
         False,
     )


### PR DESCRIPTION
## Summary
- add category metadata and course filters to product listing
- expose category endpoints matching basket and course tabs
- enrich cart API responses with product details for the WebApp

## Testing
- python -m compileall services webapi.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b47beea8832684b552d9a26aafe6)