### PR TITLE
Fix masterclass admin toggle to update course status

### DIFF
--- a/services/products.py
+++ b/services/products.py
@@ -280,8 +280,15 @@ def update_product_image(product_id: int, image_file_id: str | None) -> bool:
     return _update_field(product_id, "image", image_file_id)
 
 
-def toggle_product_active(product_id: int) -> bool:
-    for model in (ProductBasket, ProductCourse):
+def toggle_product_active(product_id: int, product_type: str | None = None) -> bool:
+    models: list[type[ProductBasket] | type[ProductCourse]]
+
+    if product_type:
+        models = [_pick_model(product_type)]
+    else:
+        models = [ProductBasket, ProductCourse]
+
+    for model in models:
         with get_session() as session:
             instance = session.get(model, product_id)
             if instance:

--- a/webapi.py
+++ b/webapi.py
@@ -546,6 +546,7 @@ class AdminProductsUpdatePayload(BaseModel):
 
 class AdminTogglePayload(BaseModel):
     user_id: int
+    type: str
 
 
 class AdminOrderStatusPayload(BaseModel):
@@ -1178,7 +1179,8 @@ def admin_update_product(product_id: int, payload: AdminProductsUpdatePayload):
 @app.post("/api/admin/products/{product_id}/toggle")
 def admin_toggle_product(product_id: int, payload: AdminTogglePayload):
     _ensure_admin(payload.user_id)
-    changed = products_service.toggle_product_active(product_id)
+    product_type = _validate_type(payload.type)
+    changed = products_service.toggle_product_active(product_id, product_type)
     if not changed:
         raise HTTPException(status_code=404, detail="Product not found")
     return {"ok": True}

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -752,7 +752,7 @@
         });
         toggleBtn.addEventListener('click', async () => {
           try {
-            await apiPost(`/admin/products/${item.id}/toggle`, { user_id: currentUser.telegram_id });
+            await apiPost(`/admin/products/${item.id}/toggle`, { user_id: currentUser.telegram_id, type });
             setStatus('Статус товара обновлён');
             if (type === 'basket') {
               await loadProducts();


### PR DESCRIPTION
## Summary
- ensure admin toggle endpoint validates product type and uses it when switching activity
- update admin UI to send the product type when toggling basket or course rows
- adjust product service toggle helper to target the correct model based on type

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfea9fe88832691076d11e4c45f6b)