### PR TITLE
Add Telegram login entry points

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -60,3 +60,15 @@ MiniDeN — Telegram-бот-магазин
   в БД (таблица users) и устанавливает cookie `tg_user_id` с его Telegram ID.
 - Все последующие запросы WebApp используют `/api/auth/session` для получения информации
   о текущем пользователе по этой cookie.
+
+### Точки входа на сайте
+
+- **Главная (`index.html`)** — содержит блок «Вход через Telegram» с официальным Telegram Login Widget.
+  После успешного входа backend устанавливает cookie и перенаправляет в профиль.
+
+- **Корзина (`cart.html`)** и **Профиль (`profile.html`)**:
+  если пользователь не авторизован, страницы показывают понятный блок
+  «Вы не авторизованы» с кнопкой «Перейти на главную для входа».
+
+- В режиме Telegram WebApp авторизация идёт через `initData` и `/api/auth/telegram`.
+  В режиме обычного браузера — через Telegram Login Widget и `/api/auth/telegram-login` + `/api/auth/session`.

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -119,6 +119,17 @@
     </div>
   </main>
 
+  <section class="section" id="login-hint" style="display: none; text-align: center;">
+    <h2>Вы не авторизованы</h2>
+    <p>
+      Чтобы увидеть вашу корзину и оформить заказ, войдите через Telegram.
+      Сначала откройте главную страницу и нажмите кнопку входа.
+    </p>
+    <p>
+      <a href="index.html" class="btn">Перейти на главную для входа</a>
+    </p>
+  </section>
+
   <script>
     const toggle = document.querySelector('.menu-toggle');
     const nav = document.querySelector('.nav-links');
@@ -137,6 +148,7 @@
     let finalTotal = 0;
 
     const noteEl = document.getElementById('note');
+    const loginHint = document.getElementById('login-hint');
     const tbody = document.getElementById('cart-body');
     const totalEl = document.getElementById('cart-total');
     const promoInfoEl = document.getElementById('promo-info');
@@ -144,6 +156,15 @@
     const applyPromoBtn = document.getElementById('apply-promo');
     const clearBtn = document.getElementById('clear-cart');
     const checkoutBtn = document.getElementById('checkout');
+
+    function showLoginHint(message) {
+      if (loginHint) {
+        loginHint.style.display = 'block';
+      }
+      if (noteEl && message) {
+        noteEl.textContent = message;
+      }
+    }
 
     function updateAdminLinkVisibility() {
       if (!adminLink) return;
@@ -179,6 +200,8 @@
         username = data.username;
         isAdmin = Boolean(data.is_admin);
         updateAdminLinkVisibility();
+        if (loginHint) loginHint.style.display = 'none';
+        if (noteEl) noteEl.textContent = '';
       } else {
         try {
           const data = await fetchJson(`${API_BASE}/auth/session`);
@@ -187,10 +210,12 @@
           isAdmin = Boolean(data.is_admin);
           updateAdminLinkVisibility();
         } catch (e) {
-          noteEl.textContent = 'Вы не авторизованы. Откройте главную страницу и войдите через Telegram.';
+          showLoginHint('Вы не авторизованы. Перейдите на главную страницу и войдите через Telegram.');
           updateAdminLinkVisibility();
           throw e;
         }
+        if (loginHint) loginHint.style.display = 'none';
+        if (noteEl) noteEl.textContent = '';
       }
     }
 
@@ -268,7 +293,7 @@
 
     async function loadCart() {
       if (!userId) {
-        noteEl.textContent = 'Чтобы видеть свою корзину, войдите через Telegram на главной странице.';
+        showLoginHint('Чтобы видеть свою корзину, перейдите на главную страницу и войдите через Telegram.');
         renderEmpty('Нет данных — нет Telegram user_id');
         return;
       }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -159,6 +159,11 @@
 
     h2 { margin: 28px 0 12px; letter-spacing: -0.01em; }
 
+    .muted {
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
     .grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
 
     .card {
@@ -306,9 +311,14 @@
     <div>Мы в соцсетях: <a href="#">Instagram*</a> • <a href="#">VK</a></div>
   </footer>
 
-  <section class="section">
+  <section class="section" id="telegram-login-section">
     <h2>Вход через Telegram</h2>
-    <p>Чтобы синхронизировать корзину и профиль с ботом MiniDeN, войдите через Telegram:</p>
+    <p>
+      Чтобы синхронизировать корзину и профиль с ботом MiniDeN, войдите через Telegram.
+      После входа сайт будет использовать ваш Telegram-аккаунт.
+    </p>
+
+    <!-- Вариант 1: официальный Telegram Login Widget -->
     <div id="telegram-login-container">
       <script async src="https://telegram.org/js/telegram-widget.js?22"
               data-telegram-login="MiniDeN_bot"
@@ -318,7 +328,11 @@
               data-auth-url="/api/auth/telegram-login">
       </script>
     </div>
-    <p>После входа вы будете перенаправлены в профиль, и сайт начнёт использовать ваш Telegram-аккаунт.</p>
+
+    <p class="muted">
+      Если кнопка не отображается, откройте сайт в обычном браузере и убедитесь,
+      что домен указан в настройках бота через BotFather (/setdomain).
+    </p>
   </section>
 
   <script>

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -130,6 +130,17 @@
     </div>
   </main>
 
+  <section class="section" id="login-hint" style="display: none; text-align: center;">
+    <h2>Вы не авторизованы</h2>
+    <p>
+      Профиль, заказы и избранное привязаны к вашему Telegram-аккаунту.
+      Пожалуйста, войдите через Telegram на главной странице.
+    </p>
+    <p>
+      <a href="index.html" class="btn">Перейти на главную для входа</a>
+    </p>
+  </section>
+
   <script>
     const toggle = document.querySelector('.menu-toggle');
     const nav = document.querySelector('.nav-links');
@@ -139,6 +150,7 @@
     const API_BASE = "/api";
 
     const statusEl = document.getElementById('status');
+    const loginHint = document.getElementById('login-hint');
     const profileGrid = document.getElementById('profile-grid');
     const fullNameEl = document.getElementById('full-name');
     const usernameEl = document.getElementById('username');
@@ -175,6 +187,13 @@
       statusEl.style.display = 'block';
     }
 
+    function showLoginHint(message) {
+      if (loginHint) {
+        loginHint.style.display = 'block';
+      }
+      setStatus(message, true);
+    }
+
     async function fetchJson(url, options) {
       const res = await fetch(url, options);
       if (!res.ok) {
@@ -197,6 +216,7 @@
         isAdmin = Boolean(data.is_admin);
         setStatus('');
         updateAdminLinkVisibility();
+        if (loginHint) loginHint.style.display = 'none';
       } else {
         try {
           const data = await fetchJson(`${API_BASE}/auth/session`);
@@ -205,10 +225,11 @@
           setStatus('');
           updateAdminLinkVisibility();
         } catch (e) {
-          setStatus('Вы не авторизованы. Откройте главную страницу и войдите через Telegram.', true);
+          showLoginHint('Вы не авторизованы. Перейдите на главную страницу и войдите через Telegram.');
           updateAdminLinkVisibility();
           throw e;
         }
+        if (loginHint) loginHint.style.display = 'none';
       }
     }
 


### PR DESCRIPTION
## Summary
- add a prominent Telegram login section to the main page
- show login hints with a button to the main page on cart and profile when unauthenticated
- document the web entry points and Telegram login flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929f701d0e8832687fa1feaa1b809d0)