### PR TITLE
Fix avatar upload endpoint signature

### DIFF
--- a/webapi.py
+++ b/webapi.py
@@ -718,7 +718,7 @@ def update_avatar_url(payload: AvatarUpdatePayload, request: Request):
 
 
 @app.post("/api/profile/avatar")
-def upload_avatar(file: UploadFile = File(...), request: Request | None = None):
+def upload_avatar(request: Request, file: UploadFile = File(...)) -> dict:
     """Загрузка файла аватара текущего пользователя."""
 
     if file.content_type not in ("image/jpeg", "image/png", "image/webp"):


### PR DESCRIPTION
## Summary
- adjust the `/api/profile/avatar` handler signature to use FastAPI-friendly parameters and return type

## Testing
- BOT_TOKEN=1 python - <<'PY'
import webapi
print('app loaded', bool(webapi.app))
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfa6b6fe883269fbe44277afcb35b)