### PR TITLE
Fix Telegram WebApp auth and update frontend links

### DIFF
--- a/services/users.py
+++ b/services/users.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from datetime import datetime
 from typing import Any
 
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from config import ADMIN_IDS_SET
 from database import get_session, init_db
@@ -20,7 +20,70 @@ def _extract_phone(data: dict[str, Any] | None) -> str | None:
     return None
 
 
-def get_or_create_user_from_telegram(data: dict[str, Any] | None) -> User:
+def _split_full_name(full_name: str | None) -> tuple[str | None, str | None]:
+    if not full_name:
+        return None, None
+    parts = full_name.split(" ", 1)
+    if len(parts) == 1:
+        return parts[0], None
+    return parts[0], parts[1]
+
+
+def _get_or_create_user(
+    session: Session,
+    telegram_id: int,
+    username: str | None = None,
+    first_name: str | None = None,
+    last_name: str | None = None,
+    phone: str | None = None,
+) -> User:
+    is_admin_flag = telegram_id in ADMIN_IDS_SET
+
+    user = session.scalar(select(User).where(User.telegram_id == telegram_id))
+    if user:
+        user.username = username or user.username
+        user.first_name = first_name or user.first_name
+        user.last_name = last_name or user.last_name
+        user.phone = phone or user.phone
+        user.is_admin = is_admin_flag or user.is_admin
+    else:
+        user = User(
+            telegram_id=telegram_id,
+            username=username,
+            first_name=first_name,
+            last_name=last_name,
+            phone=phone,
+            is_admin=is_admin_flag,
+            created_at=datetime.utcnow(),
+        )
+        session.add(user)
+        session.flush()
+    session.refresh(user)
+    return user
+
+
+def get_or_create_user_from_telegram(
+    data: dict[str, Any] | Session | None,
+    telegram_id: int | None = None,
+    username: str | None = None,
+    full_name: str | None = None,
+    phone: str | None = None,
+) -> User:
+    # New signature supports passing an existing session for WebApp auth
+    if isinstance(data, Session):
+        if telegram_id is None:
+            raise ValueError("Telegram user id is required")
+
+        first_name, last_name = _split_full_name(full_name)
+        return _get_or_create_user(
+            data,
+            telegram_id=int(telegram_id),
+            username=username,
+            first_name=first_name,
+            last_name=last_name,
+            phone=phone,
+        )
+
     if not data or "id" not in data:
         raise ValueError("Telegram user data is required")
 
@@ -29,31 +92,17 @@ def get_or_create_user_from_telegram(data: dict[str, Any] | None) -> User:
     first_name = data.get("first_name")
     last_name = data.get("last_name")
     phone = _extract_phone(data)
-    is_admin_flag = telegram_id in ADMIN_IDS_SET
 
     init_db()
     with get_session() as session:
-        user = session.scalar(select(User).where(User.telegram_id == telegram_id))
-        if user:
-            user.username = username or user.username
-            user.first_name = first_name or user.first_name
-            user.last_name = last_name or user.last_name
-            user.phone = phone or user.phone
-            user.is_admin = is_admin_flag or user.is_admin
-        else:
-            user = User(
-                telegram_id=telegram_id,
-                username=username,
-                first_name=first_name,
-                last_name=last_name,
-                phone=phone,
-                is_admin=is_admin_flag,
-                created_at=datetime.utcnow(),
-            )
-            session.add(user)
-            session.flush()
-        session.refresh(user)
-        return user
+        return _get_or_create_user(
+            session,
+            telegram_id,
+            username=username,
+            first_name=first_name,
+            last_name=last_name,
+            phone=phone,
+        )
 
 
 def update_user_contact(telegram_id: int, phone: str | None) -> User:

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -339,6 +339,16 @@
     </div>
   </section>
 
+  <section class="section" id="auth-status" style="display: none;">
+    <h2>Вы уже вошли</h2>
+    <p id="auth-username" class="muted"></p>
+    <div class="hero-cta">
+      <a class="btn" href="/profile.html">Перейти в профиль</a>
+      <button class="btn secondary" type="button" id="switch-user-btn">Сменить пользователя</button>
+    </div>
+  </section>
+
+  <script src="js/api.js"></script>
   <script>
     const toggle = document.querySelector('.menu-toggle');
     const nav = document.querySelector('.nav-links');
@@ -348,6 +358,37 @@
     });
 
     nav?.classList.add('open');
+
+    const loginSection = document.getElementById('telegram-login-section');
+    const authStatus = document.getElementById('auth-status');
+    const authUsername = document.getElementById('auth-username');
+    const switchUserBtn = document.getElementById('switch-user-btn');
+
+    function switchUser() {
+      document.cookie = 'tg_user_id=; Max-Age=0; path=/';
+      window._currentUser = null;
+      loginSection?.style.setProperty('display', 'block');
+      authStatus?.style.setProperty('display', 'none');
+      window.location.href = '/index.html';
+    }
+
+    switchUserBtn?.addEventListener('click', switchUser);
+
+    (async () => {
+      try {
+        const user = await getCurrentUser();
+        if (user) {
+          loginSection?.style.setProperty('display', 'none');
+          authStatus?.style.setProperty('display', 'block');
+          authUsername.textContent = `Вошли как ${user.username ? '@' + user.username : user.full_name || user.telegram_id}`;
+        } else {
+          loginSection?.style.setProperty('display', 'block');
+          authStatus?.style.setProperty('display', 'none');
+        }
+      } catch (e) {
+        console.error('Failed to load auth status', e);
+      }
+    })();
   </script>
 </body>
 </html>

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -120,7 +120,13 @@
   <section class="section" id="login-hint" style="display: none; text-align: center;">
     <h2>Вы не авторизованы</h2>
     <p>Профиль, заказы и избранное доступны после входа через Telegram. Перейдите на <a href="index.html">главную страницу</a>, выполните вход и вернитесь сюда.</p>
+    <button class="btn" id="login-button" type="button">Войти через Telegram</button>
   </section>
+
+  <div id="profile-actions" style="display: none; gap: 10px; margin-top: 16px;">
+    <button class="btn secondary" id="switch-user-btn" type="button">Сменить пользователя</button>
+    <a class="btn" href="products.html">Перейти в каталог</a>
+  </div>
 
   <script src="js/api.js"></script>
   <script>
@@ -139,6 +145,9 @@
     const favoritesList = document.getElementById('favorites-list');
     const statsList = document.getElementById('stats-list');
     const adminLink = document.getElementById('admin-link');
+    const actions = document.getElementById('profile-actions');
+    const switchUserBtn = document.getElementById('switch-user-btn');
+    const loginButton = document.getElementById('login-button');
 
     let currentUser = null;
 
@@ -164,6 +173,8 @@
         loginHint.style.display = 'block';
       }
       setStatus(message, true);
+      actions?.style.setProperty('display', 'none');
+      profileGrid?.style.setProperty('display', 'none');
     }
 
     function renderOrders(orders) {
@@ -225,6 +236,13 @@
       renderFavorites(profile.favorites || []);
       renderStats(profile.stats || {}, profile.ban || {});
       profileGrid.style.display = 'grid';
+      actions?.style.setProperty('display', 'flex');
+    }
+
+    function switchUser() {
+      document.cookie = 'tg_user_id=; Max-Age=0; path=/';
+      window._currentUser = null;
+      window.location.href = '/index.html';
     }
 
     async function initProfile() {
@@ -235,6 +253,7 @@
           return;
         }
         updateAdminLinkVisibility();
+        loginHint?.style.setProperty('display', 'none');
         setStatus('');
         renderProfile(currentUser);
       } catch (e) {
@@ -243,7 +262,11 @@
       }
     }
 
+    switchUserBtn?.addEventListener('click', switchUser);
+    loginButton?.addEventListener('click', switchUser);
+
     initProfile();
   </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- harden /api/auth/telegram parsing of WebApp initData, reuse session-based profile builder, and update redirect paths
- share the unified profile formatter across auth endpoints to align browser and WebApp data
- refresh index/profile pages to avoid legacy /webapp links and add switch-user controls that return to root pages

## Testing
- python -m compileall webapi.py services/users.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9d050f548326bb8735b07e316cf0)