### PR TITLE
Remove placeholder REST API notice from products page

### DIFF
--- a/webapp/products.html
+++ b/webapp/products.html
@@ -40,7 +40,6 @@
 
   <main>
     <h1>Товары</h1>
-    <p>Категории и товары подгружаются из общего REST API MiniDeN: здесь же работает корзина Telegram-бота.</p>
 
     <div class="tabs" id="tabs"></div>
     <div class="catalog-grid products-grid" id="cards"></div>


### PR DESCRIPTION
## Summary
- remove the temporary REST API notice above the product categories on the products page

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e00a0e9c0832697ba8b4c8733f3bc)