### PR TITLE
Fix SQLAlchemy session expiration to avoid Telegram login errors

### DIFF
--- a/database.py
+++ b/database.py
@@ -25,7 +25,13 @@ DATABASE_URL = os.getenv(
 )
 
 engine = create_engine(DATABASE_URL, future=True, echo=os.getenv("SQLALCHEMY_ECHO") == "1")
-SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+SessionLocal = sessionmaker(
+    bind=engine,
+    autoflush=False,
+    autocommit=False,
+    expire_on_commit=False,
+    future=True,
+)
 Base = declarative_base()
 
 


### PR DESCRIPTION
## Summary
- configure SQLAlchemy sessionmaker to keep ORM instances from expiring on commit, preventing DetachedInstanceError after Telegram login

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c94f3f2708326ad501da0f36149c2)