### PR TITLE
Add discounted price display for promo-eligible cart items

### DIFF
--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -117,6 +117,75 @@
     let discountAmount = 0;
     let finalTotal = 0;
 
+    function isItemEligibleForPromo(item, promo) {
+      if (!promo) return false;
+
+      const type = item.type || 'basket';
+      const productId = Number(item.product_id);
+      const categoryId = item.category_id !== undefined ? Number(item.category_id) : null;
+
+      if (Array.isArray(promo.eligible_items) && promo.eligible_items.length) {
+        return promo.eligible_items.some(
+          (eligible) => Number(eligible.product_id) === productId && (eligible.type || 'basket') === type
+        );
+      }
+
+      switch (promo.scope) {
+        case 'all':
+          return true;
+        case 'basket':
+          return type === 'basket';
+        case 'course':
+          return type === 'course';
+        case 'product':
+          return promo.target_id !== undefined && Number(promo.target_id) === productId;
+        case 'category':
+          return promo.target_id !== undefined && type === 'basket' && categoryId !== null && Number(promo.target_id) === categoryId;
+        default:
+          return false;
+      }
+    }
+
+    function calculateEligibleTotal(items, promo) {
+      if (!promo) return 0;
+      return (items || []).reduce((sum, cartItem) => {
+        if (!isItemEligibleForPromo(cartItem, promo)) return sum;
+        const price = Number(cartItem.price) || 0;
+        const qty = Number(cartItem.qty) || 0;
+        return sum + price * qty;
+      }, 0);
+    }
+
+    function getItemDiscountedSum(item, promo, eligibleTotal, totalDiscountValue) {
+      const price = Number(item.price) || 0;
+      const qty = Number(item.qty) || 0;
+      const originalSum = price * qty;
+
+      if (!promo || !isItemEligibleForPromo(item, promo)) {
+        return { originalSum, discountedSum: null };
+      }
+
+      const discountType = promo.discount_type || 'percent';
+      const discountValue = Number(promo.discount_value || 0);
+
+      if (discountType === 'percent') {
+        const percent = Math.min(Math.max(discountValue, 0), 100);
+        const discountedSum = Math.max(Math.round(originalSum - (originalSum * percent) / 100), 0);
+        return { originalSum, discountedSum };
+      }
+
+      const safeEligibleTotal = eligibleTotal > 0 ? eligibleTotal : originalSum;
+      const discountPool = Math.max(Number.isFinite(totalDiscountValue) ? totalDiscountValue : 0, 0);
+      const proportionalDiscount = Math.min(discountPool, safeEligibleTotal) * (originalSum / safeEligibleTotal);
+      const discountedSum = Math.max(Math.round(originalSum - proportionalDiscount), 0);
+
+      if (discountedSum === originalSum) {
+        return { originalSum, discountedSum: null };
+      }
+
+      return { originalSum, discountedSum };
+    }
+
     function updateAdminLinkVisibility() {
       if (!adminLink) return;
       adminLink.style.display = profile?.is_admin ? '' : 'none';
@@ -151,6 +220,10 @@
 
       cartPanel.style.display = 'grid';
 
+      const activePromo = appliedPromo;
+      const eligibleTotal = activePromo ? calculateEligibleTotal(cart.items, activePromo) : 0;
+      const promoDiscountValue = activePromo ? Number(activePromo.discount_amount ?? discountAmount ?? 0) : 0;
+
       cart.items.forEach((item) => {
         const row = document.createElement('tr');
 
@@ -183,21 +256,36 @@
         controls.append(minus, qty, plus);
         qtyCell.appendChild(controls);
 
-      const sumCell = document.createElement('td');
-      sumCell.textContent = formatPrice(item.price * item.qty);
+        const sumCell = document.createElement('td');
+        const { originalSum, discountedSum } = getItemDiscountedSum(item, activePromo, eligibleTotal, promoDiscountValue);
+        if (discountedSum !== null) {
+          const originalEl = document.createElement('span');
+          originalEl.className = 'price-original';
+          originalEl.textContent = formatPrice(originalSum);
 
-      row.append(nameCell, categoryCell, priceCell, qtyCell, sumCell);
-      tbody.appendChild(row);
-    });
+          const discountedEl = document.createElement('span');
+          discountedEl.className = 'price-discounted';
+          discountedEl.textContent = formatPrice(discountedSum);
+
+          sumCell.append(originalEl, discountedEl);
+        } else {
+          sumCell.textContent = formatPrice(originalSum);
+        }
+
+        row.append(nameCell, categoryCell, priceCell, qtyCell, sumCell);
+        tbody.appendChild(row);
+      });
 
       const baseTotal = cart.total || 0;
       const totalToShow = appliedPromo ? finalTotal || baseTotal : baseTotal;
       totalEl.textContent = formatPrice(totalToShow || 0);
       if (appliedPromo) {
         promoInfoEl.style.display = 'flex';
-        promoLabelEl.textContent = `Промокод ${appliedPromo}`;
-        promoScopeEl.textContent = discountAmount ? `Скидка применена, экономия ${formatPrice(discountAmount)}` : '';
-        promoDiscountEl.textContent = `-${formatPrice(discountAmount)}`;
+        const promoLabel = appliedPromo?.code || '';
+        promoLabelEl.textContent = promoLabel ? `Промокод ${promoLabel}` : 'Промокод';
+        const appliedDiscount = Number(appliedPromo.discount_amount ?? discountAmount ?? 0);
+        promoScopeEl.textContent = appliedDiscount ? `Скидка применена, экономия ${formatPrice(appliedDiscount)}` : '';
+        promoDiscountEl.textContent = appliedDiscount ? `-${formatPrice(appliedDiscount)}` : '';
       } else {
         promoInfoEl.style.display = 'none';
         promoLabelEl.textContent = '';
@@ -337,7 +425,7 @@
 
       try {
         const result = await apiPost('/cart/apply-promocode', { user_id: profile.telegram_id, code });
-        appliedPromo = result.code;
+        appliedPromo = result;
         discountAmount = Number(result.discount_amount || 0);
         finalTotal = Number(result.final_total || currentCart.total || 0);
         currentCart = { ...currentCart, total: result.cart_total ?? currentCart.total };
@@ -417,7 +505,7 @@
       const customerName = nameInput.value.trim();
       const contact = contactInput.value.trim();
       const comment = commentInput.value.trim();
-      const promocode = appliedPromo || (promoInput.value || '').trim() || null;
+      const promocode = (appliedPromo?.code || (promoInput.value || '').trim()) || null;
 
       if (!customerName || !contact) {
         showToast('Укажите имя и способ связи.');

--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -751,6 +751,28 @@ footer a {
   align-items: center;
 }
 
+.price-original {
+  position: relative;
+  display: inline-block;
+  color: var(--color-text-muted);
+}
+
+.price-original::after {
+  content: "";
+  position: absolute;
+  left: -6px;
+  right: -6px;
+  top: 50%;
+  border-top: 2px solid var(--color-text-muted);
+  transform: rotate(-12deg);
+  opacity: 0.8;
+}
+
+.price-discounted {
+  font-weight: 800;
+  margin-left: 10px;
+}
+
 .qty-btn {
   padding: 4px 10px;
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- calculate per-item promo eligibility and discounted sums using backend promo metadata
- render cart rows with original and discounted amounts when a promo applies to the item
- style original prices with a diagonal strike-through and emphasize discounted values

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692decc4129c8326b6a7d5ef1b1c6612)