### PR TITLE
Use environment links in WebApp

### DIFF
--- a/webapi.py
+++ b/webapi.py
@@ -45,6 +45,18 @@ def _startup() -> None:
     init_db()
 
 
+@app.get("/api/env")
+def api_env():
+    from config import get_settings
+
+    settings = get_settings()
+    bot_username = settings.bot_username.lstrip("@") if hasattr(settings, "bot_username") else ""
+    return {
+        "bot_link": f"https://t.me/{bot_username}",
+        "channel_link": settings.required_channel_link,
+    }
+
+
 def _validate_type(product_type: str) -> str:
     if product_type not in ALLOWED_TYPES:
         raise HTTPException(status_code=400, detail="type must be 'basket' or 'course'")

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -316,6 +316,19 @@
     const tg = window.Telegram?.WebApp;
     const API_BASE = '/api';
 
+    let ENV = { bot_link: null, channel_link: null };
+    window.ENV = ENV;
+
+    async function initEnv() {
+      try {
+        const res = await fetch('/api/env');
+        ENV = await res.json();
+        window.ENV = ENV;
+      } catch (e) {
+        console.warn("ENV load failed", e);
+      }
+    }
+
     let userId = null;
     let isAdmin = false;
 
@@ -709,6 +722,7 @@
     async function init() {
       hideStatus();
       try {
+        await initEnv();
         await authorize();
       } catch (e) {
         return;

--- a/webapp/baskets.html
+++ b/webapp/baskets.html
@@ -122,6 +122,19 @@
 
     const tg = window.Telegram?.WebApp;
 
+    let ENV = { bot_link: null, channel_link: null };
+    window.ENV = ENV;
+
+    async function initEnv() {
+      try {
+        const res = await fetch('/api/env');
+        ENV = await res.json();
+        window.ENV = ENV;
+      } catch (e) {
+        console.warn("ENV load failed", e);
+      }
+    }
+
     const baskets = [
       {
         id: 1,
@@ -234,7 +247,12 @@
       tg.MainButton.hide();
     }
 
-    renderCards(baskets);
+    async function initPage() {
+      await initEnv();
+      renderCards(baskets);
+    }
+
+    initPage();
   </script>
 </body>
 </html>

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -138,6 +138,19 @@
     const tg = window.Telegram?.WebApp;
     const API_BASE = "/api";
 
+    let ENV = { bot_link: null, channel_link: null };
+    window.ENV = ENV;
+
+    async function initEnv() {
+      try {
+        const res = await fetch('/api/env');
+        ENV = await res.json();
+        window.ENV = ENV;
+      } catch (e) {
+        console.warn("ENV load failed", e);
+      }
+    }
+
     let userId = null;
     let username = null;
     let isAdmin = false;
@@ -197,7 +210,7 @@
           noteEl.innerHTML =
             'Корзина привязана к вашему Telegram-профилю. ' +
             'Откройте эту страницу из ' +
-            '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>, ' +
+            `<a href="${ENV.bot_link}" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>, ` +
             'а затем вернитесь и обновите страницу.';
         }
         updateAdminLinkVisibility();
@@ -225,7 +238,7 @@
           noteEl.innerHTML =
             'Не удалось получить данные Telegram. ' +
             'Откройте корзину через ' +
-            '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">бот MiniDeN</a>.';
+            `<a href="${ENV.bot_link}" target="_blank" rel="noopener">бот MiniDeN</a>.`;
         }
         updateAdminLinkVisibility();
       }
@@ -406,6 +419,7 @@
 
     async function initApp() {
       try {
+        await initEnv();
         await authorize();
         await loadCart();
       } catch (e) {

--- a/webapp/courses.html
+++ b/webapp/courses.html
@@ -126,6 +126,19 @@
 
     const tg = window.Telegram?.WebApp;
 
+    let ENV = { bot_link: null, channel_link: null };
+    window.ENV = ENV;
+
+    async function initEnv() {
+      try {
+        const res = await fetch('/api/env');
+        ENV = await res.json();
+        window.ENV = ENV;
+      } catch (e) {
+        console.warn("ENV load failed", e);
+      }
+    }
+
     const courses = [
       {
         id: 1,
@@ -246,7 +259,12 @@
       tg.MainButton.hide();
     }
 
-    renderCards(courses);
+    async function initPage() {
+      await initEnv();
+      renderCards(courses);
+    }
+
+    initPage();
   </script>
 </body>
 </html>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -305,7 +305,7 @@
         После этого каталоги, корзина и профиль на сайте будут связаны с вашим аккаунтом.
       </p>
       <p style="margin-top:8px;">
-        <a class="btn" href="https://t.me/miniden_bot" target="_blank" rel="noopener">
+        <a class="btn" id="bot-link-hero" href="#" target="_blank" rel="noopener">
           Открыть бота MiniDeN в Telegram
         </a>
       </p>
@@ -320,11 +320,11 @@
   <footer>
     <div>
       Готовы помочь в Telegram:
-      <a href="https://t.me/miniden_bot" target="_blank" rel="noopener">бот MiniDeN</a>
+      <a id="bot-link-footer" href="#" target="_blank" rel="noopener">бот MiniDeN</a>
     </div>
     <div>
       Новости и вдохновение:
-      <a href="https://t.me" target="_blank" rel="noopener">Telegram-канал</a>
+      <a id="channel-link-footer" href="#" target="_blank" rel="noopener">Telegram-канал</a>
     </div>
     <div>Мы в соцсетях: <a href="#">Instagram*</a> • <a href="#">VK</a></div>
   </footer>
@@ -354,12 +354,39 @@
   </section>
 
   <script>
+    let ENV = { bot_link: null, channel_link: null };
+    window.ENV = ENV;
+
+    async function initEnv() {
+      try {
+        const res = await fetch('/api/env');
+        ENV = await res.json();
+        window.ENV = ENV;
+      } catch (e) {
+        console.warn("ENV load failed", e);
+      }
+    }
+
     const toggle = document.querySelector('.menu-toggle');
     const nav = document.querySelector('.nav-links');
 
     toggle?.addEventListener('click', () => {
       nav?.classList.toggle('open');
     });
+
+    async function initPage() {
+      await initEnv();
+
+      const botLinks = document.querySelectorAll('#bot-link-hero, #bot-link-footer');
+      botLinks.forEach((link) => {
+        link?.setAttribute('href', ENV.bot_link || '#');
+      });
+
+      const channelLink = document.getElementById('channel-link-footer');
+      channelLink?.setAttribute('href', ENV.channel_link || '#');
+    }
+
+    initPage();
   </script>
 </body>
 </html>

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -109,6 +109,19 @@
     const tg = window.Telegram?.WebApp;
     const API_BASE = "/api";
 
+    let ENV = { bot_link: null, channel_link: null };
+    window.ENV = ENV;
+
+    async function initEnv() {
+      try {
+        const res = await fetch('/api/env');
+        ENV = await res.json();
+        window.ENV = ENV;
+      } catch (e) {
+        console.warn("ENV load failed", e);
+      }
+    }
+
     let userId = null;
     let username = null;
     let isAdmin = false;
@@ -195,7 +208,7 @@
         noteEl.innerHTML =
           'Каталог мастер-классов доступен в режиме просмотра. ' +
           'Чтобы добавлять курсы в корзину и в избранное, откройте сайт из ' +
-          '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.';
+          `<a href="${ENV.bot_link}" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.`;
         updateAdminLinkVisibility();
         return;
       }
@@ -219,7 +232,7 @@
         noteEl.innerHTML =
           'Каталог мастер-классов доступен в режиме просмотра. ' +
           'Чтобы использовать корзину, откройте сайт из ' +
-          '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.';
+          `<a href="${ENV.bot_link}" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.`;
         updateAdminLinkVisibility();
       }
     }
@@ -348,6 +361,7 @@
 
     async function initApp() {
       try {
+        await initEnv();
         await authorize();
         await loadFavorites();
         await loadCategories();

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -129,6 +129,19 @@
     const tg = window.Telegram?.WebApp;
     const API_BASE = "/api";
 
+    let ENV = { bot_link: null, channel_link: null };
+    window.ENV = ENV;
+
+    async function initEnv() {
+      try {
+        const res = await fetch('/api/env');
+        ENV = await res.json();
+        window.ENV = ENV;
+      } catch (e) {
+        console.warn("ENV load failed", e);
+      }
+    }
+
     let userId = null;
     let username = null;
     let isAdmin = false;
@@ -213,7 +226,7 @@
           'Каталог доступен в режиме просмотра. ' +
           'Чтобы добавлять товары в корзину и видеть свои заказы, ' +
           'откройте сайт из ' +
-          '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a> ' +
+          `<a href="${ENV.bot_link}" target="_blank" rel="noopener">Telegram-бота MiniDeN</a> ` +
           'и затем обновите страницу.';
         updateAdminLinkVisibility();
         return;
@@ -240,7 +253,7 @@
         noteEl.innerHTML =
           'Каталог доступен в режиме просмотра. ' +
           'Чтобы добавить товары в корзину, откройте сайт из ' +
-          '<a href="https://t.me/miniden_bot" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.';
+          `<a href="${ENV.bot_link}" target="_blank" rel="noopener">Telegram-бота MiniDeN</a>.`;
         updateAdminLinkVisibility();
       }
     }
@@ -366,6 +379,7 @@
 
     async function initApp() {
       try {
+        await initEnv();
         await authorize();
         await loadFavorites();
         await loadCategories();

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -149,6 +149,19 @@
     const tg = window.Telegram?.WebApp;
     const API_BASE = "/api";
 
+    let ENV = { bot_link: null, channel_link: null };
+    window.ENV = ENV;
+
+    async function initEnv() {
+      try {
+        const res = await fetch('/api/env');
+        ENV = await res.json();
+        window.ENV = ENV;
+      } catch (e) {
+        console.warn("ENV load failed", e);
+      }
+    }
+
     const statusEl = document.getElementById('status');
     const loginHint = document.getElementById('login-hint');
     const profileGrid = document.getElementById('profile-grid');
@@ -208,7 +221,7 @@
       if (!initData) {
         userId = null;
         setStatus(
-          'Профиль доступен только из Telegram. Откройте страницу через бота MiniDeN (https://t.me/miniden_bot) и затем обновите эту вкладку.',
+          `Профиль доступен только из Telegram. Откройте страницу через бота MiniDeN (${ENV.bot_link}) и затем обновите эту вкладку.`,
           true
         );
         updateAdminLinkVisibility();
@@ -231,7 +244,7 @@
         userId = null;
         setStatus(
           'Не удалось получить данные Telegram. ' +
-            'Откройте страницу профиля из бота MiniDeN и повторите попытку.',
+            `Откройте страницу профиля из бота MiniDeN (${ENV.bot_link}) и повторите попытку.`,
           true
         );
         updateAdminLinkVisibility();
@@ -343,6 +356,7 @@
 
     (async function initApp() {
       try {
+        await initEnv();
         await authorize();
         if (!userId) return;
         await loadProfile();


### PR DESCRIPTION
## Summary
- add /api/env endpoint to expose bot and channel links from configuration
- load bot and channel links from /api/env across webapp pages instead of hardcoded Telegram URLs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a056b3d1c83269c6fbe83de13498a)