### PR TITLE
Add cream theme option to web UI

### DIFF
--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241215" />
+  <link rel="stylesheet" href="css/theme.css?v=20241216" />
 
 </head>
 <body data-theme="purple" class="page-admin">
@@ -32,6 +32,7 @@
               <option value="purple">Фиолетовая</option>
               <option value="dark">Тёмная</option>
               <option value="light">Светлая</option>
+          <option value="cream">Сливочная</option>
             </select>
           </div>
           <a href="/webapp/index.html" class="admin-btn secondary admin-back-to-main">Вернуться на главную</a>
@@ -348,8 +349,8 @@
     </main>
   </div>
 
-  <script src="js/app.js?v=20241215"></script>
-  <script src="js/api.js?v=20241215"></script>
+  <script src="js/app.js?v=20241216"></script>
+  <script src="js/api.js?v=20241216"></script>
   <script>
     const statusBox = document.getElementById('status');
     const accessDenied = document.getElementById('access-denied');

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241215" />
+  <link rel="stylesheet" href="css/theme.css?v=20241216" />
 
 </head>
 <body data-theme="purple" class="page-cart">
@@ -20,6 +20,7 @@
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
+          <option value="cream">Сливочная</option>
         </select>
       </div>
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
@@ -86,8 +87,8 @@
     </div>
   </main>
 
-  <script src="js/app.js?v=20241215"></script>
-  <script src="js/api.js?v=20241215"></script>
+  <script src="js/app.js?v=20241216"></script>
+  <script src="js/api.js?v=20241216"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const noteEl = document.getElementById('note');

--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -38,6 +38,33 @@ body[data-theme="light"] {
   --color-overlay: rgba(0, 0, 0, 0.35);
 }
 
+body[data-theme="cream"] {
+  --bg-color: #f5f5dc;
+  --text-color: #3a3a32;
+  --bg-main: #f5f5dc;
+  --bg-card: #ffffff;
+  --text-primary: #3a3a32;
+  --text-secondary: #6e6b5e;
+  --button-bg: #e4dccf;
+  --button-bg-hover: #d6cfc5;
+  --accent-color: #c59a6f;
+  --border-color: #ddd7c8;
+
+  --color-bg: var(--bg-main);
+  --color-bg-card: var(--bg-card);
+  --color-bg-card-elevated: #f1ebdf;
+  --color-text-main: var(--text-primary);
+  --color-text-muted: var(--text-secondary);
+  --color-border-subtle: var(--border-color);
+  --color-overlay: rgba(58, 58, 50, 0.6);
+  --color-accent-primary: var(--accent-color);
+  --color-accent-primary-strong: #b78559;
+  --color-accent-secondary: #d8b58c;
+  --color-accent-secondary-strong: #b88d63;
+  --color-btn-on-accent: #2f2a22;
+  --shadow-strong: 0 12px 32px rgba(197, 154, 111, 0.2);
+}
+
 * {
   box-sizing: border-box;
 }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241215" />
+  <link rel="stylesheet" href="css/theme.css?v=20241216" />
 </head>
 <body data-theme="purple" class="page-index">
   <header class="top-nav">
@@ -20,6 +20,7 @@
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
+          <option value="cream">Сливочная</option>
         </select>
       </div>
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
@@ -148,8 +149,8 @@
     </div>
   </section>
 
-  <script src="js/app.js?v=20241215"></script>
-  <script src="js/api.js?v=20241215"></script>
+  <script src="js/app.js?v=20241216"></script>
+  <script src="js/api.js?v=20241216"></script>
   <script>
     const loginSection = document.getElementById('telegram-login-section');
     const authStatus = document.getElementById('auth-status');

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -1,9 +1,11 @@
 const THEME_KEY = 'miniden.theme';
 const DEFAULT_THEME = 'purple';
+const AVAILABLE_THEMES = ['purple', 'dark', 'light', 'cream'];
 
 function applyTheme(theme) {
-  const value = theme || DEFAULT_THEME;
+  const value = AVAILABLE_THEMES.includes(theme) ? theme : DEFAULT_THEME;
   document.body.dataset.theme = value;
+  document.documentElement.dataset.theme = value;
 }
 
 function initThemeSwitcher() {
@@ -11,11 +13,12 @@ function initThemeSwitcher() {
   if (!select) return;
 
   const saved = localStorage.getItem(THEME_KEY) || DEFAULT_THEME;
-  applyTheme(saved);
-  select.value = saved;
+  const themeToApply = AVAILABLE_THEMES.includes(saved) ? saved : DEFAULT_THEME;
+  applyTheme(themeToApply);
+  select.value = themeToApply;
 
   select.addEventListener('change', () => {
-    const value = select.value || DEFAULT_THEME;
+    const value = AVAILABLE_THEMES.includes(select.value) ? select.value : DEFAULT_THEME;
     applyTheme(value);
     localStorage.setItem(THEME_KEY, value);
   });

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241215" />
+  <link rel="stylesheet" href="css/theme.css?v=20241216" />
 
 </head>
 <body data-theme="purple" class="page-masterclasses">
@@ -20,6 +20,7 @@
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
+          <option value="cream">Сливочная</option>
         </select>
       </div>
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
@@ -64,8 +65,8 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=20241215"></script>
-  <script src="js/api.js?v=20241215"></script>
+  <script src="js/app.js?v=20241216"></script>
+  <script src="js/api.js?v=20241216"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const tabsEl = document.getElementById('tabs');

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241215" />
+  <link rel="stylesheet" href="css/theme.css?v=20241216" />
 
 </head>
 <body data-theme="purple" class="page-products">
@@ -20,6 +20,7 @@
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
+          <option value="cream">Сливочная</option>
         </select>
       </div>
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
@@ -68,8 +69,8 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=20241215"></script>
-  <script src="js/api.js?v=20241215"></script>
+  <script src="js/app.js?v=20241216"></script>
+  <script src="js/api.js?v=20241216"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const tabsEl = document.getElementById('tabs');

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241215" />
+  <link rel="stylesheet" href="css/theme.css?v=20241216" />
 
 </head>
 <body data-theme="purple" class="page-profile">
@@ -20,6 +20,7 @@
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
+          <option value="cream">Сливочная</option>
         </select>
       </div>
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
@@ -101,8 +102,8 @@
     <a class="btn" href="products.html">Перейти в каталог</a>
   </div>
 
-  <script src="js/app.js?v=20241215"></script>
-  <script src="js/api.js?v=20241215"></script>
+  <script src="js/app.js?v=20241216"></script>
+  <script src="js/api.js?v=20241216"></script>
   <script>
     const statusEl = document.getElementById('status');
     const loginHint = document.getElementById('login-hint');


### PR DESCRIPTION
## Summary
- add a new creamy theme palette with soft accents and updated component variables
- expose the Cream option in all theme selectors and validate theme selection with localStorage
- refresh cached assets versions to deliver the new styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfc2241088326a2512e903f0f4736)