### PR TITLE
Allow guest browsing and add Telegram entry points

### DIFF
--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -395,35 +395,43 @@
 
     async function authorize() {
       try {
-        const hasTelegram = !!tg && !!tg.initData;
-        let data;
-
-        if (hasTelegram) {
-          const initData = tg.initData;
-          data = await fetchJson(`${API_BASE}/auth/telegram`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ initData }),
-          });
-        } else {
-          data = await fetchJson(`${API_BASE}/auth/session`);
+        const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+        if (!initData) {
+          userId = null;
+          isAdmin = false;
+          showStatus(
+            'Админ-панель доступна только из Telegram-бота MiniDeN и только администраторам. ' +
+              'Откройте её из бота и повторите попытку.',
+            true
+          );
+          updateAdminLinkVisibility();
+          return;
         }
+
+        const data = await fetchJson(`${API_BASE}/auth/telegram`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ initData }),
+        });
 
         userId = data.telegram_id;
         isAdmin = Boolean(data.is_admin);
         updateAdminLinkVisibility();
         if (!isAdmin) {
-          showStatus('Нет доступа: вы не администратор', true);
-          throw new Error('Forbidden');
+          showStatus('У вас нет прав администратора.', true);
+          return;
         }
+
+        showStatus('');
       } catch (e) {
-        if (e.message === 'Forbidden') {
-          showStatus('Нет доступа: вы не администратор', true);
-        } else {
-          showStatus('Вы не авторизованы. Откройте главную страницу и войдите через Telegram.', true);
-        }
+        console.warn('WebApp auth failed в админке', e);
+        userId = null;
+        isAdmin = false;
+        showStatus(
+          'Не удалось авторизоваться через Telegram. Попробуйте открыть админку ещё раз из бота MiniDeN.',
+          true
+        );
         updateAdminLinkVisibility();
-        throw e;
       }
     }
 

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -188,9 +188,23 @@
     }
 
     async function authorize() {
-      const hasTelegram = !!tg && !!tg.initData;
-      if (hasTelegram) {
-        const initData = tg.initData;
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      if (!initData) {
+        userId = null;
+        username = null;
+        isAdmin = false;
+        if (noteEl) {
+          noteEl.innerHTML =
+            'Корзина привязана к вашему Telegram-профилю. ' +
+            'Откройте эту страницу из ' +
+            '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>, ' +
+            'а затем вернитесь и обновите страницу.';
+        }
+        updateAdminLinkVisibility();
+        return;
+      }
+
+      try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -202,20 +216,18 @@
         updateAdminLinkVisibility();
         if (loginHint) loginHint.style.display = 'none';
         if (noteEl) noteEl.textContent = '';
-      } else {
-        try {
-          const data = await fetchJson(`${API_BASE}/auth/session`);
-          userId = data.telegram_id;
-          username = data.username;
-          isAdmin = Boolean(data.is_admin);
-          updateAdminLinkVisibility();
-        } catch (e) {
-          showLoginHint('Вы не авторизованы. Перейдите на главную страницу и войдите через Telegram.');
-          updateAdminLinkVisibility();
-          throw e;
+      } catch (e) {
+        console.warn('WebApp auth failed, показываем пустую корзину', e);
+        userId = null;
+        username = null;
+        isAdmin = false;
+        if (noteEl) {
+          noteEl.innerHTML =
+            'Не удалось получить данные Telegram. ' +
+            'Откройте корзину через ' +
+            '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">бот MiniDeN</a>.';
         }
-        if (loginHint) loginHint.style.display = 'none';
-        if (noteEl) noteEl.textContent = '';
+        updateAdminLinkVisibility();
       }
     }
 
@@ -293,7 +305,7 @@
 
     async function loadCart() {
       if (!userId) {
-        showLoginHint('Чтобы видеть свою корзину, перейдите на главную страницу и войдите через Telegram.');
+        showLoginHint('Чтобы видеть содержимое корзины, откройте эту страницу из Telegram-бота MiniDeN.');
         renderEmpty('Нет данных — нет Telegram user_id');
         return;
       }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -298,6 +298,18 @@
     </div>
 
     <h2>Как это работает</h2>
+    <div class="step">
+      <strong>0) Войдите через Telegram-бота</strong>
+      <p>
+        Нажмите кнопку ниже, откройте бота MiniDeN в Telegram и нажмите «Старт».
+        После этого каталоги, корзина и профиль на сайте будут связаны с вашим аккаунтом.
+      </p>
+      <p style="margin-top:8px;">
+        <a class="btn" href="https://t.me/miniden_bot" target="_blank" rel="noopener">
+          Открыть бота MiniDeN в Telegram
+        </a>
+      </p>
+    </div>
     <div class="steps">
       <div class="step"><strong>1) Выберите товар или курс</strong><p>Откройте раздел «Товары» или «Мастер-классы» и найдите то, что подходит именно вам.</p></div>
       <div class="step"><strong>2) Добавьте в корзину</strong><p>Нажмите «В корзину» на карточке. В демо пока заглушка, позже привяжем API и Telegram-бота.</p></div>
@@ -306,8 +318,14 @@
   </main>
 
   <footer>
-    <div>Готовы помочь в Telegram: <a href="https://t.me" target="_blank" rel="noopener">бот MiniDeN</a></div>
-    <div>Новости и вдохновение: <a href="https://t.me" target="_blank" rel="noopener">Telegram-канал</a></div>
+    <div>
+      Готовы помочь в Telegram:
+      <a href="https://t.me/miniden_bot" target="_blank" rel="noopener">бот MiniDeN</a>
+    </div>
+    <div>
+      Новости и вдохновение:
+      <a href="https://t.me" target="_blank" rel="noopener">Telegram-канал</a>
+    </div>
     <div>Мы в соцсетях: <a href="#">Instagram*</a> • <a href="#">VK</a></div>
   </footer>
 

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -187,9 +187,20 @@
     updateAdminLinkVisibility();
 
     async function authorize() {
-      const hasTelegram = !!tg && !!tg.initData;
-      if (hasTelegram) {
-        const initData = tg.initData;
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      if (!initData) {
+        userId = null;
+        username = null;
+        isAdmin = false;
+        noteEl.innerHTML =
+          'Каталог мастер-классов доступен в режиме просмотра. ' +
+          'Чтобы добавлять курсы в корзину и в избранное, откройте сайт из ' +
+          '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.';
+        updateAdminLinkVisibility();
+        return;
+      }
+
+      try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -198,19 +209,18 @@
         userId = data.telegram_id;
         username = data.username;
         isAdmin = Boolean(data.is_admin);
+        noteEl.textContent = '';
         updateAdminLinkVisibility();
-      } else {
-        try {
-          const data = await fetchJson(`${API_BASE}/auth/session`);
-          userId = data.telegram_id;
-          username = data.username;
-          isAdmin = Boolean(data.is_admin);
-          updateAdminLinkVisibility();
-        } catch (e) {
-          noteEl.textContent = 'Вы не авторизованы. Откройте главную страницу и войдите через Telegram.';
-          updateAdminLinkVisibility();
-          throw e;
-        }
+      } catch (e) {
+        console.warn('WebApp auth failed, продолжаем как гость', e);
+        userId = null;
+        username = null;
+        isAdmin = false;
+        noteEl.innerHTML =
+          'Каталог мастер-классов доступен в режиме просмотра. ' +
+          'Чтобы использовать корзину, откройте сайт из ' +
+          '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.';
+        updateAdminLinkVisibility();
       }
     }
 

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -202,9 +202,24 @@
     updateAdminLinkVisibility();
 
     async function authorize() {
-      const hasTelegram = !!tg && !!tg.initData;
-      if (hasTelegram) {
-        const initData = tg.initData;
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      // Если сайт открыт НЕ как Telegram WebApp, работаем в режиме гостя:
+      // каталог виден, но избранное и корзина не работают.
+      if (!initData) {
+        userId = null;
+        username = null;
+        isAdmin = false;
+        noteEl.innerHTML =
+          'Каталог доступен в режиме просмотра. ' +
+          'Чтобы добавлять товары в корзину и видеть свои заказы, ' +
+          'откройте сайт из ' +
+          '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a> ' +
+          'и затем обновите страницу.';
+        updateAdminLinkVisibility();
+        return;
+      }
+
+      try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -213,19 +228,20 @@
         userId = data.telegram_id;
         username = data.username;
         isAdmin = Boolean(data.is_admin);
+        // успешная авторизация — убираем подсказку
+        noteEl.textContent = '';
         updateAdminLinkVisibility();
-      } else {
-        try {
-          const data = await fetchJson(`${API_BASE}/auth/session`);
-          userId = data.telegram_id;
-          username = data.username;
-          isAdmin = Boolean(data.is_admin);
-          updateAdminLinkVisibility();
-        } catch (e) {
-          noteEl.textContent = 'Вы не авторизованы. Откройте главную страницу и войдите через Telegram.';
-          updateAdminLinkVisibility();
-          throw e;
-        }
+      } catch (e) {
+        // При ошибке авторизации не блокируем каталог — просто работаем как гость
+        console.warn('WebApp auth failed, продолжаем как гость', e);
+        userId = null;
+        username = null;
+        isAdmin = false;
+        noteEl.innerHTML =
+          'Каталог доступен в режиме просмотра. ' +
+          'Чтобы добавить товары в корзину, откройте сайт из ' +
+          '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.';
+        updateAdminLinkVisibility();
       }
     }
 

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -204,9 +204,18 @@
     }
 
     async function authorize() {
-      const hasTelegram = !!tg && !!tg.initData;
-      if (hasTelegram) {
-        const initData = tg.initData;
+      const initData = tg?.initData || tg?.initDataUnsafe?.query_id ? tg.initData : null;
+      if (!initData) {
+        userId = null;
+        setStatus(
+          'Профиль доступен только из Telegram. Откройте страницу через бота MiniDeN (https://t.me/miniden_bot) и затем обновите эту вкладку.',
+          true
+        );
+        updateAdminLinkVisibility();
+        return;
+      }
+
+      try {
         const data = await fetchJson(`${API_BASE}/auth/telegram`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -217,19 +226,15 @@
         setStatus('');
         updateAdminLinkVisibility();
         if (loginHint) loginHint.style.display = 'none';
-      } else {
-        try {
-          const data = await fetchJson(`${API_BASE}/auth/session`);
-          userId = data.telegram_id;
-          isAdmin = Boolean(data.is_admin);
-          setStatus('');
-          updateAdminLinkVisibility();
-        } catch (e) {
-          showLoginHint('Вы не авторизованы. Перейдите на главную страницу и войдите через Telegram.');
-          updateAdminLinkVisibility();
-          throw e;
-        }
-        if (loginHint) loginHint.style.display = 'none';
+      } catch (e) {
+        console.warn('WebApp auth failed в профиле', e);
+        userId = null;
+        setStatus(
+          'Не удалось получить данные Telegram. ' +
+            'Откройте страницу профиля из бота MiniDeN и повторите попытку.',
+          true
+        );
+        updateAdminLinkVisibility();
       }
     }
 


### PR DESCRIPTION
## Summary
- allow products and masterclasses catalogs to load in guest mode and show Telegram bot hints
- soften authorization handling for cart, profile, and admin with clearer guidance to open in Telegram
- add prominent bot entry call-to-action on the homepage

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929ffd9162883269f589735bd5827db)