### PR TITLE
Fix Telegram WebApp auth and hide admin access for non-admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ REST API развернут в каталоге `api/` (FastAPI) и исполь
 Базовый запуск локально:
 
 ```
-uvicorn api.main:app --host 127.0.0.1 --port 8000 --reload
+uvicorn webapi:app --host 127.0.0.1 --port 8000 --reload
 ```
 
 Для корректной работы добавьте в `.env` ключи `BOT_TOKEN`, `ADMIN_CHAT_ID`, `BASE_URL="https://miniden.ru"` и `API_URL="https://miniden.ru/api"` (реальные значения подставляются на сервере).
@@ -204,7 +204,7 @@ After=network.target
 WorkingDirectory=/opt/miniden
 Environment="PYTHONUNBUFFERED=1"
 EnvironmentFile=/opt/miniden/.env
-ExecStart=/usr/bin/python -m uvicorn api.main:app --host 127.0.0.1 --port 8000
+ExecStart=/usr/bin/python -m uvicorn webapi:app --host 127.0.0.1 --port 8000
 Restart=always
 
 [Install]

--- a/README.txt
+++ b/README.txt
@@ -30,3 +30,23 @@ MiniDeN — Telegram-бот-магазин
   с `TypeError: list_products_by_status() got an unexpected keyword argument 'product_type'`.
 - Бот и WebApp используют общую базу данных, пока JSON-файлы служат
   только для начального наполнения каталога (опционально).
+
+## WebApp, авторизация и админка
+
+- Backend поднимается через FastAPI-приложение `webapi:app` на 127.0.0.1:8000,
+  nginx проксирует `/api` на этот порт.
+- Telegram WebApp-страницы (`products.html`, `masterclasses.html`, `cart.html`,
+  `profile.html`, `admin.html`) авторизуют пользователя через эндпоинт:
+
+    POST /api/auth/telegram
+
+  с передачей `initData` из `Telegram.WebApp`. Backend проверяет подпись initData
+  по токену бота (BOT_TOKEN), создаёт/обновляет запись пользователя в PostgreSQL
+  и возвращает `telegram_id`, `username`, `full_name`, `is_admin`.
+
+- Админские права определяются через переменные окружения `ADMIN_CHAT_ID` / `ADMIN_CHAT_IDS`.
+  При инициализации базы (`init_db`) пользователи с такими ID помечаются `is_admin = True`.
+
+- В WebApp ссылка «Админка» в верхнем меню отображается только для пользователей,
+  у которых `is_admin = True`. Для остальных она скрыта, а прямой доступ к admin.html
+  всё равно блокируется backend'ом (эндпоинты `/api/admin/*` возвращают 403).

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -145,7 +145,7 @@
       <a href="masterclasses.html">Мастер-классы</a>
       <a href="cart.html">Корзина</a>
       <a href="profile.html">Профиль</a>
-      <a href="admin.html" class="active">Админка</a>
+      <a href="admin.html" id="admin-link" class="active">Админка</a>
     </div>
   </nav>
 
@@ -324,6 +324,7 @@
     toggle?.addEventListener('click', () => nav?.classList.toggle('open'));
 
     const statusEl = document.getElementById('status');
+    const adminLink = document.getElementById('admin-link');
     const adminContent = document.getElementById('admin-content');
     const ordersSection = document.getElementById('orders-section');
     const promosSection = document.getElementById('promos-section');
@@ -359,6 +360,13 @@
     let products = [];
     let currentType = 'basket';
 
+    function updateAdminLinkVisibility() {
+      if (!adminLink) return;
+      adminLink.style.display = isAdmin ? '' : 'none';
+    }
+
+    updateAdminLinkVisibility();
+
     function showStatus(msg, isError = false) {
       statusEl.textContent = msg;
       statusEl.style.display = 'block';
@@ -386,7 +394,13 @@
     }
 
     async function authorize() {
-      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
+      if (!tg || !initData) {
+        showStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
+        updateAdminLinkVisibility();
+        throw new Error('Telegram WebApp required');
+      }
+
       try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
@@ -395,8 +409,16 @@
         });
         userId = data.telegram_id;
         isAdmin = Boolean(data.is_admin);
+        updateAdminLinkVisibility();
+        if (!isAdmin) {
+          showStatus('Нет доступа: вы не администратор', true);
+          throw new Error('Forbidden');
+        }
       } catch (e) {
-        showStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
+        if (e.message !== 'Forbidden') {
+          showStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
+        }
+        updateAdminLinkVisibility();
         throw e;
       }
     }

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -82,7 +82,7 @@
       <a href="masterclasses.html">Мастер-классы</a>
       <a href="cart.html" class="active">Корзина</a>
       <a href="profile.html">Профиль</a>
-      <a href="admin.html">Админка</a>
+      <a href="admin.html" id="admin-link">Админка</a>
     </nav>
   </header>
 
@@ -130,6 +130,7 @@
     let userId = null;
     let username = null;
     let isAdmin = false;
+    const adminLink = document.getElementById('admin-link');
     let currentCart = { items: [], total: 0 };
     let appliedPromo = null;
     let discountAmount = 0;
@@ -143,6 +144,13 @@
     const applyPromoBtn = document.getElementById('apply-promo');
     const clearBtn = document.getElementById('clear-cart');
     const checkoutBtn = document.getElementById('checkout');
+
+    function updateAdminLinkVisibility() {
+      if (!adminLink) return;
+      adminLink.style.display = isAdmin ? '' : 'none';
+    }
+
+    updateAdminLinkVisibility();
 
     function formatPrice(value) {
       const num = Number(value) || 0;
@@ -159,7 +167,13 @@
     }
 
     async function authorize() {
-      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
+      if (!tg || !initData) {
+        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
+        updateAdminLinkVisibility();
+        return;
+      }
+
       try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
@@ -169,9 +183,10 @@
         userId = data.telegram_id;
         username = data.username;
         isAdmin = Boolean(data.is_admin);
+        updateAdminLinkVisibility();
       } catch (e) {
-        document.querySelector('#summary').textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        throw e;
+        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
+        updateAdminLinkVisibility();
       }
     }
 

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -87,7 +87,7 @@
       <a href="masterclasses.html" class="active">Мастер-классы</a>
       <a href="cart.html">Корзина</a>
       <a href="profile.html">Профиль</a>
-      <a href="admin.html">Админка</a>
+      <a href="admin.html" id="admin-link">Админка</a>
     </nav>
   </header>
 
@@ -113,6 +113,7 @@
     let username = null;
     let isAdmin = false;
     let favorites = new Set();
+    const adminLink = document.getElementById('admin-link');
 
     const tabsEl = document.getElementById('tabs');
     const cardsEl = document.getElementById('cards');
@@ -178,8 +179,21 @@
       return res.json();
     }
 
+    function updateAdminLinkVisibility() {
+      if (!adminLink) return;
+      adminLink.style.display = isAdmin ? '' : 'none';
+    }
+
+    updateAdminLinkVisibility();
+
     async function authorize() {
-      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
+      if (!tg || !initData) {
+        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
+        updateAdminLinkVisibility();
+        return;
+      }
+
       try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
@@ -189,9 +203,10 @@
         userId = data.telegram_id;
         username = data.username;
         isAdmin = Boolean(data.is_admin);
+        updateAdminLinkVisibility();
       } catch (e) {
         noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        throw e;
+        updateAdminLinkVisibility();
       }
     }
 

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -108,7 +108,7 @@
       <a href="masterclasses.html">Мастер-классы</a>
       <a href="cart.html">Корзина</a>
       <a href="profile.html">Профиль</a>
-      <a href="admin.html">Админка</a>
+      <a href="admin.html" id="admin-link">Админка</a>
     </nav>
   </header>
 
@@ -133,6 +133,7 @@
     let username = null;
     let isAdmin = false;
     let favorites = new Set();
+    const adminLink = document.getElementById('admin-link');
 
     const tabsEl = document.getElementById('tabs');
     const cardsEl = document.getElementById('cards');
@@ -193,8 +194,21 @@
       return res.json();
     }
 
+    function updateAdminLinkVisibility() {
+      if (!adminLink) return;
+      adminLink.style.display = isAdmin ? '' : 'none';
+    }
+
+    updateAdminLinkVisibility();
+
     async function authorize() {
-      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
+      if (!tg || !initData) {
+        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
+        updateAdminLinkVisibility();
+        return;
+      }
+
       try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
@@ -204,9 +218,10 @@
         userId = data.telegram_id;
         username = data.username;
         isAdmin = Boolean(data.is_admin);
+        updateAdminLinkVisibility();
       } catch (e) {
         noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        throw e;
+        updateAdminLinkVisibility();
       }
     }
 

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -80,7 +80,7 @@
       <a href="masterclasses.html">Мастер-классы</a>
       <a href="cart.html">Корзина</a>
       <a href="profile.html" class="active">Профиль</a>
-      <a href="admin.html">Админка</a>
+      <a href="admin.html" id="admin-link">Админка</a>
     </nav>
   </header>
 
@@ -153,6 +153,15 @@
     const savePhoneBtn = document.getElementById('save-phone');
 
     let userId = null;
+    let isAdmin = false;
+    const adminLink = document.getElementById('admin-link');
+
+    function updateAdminLinkVisibility() {
+      if (!adminLink) return;
+      adminLink.style.display = isAdmin ? '' : 'none';
+    }
+
+    updateAdminLinkVisibility();
 
     function setStatus(message, isError = false) {
       if (!message) {
@@ -176,7 +185,13 @@
     }
 
     async function authorize() {
-      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
+      if (!tg || !initData) {
+        setStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
+        updateAdminLinkVisibility();
+        return;
+      }
+
       try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
@@ -184,10 +199,12 @@
           body: JSON.stringify({ initData }),
         });
         userId = data.telegram_id;
+        isAdmin = Boolean(data.is_admin);
         setStatus('');
+        updateAdminLinkVisibility();
       } catch (e) {
         setStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
-        throw e;
+        updateAdminLinkVisibility();
       }
     }
 
@@ -297,6 +314,7 @@
     (async function initApp() {
       try {
         await authorize();
+        if (!userId) return;
         await loadProfile();
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
## Summary
- document running the backend via `webapi:app` and describe WebApp auth/admin flow
- align WebApp pages with Telegram auth endpoint, showing clear messages outside Telegram
- hide admin navigation links and block admin page access for non-admin users

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929ee8c1e8483269a12d5414ef6607a)