### PR TITLE
Implement review photo thumbnails with modal viewer

### DIFF
--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -667,6 +667,62 @@ footer a {
   grid-template-columns: 240px 1fr;
 }
 
+.review-photo-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1250;
+}
+
+.review-photo-modal.hidden {
+  display: none;
+}
+
+.review-photo-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--color-overlay);
+  backdrop-filter: blur(3px);
+}
+
+.review-photo-modal__content {
+  position: relative;
+  background: var(--color-bg-card-elevated);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 14px;
+  padding: 14px;
+  max-width: 820px;
+  width: min(820px, 86vw);
+  max-height: 82vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.4);
+}
+
+.review-photo-modal__image {
+  max-width: 100%;
+  max-height: 78vh;
+  object-fit: contain;
+  border-radius: 12px;
+  display: block;
+}
+
+.review-photo-modal__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text-main);
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
 .product-modal__close,
 .course-modal__close {
   position: absolute;
@@ -870,21 +926,30 @@ footer a {
   flex-wrap: wrap;
 }
 
-.review-card__photo {
-  width: 64px;
-  height: 64px;
+.review-photos {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.review-photo-thumb {
+  width: 82px;
+  height: 82px;
   border-radius: 10px;
   overflow: hidden;
   border: 1px solid var(--color-border-subtle);
   background: var(--color-bg-card-elevated);
+  object-fit: cover;
   display: inline-flex;
+  cursor: pointer;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
 }
 
-.review-card__photo img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
+.page-admin .review-photo-thumb {
+  width: 54px;
+  height: 54px;
+  box-shadow: none;
 }
 
 .review-photo-chip {

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -46,7 +46,7 @@
     <div class="note" id="note"></div>
   </main>
 
-  <div id="product-modal" class="product-modal hidden" aria-hidden="true">
+    <div id="product-modal" class="product-modal hidden" aria-hidden="true">
     <div class="product-modal__backdrop" id="product-modal-backdrop"></div>
     <div class="product-modal__content" role="dialog" aria-modal="true">
       <button class="product-modal__close" type="button" id="product-modal-close" aria-label="Закрыть">×</button>
@@ -115,10 +115,18 @@
         </section>
       </div>
     </div>
-  </div>
+    </div>
 
-  <script src="js/app.js?v=20241216"></script>
-  <script src="js/api.js?v=20241216"></script>
+    <div id="review-photo-modal" class="review-photo-modal hidden" aria-hidden="true">
+      <div class="review-photo-modal__backdrop" id="review-photo-modal-backdrop"></div>
+      <div class="review-photo-modal__content" role="dialog" aria-modal="true" aria-label="Фото отзыва">
+        <button class="review-photo-modal__close" type="button" id="review-photo-modal-close" aria-label="Закрыть">×</button>
+        <img class="review-photo-modal__image" id="review-photo-modal-image" src="" alt="" />
+      </div>
+    </div>
+
+    <script src="js/app.js?v=20241216"></script>
+    <script src="js/api.js?v=20241216"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const tabsEl = document.getElementById('tabs');
@@ -132,11 +140,15 @@
     const productModalDescription = document.getElementById('product-modal-description');
     const productModalPrice = document.getElementById('product-modal-price');
     const productModalAdd = document.getElementById('product-modal-add');
-    const productModalImage = document.getElementById('product-modal-image');
-    const productModalPlaceholder = document.getElementById('product-modal-placeholder');
+      const productModalImage = document.getElementById('product-modal-image');
+      const productModalPlaceholder = document.getElementById('product-modal-placeholder');
+      const reviewPhotoModal = document.getElementById('review-photo-modal');
+      const reviewPhotoModalBackdrop = document.getElementById('review-photo-modal-backdrop');
+      const reviewPhotoModalClose = document.getElementById('review-photo-modal-close');
+      const reviewPhotoModalImage = document.getElementById('review-photo-modal-image');
 
-    const productReviewsSection = document.getElementById('product-reviews-section');
-    const productReviewsSummary = document.getElementById('product-reviews-summary');
+      const productReviewsSection = document.getElementById('product-reviews-section');
+      const productReviewsSummary = document.getElementById('product-reviews-summary');
     const productReviewsList = document.getElementById('product-reviews-list');
     const productReviewsMoreBtn = document.getElementById('product-reviews-more');
     const productReviewsForm = document.getElementById('product-reviews-form');
@@ -222,15 +234,33 @@
       return { average_rating: Math.round(avg * 10) / 10, reviews_count: items.length };
     }
 
-    function formatRating(value) {
-      const num = Number(value) || 0;
-      return (Math.round(num * 10) / 10).toFixed(1);
-    }
+      function formatRating(value) {
+        const num = Number(value) || 0;
+        return (Math.round(num * 10) / 10).toFixed(1);
+      }
 
-    function updateAdminLinkVisibility() {
-      if (!adminLink) return;
-      adminLink.style.display = profile?.is_admin ? '' : 'none';
-    }
+      function openReviewPhotoModal(url, altText = 'Фото отзыва') {
+        if (!reviewPhotoModal || !reviewPhotoModalImage) return;
+        reviewPhotoModalImage.src = url;
+        reviewPhotoModalImage.alt = altText;
+        reviewPhotoModal.classList.remove('hidden');
+        reviewPhotoModal.setAttribute('aria-hidden', 'false');
+      }
+
+      function closeReviewPhotoModal() {
+        if (!reviewPhotoModal) return;
+        reviewPhotoModal.classList.add('hidden');
+        reviewPhotoModal.setAttribute('aria-hidden', 'true');
+        if (reviewPhotoModalImage) {
+          reviewPhotoModalImage.src = '';
+          reviewPhotoModalImage.alt = '';
+        }
+      }
+
+      function updateAdminLinkVisibility() {
+        if (!adminLink) return;
+        adminLink.style.display = profile?.is_admin ? '' : 'none';
+      }
 
     function renderTabs() {
       if (!tabsEl) return;
@@ -432,14 +462,33 @@
       productModal.setAttribute('aria-hidden', 'false');
     }
 
-    [productModalClose, productModalCloseBtn, productModalBackdrop].forEach((el) => {
-      el?.addEventListener('click', closeProductModal);
-    });
+      [productModalClose, productModalCloseBtn, productModalBackdrop].forEach((el) => {
+        el?.addEventListener('click', closeProductModal);
+      });
 
-    reviewRatingStars?.addEventListener('click', (event) => {
-      const target = event.target.closest('.rating-stars__item');
-      if (!target) return;
-      selectedReviewRating = Number(target.dataset.value) || 0;
+      [reviewPhotoModalClose, reviewPhotoModalBackdrop].forEach((el) => {
+        el?.addEventListener('click', closeReviewPhotoModal);
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !reviewPhotoModal?.classList.contains('hidden')) {
+          closeReviewPhotoModal();
+        }
+      });
+
+      productReviewsList?.addEventListener('click', (event) => {
+        const target = event.target instanceof HTMLElement ? event.target.closest('.review-photo-thumb') : null;
+        if (!target) return;
+        const fullUrl = target.dataset.fullUrl || target.getAttribute('src');
+        if (!fullUrl) return;
+        const altText = target.getAttribute('alt') || 'Фото отзыва';
+        openReviewPhotoModal(fullUrl, altText);
+      });
+
+      reviewRatingStars?.addEventListener('click', (event) => {
+        const target = event.target.closest('.rating-stars__item');
+        if (!target) return;
+        selectedReviewRating = Number(target.dataset.value) || 0;
       renderRatingSelection();
       if (reviewRatingError) reviewRatingError.textContent = '';
     });
@@ -561,32 +610,27 @@
 
       header.append(author, rating, date);
 
-      const text = document.createElement('p');
-      text.className = 'review-card__text';
-      text.textContent = review.text || '';
+        const text = document.createElement('p');
+        text.className = 'review-card__text';
+        text.textContent = review.text || '';
 
-      card.append(header, text);
-
-      const photos = review.photos || review.photos_json || [];
-      if (photos.length) {
-        const photoRow = document.createElement('div');
-        photoRow.className = 'review-card__photos';
-        photos.forEach((url, idx) => {
-          const link = document.createElement('a');
-          link.href = url;
-          link.target = '_blank';
-          link.rel = 'noopener';
-          link.className = 'review-card__photo';
-          link.title = `Фото ${idx + 1}`;
-
-          const img = document.createElement('img');
-          img.src = url;
-          img.alt = `Фото отзыва ${idx + 1}`;
-          link.appendChild(img);
-          photoRow.appendChild(link);
-        });
-        card.appendChild(photoRow);
-      }
+        card.append(header, text);
+        
+        const photos = review.photos || review.photos_json || [];
+        if (photos.length) {
+          const photoRow = document.createElement('div');
+          photoRow.className = 'review-card__photos review-photos';
+          photos.forEach((url, idx) => {
+            const img = document.createElement('img');
+            img.src = url;
+            img.alt = `Фото отзыва ${idx + 1}`;
+            img.className = 'review-photo-thumb';
+            img.loading = 'lazy';
+            img.dataset.fullUrl = url;
+            photoRow.appendChild(img);
+          });
+          card.appendChild(photoRow);
+        }
 
       return card;
     }


### PR DESCRIPTION
## Summary
- render review photos as thumbnail gallery in product reviews and open selected images in a dedicated modal
- style review thumbnails and modal to fit the existing product modal design without dominating the page
- preserve admin review thumbnails sizing while adding new markup for the modal viewer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f121ac31c832698bae8b41e0b9485)