### PR TITLE
Add Telegram Login Widget support for browser sessions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -33,9 +33,9 @@ MiniDeN — Telegram-бот-магазин
 
 ## WebApp, авторизация и админка
 
-- Backend поднимается через FastAPI-приложение `webapi:app` на 127.0.0.1:8000,
+  - Backend поднимается через FastAPI-приложение `webapi:app` на 127.0.0.1:8000,
   nginx проксирует `/api` на этот порт.
-- Telegram WebApp-страницы (`products.html`, `masterclasses.html`, `cart.html`,
+  - Telegram WebApp-страницы (`products.html`, `masterclasses.html`, `cart.html`,
   `profile.html`, `admin.html`) авторизуют пользователя через эндпоинт:
 
     POST /api/auth/telegram
@@ -44,9 +44,19 @@ MiniDeN — Telegram-бот-магазин
   по токену бота (BOT_TOKEN), создаёт/обновляет запись пользователя в PostgreSQL
   и возвращает `telegram_id`, `username`, `full_name`, `is_admin`.
 
-- Админские права определяются через переменные окружения `ADMIN_CHAT_ID` / `ADMIN_CHAT_IDS`.
+  - Админские права определяются через переменные окружения `ADMIN_CHAT_ID` / `ADMIN_CHAT_IDS`.
   При инициализации базы (`init_db`) пользователи с такими ID помечаются `is_admin = True`.
 
-- В WebApp ссылка «Админка» в верхнем меню отображается только для пользователей,
+  - В WebApp ссылка «Админка» в верхнем меню отображается только для пользователей,
   у которых `is_admin = True`. Для остальных она скрыта, а прямой доступ к admin.html
   всё равно блокируется backend'ом (эндпоинты `/api/admin/*` возвращают 403).
+
+### Авторизация на сайте через Telegram
+
+- Для входа на сайт с ПК используется Telegram Login Widget.
+- В @BotFather нужно выполнить `/setdomain` и указать домен `miniden.ru`.
+- На страничке `index.html` встроена кнопка «Войти через Telegram», которая обращается к
+  `/api/auth/telegram-login`. Бэкенд проверяет подпись данных, создаёт/обновляет пользователя
+  в БД (таблица users) и устанавливает cookie `tg_user_id` с его Telegram ID.
+- Все последующие запросы WebApp используют `/api/auth/session` для получения информации
+  о текущем пользователе по этой cookie.

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -394,19 +394,21 @@
     }
 
     async function authorize() {
-      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
-      if (!tg || !initData) {
-        showStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
-        updateAdminLinkVisibility();
-        throw new Error('Telegram WebApp required');
-      }
-
       try {
-        const data = await fetchJson(`${API_BASE}/auth/telegram`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ initData }),
-        });
+        const hasTelegram = !!tg && !!tg.initData;
+        let data;
+
+        if (hasTelegram) {
+          const initData = tg.initData;
+          data = await fetchJson(`${API_BASE}/auth/telegram`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ initData }),
+          });
+        } else {
+          data = await fetchJson(`${API_BASE}/auth/session`);
+        }
+
         userId = data.telegram_id;
         isAdmin = Boolean(data.is_admin);
         updateAdminLinkVisibility();
@@ -415,8 +417,10 @@
           throw new Error('Forbidden');
         }
       } catch (e) {
-        if (e.message !== 'Forbidden') {
-          showStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
+        if (e.message === 'Forbidden') {
+          showStatus('Нет доступа: вы не администратор', true);
+        } else {
+          showStatus('Вы не авторизованы. Откройте главную страницу и войдите через Telegram.', true);
         }
         updateAdminLinkVisibility();
         throw e;

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -167,14 +167,9 @@
     }
 
     async function authorize() {
-      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
-      if (!tg || !initData) {
-        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        updateAdminLinkVisibility();
-        return;
-      }
-
-      try {
+      const hasTelegram = !!tg && !!tg.initData;
+      if (hasTelegram) {
+        const initData = tg.initData;
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -184,9 +179,18 @@
         username = data.username;
         isAdmin = Boolean(data.is_admin);
         updateAdminLinkVisibility();
-      } catch (e) {
-        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        updateAdminLinkVisibility();
+      } else {
+        try {
+          const data = await fetchJson(`${API_BASE}/auth/session`);
+          userId = data.telegram_id;
+          username = data.username;
+          isAdmin = Boolean(data.is_admin);
+          updateAdminLinkVisibility();
+        } catch (e) {
+          noteEl.textContent = 'Вы не авторизованы. Откройте главную страницу и войдите через Telegram.';
+          updateAdminLinkVisibility();
+          throw e;
+        }
       }
     }
 
@@ -264,7 +268,7 @@
 
     async function loadCart() {
       if (!userId) {
-        noteEl.textContent = 'Чтобы видеть свою корзину, откройте сайт через Telegram-бота.';
+        noteEl.textContent = 'Чтобы видеть свою корзину, войдите через Telegram на главной странице.';
         renderEmpty('Нет данных — нет Telegram user_id');
         return;
       }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -306,6 +306,21 @@
     <div>Мы в соцсетях: <a href="#">Instagram*</a> • <a href="#">VK</a></div>
   </footer>
 
+  <section class="section">
+    <h2>Вход через Telegram</h2>
+    <p>Чтобы синхронизировать корзину и профиль с ботом MiniDeN, войдите через Telegram:</p>
+    <div id="telegram-login-container">
+      <script async src="https://telegram.org/js/telegram-widget.js?22"
+              data-telegram-login="MiniDeN_bot"
+              data-size="large"
+              data-userpic="false"
+              data-request-access="write"
+              data-auth-url="/api/auth/telegram-login">
+      </script>
+    </div>
+    <p>После входа вы будете перенаправлены в профиль, и сайт начнёт использовать ваш Telegram-аккаунт.</p>
+  </section>
+
   <script>
     const toggle = document.querySelector('.menu-toggle');
     const nav = document.querySelector('.nav-links');

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -150,7 +150,7 @@
 
     async function toggleFavorite(course) {
       if (!userId) {
-        alert('Чтобы добавить в избранное, откройте сайт из Telegram-бота.');
+        alert('Чтобы добавить в избранное, войдите через Telegram на главной странице.');
         return;
       }
       try {
@@ -187,14 +187,9 @@
     updateAdminLinkVisibility();
 
     async function authorize() {
-      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
-      if (!tg || !initData) {
-        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        updateAdminLinkVisibility();
-        return;
-      }
-
-      try {
+      const hasTelegram = !!tg && !!tg.initData;
+      if (hasTelegram) {
+        const initData = tg.initData;
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -204,9 +199,18 @@
         username = data.username;
         isAdmin = Boolean(data.is_admin);
         updateAdminLinkVisibility();
-      } catch (e) {
-        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        updateAdminLinkVisibility();
+      } else {
+        try {
+          const data = await fetchJson(`${API_BASE}/auth/session`);
+          userId = data.telegram_id;
+          username = data.username;
+          isAdmin = Boolean(data.is_admin);
+          updateAdminLinkVisibility();
+        } catch (e) {
+          noteEl.textContent = 'Вы не авторизованы. Откройте главную страницу и войдите через Telegram.';
+          updateAdminLinkVisibility();
+          throw e;
+        }
       }
     }
 
@@ -315,7 +319,7 @@
 
     async function handleAddToCart(course) {
       if (!userId) {
-        alert('Для добавления в корзину откройте сайт из Telegram-бота.');
+        alert('Для добавления в корзину войдите через Telegram на главной странице.');
         return;
       }
 

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -165,7 +165,7 @@
 
     async function toggleFavorite(item) {
       if (!userId) {
-        alert('Чтобы добавить в избранное, откройте сайт из Telegram-бота.');
+        alert('Чтобы добавить в избранное, войдите через Telegram на главной странице.');
         return;
       }
       try {
@@ -202,14 +202,9 @@
     updateAdminLinkVisibility();
 
     async function authorize() {
-      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
-      if (!tg || !initData) {
-        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        updateAdminLinkVisibility();
-        return;
-      }
-
-      try {
+      const hasTelegram = !!tg && !!tg.initData;
+      if (hasTelegram) {
+        const initData = tg.initData;
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -219,9 +214,18 @@
         username = data.username;
         isAdmin = Boolean(data.is_admin);
         updateAdminLinkVisibility();
-      } catch (e) {
-        noteEl.textContent = 'Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить';
-        updateAdminLinkVisibility();
+      } else {
+        try {
+          const data = await fetchJson(`${API_BASE}/auth/session`);
+          userId = data.telegram_id;
+          username = data.username;
+          isAdmin = Boolean(data.is_admin);
+          updateAdminLinkVisibility();
+        } catch (e) {
+          noteEl.textContent = 'Вы не авторизованы. Откройте главную страницу и войдите через Telegram.';
+          updateAdminLinkVisibility();
+          throw e;
+        }
       }
     }
 
@@ -327,7 +331,7 @@
 
     async function handleAddToCart(product) {
       if (!userId) {
-        alert('Для добавления в корзину откройте сайт из Telegram-бота.');
+        alert('Для добавления в корзину войдите через Telegram на главной странице.');
         return;
       }
 

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -185,14 +185,9 @@
     }
 
     async function authorize() {
-      const initData = tg?.initData || (tg?.initDataUnsafe ? tg.initData : null);
-      if (!tg || !initData) {
-        setStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
-        updateAdminLinkVisibility();
-        return;
-      }
-
-      try {
+      const hasTelegram = !!tg && !!tg.initData;
+      if (hasTelegram) {
+        const initData = tg.initData;
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -202,9 +197,18 @@
         isAdmin = Boolean(data.is_admin);
         setStatus('');
         updateAdminLinkVisibility();
-      } catch (e) {
-        setStatus('Откройте сайт из Telegram-бота MiniDeN, чтобы продолжить', true);
-        updateAdminLinkVisibility();
+      } else {
+        try {
+          const data = await fetchJson(`${API_BASE}/auth/session`);
+          userId = data.telegram_id;
+          isAdmin = Boolean(data.is_admin);
+          setStatus('');
+          updateAdminLinkVisibility();
+        } catch (e) {
+          setStatus('Вы не авторизованы. Откройте главную страницу и войдите через Telegram.', true);
+          updateAdminLinkVisibility();
+          throw e;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- add Telegram Login Widget and cookie-based session endpoints for browser users
- update webapp pages to authorize via Telegram WebApp or session cookies and refresh user messaging
- document the new login flow and add the Telegram login widget to the site landing page

## Testing
- python -m compileall webapi.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929f433902483269928b04b9bff645a)