### PR TITLE
Add toast notifications to masterclasses page

### DIFF
--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -36,6 +36,7 @@
   </header>
 
   <div class="app-sidebar-overlay"></div>
+  <div id="toast-container"></div>
 
   <main>
     <h1>Мастер-классы</h1>
@@ -375,13 +376,13 @@
       try {
         if (currentProfile?.telegram_id) {
           await apiPost('/cart/add', { user_id: currentProfile.telegram_id, product_id: course.id, qty: 1, type: 'course' });
-          alert('Курс добавлен в корзину');
+          showToast('Курс добавлен в корзину');
         } else {
           addToGuestCart(course.id, 'course', 1);
-          alert('Курс добавлен в корзину. Оформить заказ можно после входа через Telegram.');
+          showToast('Курс добавлен в корзину. Оформить заказ можно после входа через Telegram.');
         }
       } catch (e) {
-        alert('Не удалось добавить курс. Попробуйте ещё раз.');
+        showToast('Не удалось добавить курс. Попробуйте ещё раз.');
       }
     }
 


### PR DESCRIPTION
## Summary
- add toast container to the masterclasses page to support consistent notifications
- replace alert-based cart messages with the shared toast notifications for masterclasses

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f04bcb50c8326b20ea2eec399fd6f)