### PR TITLE
Fix product creation photo handling

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -922,17 +922,21 @@ async def create_product_photo(message: types.Message, state: FSMContext):
     else:
         txt = (message.text or "").strip()
         if txt != "-":
-            await message.answer("Отправьте фото или '-' для пропуска.")
+            await message.answer("Отправьте фото или '-' если без фото.")
             return
 
+    # 1) создаём товар без фото
     product_id = products_service.create_product(
         product_type=product_type,
         name=name,
         price=price,
         description=description,
         detail_url=detail_url,
-        image_file_id=image_file_id,
     )
+
+    # 2) если есть фото — сохраняем его отдельной функцией
+    if image_file_id:
+        products_service.update_product_image(product_id, image_file_id)
 
     await state.clear()
 


### PR DESCRIPTION
## Summary
- create products without an image in the admin creation flow
- upload the product photo afterwards using the update helper when provided

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b942fd648326a9a93abfe7086104)