### PR TITLE
Add logout endpoint and refresh auth flows

### DIFF
--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -156,6 +156,10 @@
     const commentInput = document.getElementById('customer-comment');
 
     let currentUser = null;
+    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
+    if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
+      window.Telegram.WebApp.ready();
+    }
     let currentCart = { items: [], total: 0 };
     let appliedPromo = null;
     let discountAmount = 0;
@@ -166,6 +170,23 @@
       if (noteEl) noteEl.textContent = message || '';
       if (unauthorizedBlock) unauthorizedBlock.style.display = 'block';
       if (cartPanel) cartPanel.style.display = 'none';
+    }
+
+    async function loadCurrentUser() {
+      try {
+        if (isTelegramWebApp && window.Telegram?.WebApp?.initData) {
+          return await apiPost('/auth/telegram', { initData: window.Telegram.WebApp.initData });
+        }
+        const res = await fetch('/api/auth/session');
+        if (res.status === 401 || res.status === 404) {
+          return null;
+        }
+        return await handleResponse(res);
+      } catch (e) {
+        if (e?.status === 401 || e?.status === 404) return null;
+        console.error('Не удалось получить пользователя', e);
+        return null;
+      }
     }
 
     function updateAdminLinkVisibility() {
@@ -365,7 +386,7 @@
 
     async function initApp() {
       try {
-        currentUser = await getCurrentUser();
+        currentUser = await loadCurrentUser();
         updateAdminLinkVisibility();
         if (!currentUser) {
           showUnauthorized('Вы не авторизованы. Войдите через Telegram.');

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -364,20 +364,33 @@
     const authUsername = document.getElementById('auth-username');
     const switchUserBtn = document.getElementById('switch-user-btn');
 
-    function switchUser() {
-      document.cookie = 'tg_user_id=; Max-Age=0; path=/';
+    async function logoutAndGoToIndex() {
+      try {
+        await fetch('/api/auth/logout', { method: 'POST' });
+      } catch (e) {
+        console.warn('Failed to call logout', e);
+      }
       window._currentUser = null;
-      loginSection?.style.setProperty('display', 'block');
-      authStatus?.style.setProperty('display', 'none');
-      window.location.href = '/index.html';
+      window.location.reload();
     }
 
-    switchUserBtn?.addEventListener('click', switchUser);
+    switchUserBtn?.addEventListener('click', logoutAndGoToIndex);
 
-    (async () => {
+    async function loadSession() {
       try {
-        const user = await getCurrentUser();
-        if (user) {
+        const res = await fetch('/api/auth/session');
+        if (res.status === 401 || res.status === 404) {
+          loginSection?.style.setProperty('display', 'block');
+          authStatus?.style.setProperty('display', 'none');
+          return;
+        }
+
+        if (!res.ok) {
+          throw new Error('Failed to check session');
+        }
+
+        const user = await res.json();
+        if (user?.ok) {
           loginSection?.style.setProperty('display', 'none');
           authStatus?.style.setProperty('display', 'block');
           authUsername.textContent = `Вошли как ${user.username ? '@' + user.username : user.full_name || user.telegram_id}`;
@@ -387,8 +400,12 @@
         }
       } catch (e) {
         console.error('Failed to load auth status', e);
+        loginSection?.style.setProperty('display', 'block');
+        authStatus?.style.setProperty('display', 'none');
       }
-    })();
+    }
+
+    loadSession();
   </script>
 </body>
 </html>

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -119,6 +119,10 @@
     const noteEl = document.getElementById('note');
 
     let currentUser = null;
+    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
+    if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
+      window.Telegram.WebApp.ready();
+    }
     let categories = [];
     let courses = [];
     let active = null;
@@ -141,6 +145,23 @@
 
     function showLoginHint() {
       if (loginHint) loginHint.style.display = 'block';
+    }
+
+    async function loadCurrentUser() {
+      try {
+        if (isTelegramWebApp && window.Telegram?.WebApp?.initData) {
+          return await apiPost('/auth/telegram', { initData: window.Telegram.WebApp.initData });
+        }
+        const res = await fetch('/api/auth/session');
+        if (res.status === 401 || res.status === 404) {
+          return null;
+        }
+        return await handleResponse(res);
+      } catch (e) {
+        if (e?.status === 401 || e?.status === 404) return null;
+        console.error('Не удалось получить пользователя', e);
+        return null;
+      }
     }
 
     function renderTabs() {
@@ -279,7 +300,7 @@
 
     async function initApp() {
       try {
-        currentUser = await getCurrentUser();
+        currentUser = await loadCurrentUser();
         if (!currentUser) {
           showLoginHint();
           noteEl.textContent = 'Каталог доступен в режиме просмотра. Чтобы оформить заказ, войдите через Telegram.';

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -139,6 +139,11 @@
     const noteEl = document.getElementById('note');
 
     let currentUser = null;
+    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
+
+    if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
+      window.Telegram.WebApp.ready();
+    }
     let categories = [];
     let products = [];
     let active = null;
@@ -156,6 +161,24 @@
 
     function showLoginHint() {
       if (loginHint) loginHint.style.display = 'block';
+    }
+
+    async function loadCurrentUser() {
+      try {
+        if (isTelegramWebApp && window.Telegram?.WebApp?.initData) {
+          return await apiPost('/auth/telegram', { initData: window.Telegram.WebApp.initData });
+        }
+
+        const res = await fetch('/api/auth/session');
+        if (res.status === 401 || res.status === 404) {
+          return null;
+        }
+        return await handleResponse(res);
+      } catch (e) {
+        if (e?.status === 401 || e?.status === 404) return null;
+        console.error('Не удалось получить пользователя', e);
+        return null;
+      }
     }
 
     function renderTabs() {
@@ -280,7 +303,7 @@
 
     async function initApp() {
       try {
-        currentUser = await getCurrentUser();
+        currentUser = await loadCurrentUser();
         if (!currentUser) {
           showLoginHint();
           noteEl.textContent = 'Каталог доступен для просмотра. Чтобы оформить заказ, войдите через Telegram.';

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -150,6 +150,7 @@
     const loginButton = document.getElementById('login-button');
 
     let currentUser = null;
+    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
 
     function updateAdminLinkVisibility() {
       if (!adminLink) return;
@@ -239,17 +240,47 @@
       actions?.style.setProperty('display', 'flex');
     }
 
-    function switchUser() {
-      document.cookie = 'tg_user_id=; Max-Age=0; path=/';
-      window._currentUser = null;
-      window.location.href = '/index.html';
+    async function logout() {
+      try {
+        await fetch('/api/auth/logout', { method: 'POST' });
+      } catch (e) {
+        console.warn('Logout request failed', e);
+      }
+
+      if (isTelegramWebApp && window.Telegram?.WebApp?.close) {
+        profileGrid?.style.setProperty('display', 'none');
+        actions?.style.setProperty('display', 'none');
+        setStatus('Вы вышли. Чтобы войти другим пользователем, откройте WebApp заново из бота.', false);
+        setTimeout(() => window.Telegram.WebApp.close(), 200);
+      } else {
+        window.location.href = '/index.html';
+      }
+    }
+
+    async function loadProfileFromSession() {
+      const res = await fetch('/api/auth/session?include_notes=true');
+      if (res.status === 401 || res.status === 404) {
+        showLoginHint('Вы не авторизованы. Перейдите на главную страницу и выполните вход через Telegram.');
+        return null;
+      }
+      const data = await handleResponse(res);
+      return data;
+    }
+
+    async function loadProfileFromWebApp() {
+      const initData = window.Telegram?.WebApp?.initData;
+      if (!initData) {
+        showLoginHint('Не удалось получить данные Telegram WebApp. Откройте профиль из бота.');
+        return null;
+      }
+      const profile = await apiPost('/auth/telegram', { initData, include_notes: true });
+      return profile;
     }
 
     async function initProfile() {
       try {
-        currentUser = await getCurrentUser({ includeNotes: true });
+        currentUser = isTelegramWebApp ? await loadProfileFromWebApp() : await loadProfileFromSession();
         if (!currentUser) {
-          showLoginHint('Вы не авторизованы. Перейдите на главную страницу и выполните вход через Telegram.');
           return;
         }
         updateAdminLinkVisibility();
@@ -262,8 +293,14 @@
       }
     }
 
-    switchUserBtn?.addEventListener('click', switchUser);
-    loginButton?.addEventListener('click', switchUser);
+    switchUserBtn?.addEventListener('click', logout);
+    loginButton?.addEventListener('click', () => {
+      window.location.href = '/index.html';
+    });
+
+    if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
+      window.Telegram.WebApp.ready();
+    }
 
     initProfile();
   </script>


### PR DESCRIPTION
## Summary
- add shared profile builder usage across auth endpoints and provide logout endpoint clearing cookies
- update main and profile pages to separate browser and Telegram WebApp flows, using new logout flow
- align catalog pages with unified session detection for browser and Telegram WebApp users

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ca1b6fe408326836fd3bb883eaca1)