### PR TITLE
Add carousel support for product and masterclass images

### DIFF
--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -533,6 +533,70 @@ footer a {
   text-align: center;
   padding: 12px;
   color: #0b0c10;
+  position: relative;
+  overflow: hidden;
+}
+
+.product-card__image-wrapper,
+.course-card__image-wrapper {
+  background: var(--color-bg-card);
+  padding: 0;
+}
+
+.product-card__image,
+.course-card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.product-card__placeholder,
+.course-card__placeholder {
+  width: 100%;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+}
+
+.product-card__nav,
+.course-card__nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: rgba(0, 0, 0, 0.28);
+  color: #fff;
+  width: 28px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  cursor: pointer;
+  opacity: 0.8;
+  transition: opacity 0.2s ease, background 0.2s ease;
+  padding: 0;
+}
+
+.product-card__nav:hover,
+.course-card__nav:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.product-card__nav--prev,
+.course-card__nav--prev {
+  left: 8px;
+}
+
+.product-card__nav--next,
+.course-card__nav--next {
+  right: 8px;
 }
 
 .catalog-card-body {
@@ -747,6 +811,7 @@ footer a {
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
 }
 
 .product-modal__media img,
@@ -755,6 +820,42 @@ footer a {
   height: 100%;
   object-fit: cover;
   display: block;
+}
+
+.product-modal__nav,
+.course-modal__nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
+  width: 40px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: opacity 0.2s ease, background 0.2s ease;
+  opacity: 0.9;
+  padding: 0;
+}
+
+.product-modal__nav:hover,
+.course-modal__nav:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.product-modal__nav--prev,
+.course-modal__nav--prev {
+  left: 10px;
+}
+
+.product-modal__nav--next,
+.course-modal__nav--next {
+  right: 10px;
 }
 
 .product-modal__info,

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -51,8 +51,10 @@
     <div class="course-modal__content" role="dialog" aria-modal="true">
       <button class="course-modal__close" type="button" id="course-modal-close" aria-label="Закрыть">×</button>
       <div class="course-modal__media">
+        <button class="course-modal__nav course-modal__nav--prev" type="button" id="course-modal-prev" aria-label="Предыдущее изображение">‹</button>
         <img id="course-modal-image" alt="" />
         <div id="course-modal-placeholder" style="display:none; color: var(--muted); padding: 12px; text-align:center;">Нет изображения</div>
+        <button class="course-modal__nav course-modal__nav--next" type="button" id="course-modal-next" aria-label="Следующее изображение">›</button>
       </div>
       <div class="course-modal__info">
         <h3 id="course-modal-title" style="margin:0;"></h3>
@@ -78,6 +80,8 @@
     const courseModalBackdrop = document.getElementById('course-modal-backdrop');
     const courseModalImage = document.getElementById('course-modal-image');
     const courseModalPlaceholder = document.getElementById('course-modal-placeholder');
+    const courseModalPrev = document.getElementById('course-modal-prev');
+    const courseModalNext = document.getElementById('course-modal-next');
     const courseModalTitle = document.getElementById('course-modal-title');
     const courseModalMeta = document.getElementById('course-modal-meta');
     const courseModalDescription = document.getElementById('course-modal-description');
@@ -90,6 +94,7 @@
     let active = null;
     let courseMap = new Map();
     let currentCourse = null;
+    let courseModalIndex = 0;
 
     const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
     if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
@@ -116,6 +121,32 @@
       if (item?.short_description) return item.short_description;
       const fallback = item?.description ? truncateText(item.description, 140) : '';
       return fallback || 'Описание появится позже.';
+    }
+
+    function normalizeImages(item, extraFields = []) {
+      const urls = [];
+      const pushUrl = (value) => {
+        if (!value) return;
+        if (typeof value === 'string') {
+          urls.push(value);
+          return;
+        }
+        if (typeof value === 'object') {
+          const maybe = value.image_url || value.url || value.path;
+          if (maybe) urls.push(maybe);
+        }
+      };
+
+      pushUrl(item.image_url || item.image);
+      (Array.isArray(item.images) ? item.images : []).forEach(pushUrl);
+      (extraFields || []).forEach((field) => {
+        const value = item[field];
+        if (Array.isArray(value)) value.forEach(pushUrl);
+      });
+
+      const unique = Array.from(new Set(urls.filter(Boolean)));
+      item.images = unique;
+      return item;
     }
 
     function updateAdminLinkVisibility() {
@@ -187,14 +218,61 @@
         card.className = 'catalog-card course-card';
 
         const cover = document.createElement('div');
-        cover.className = 'course-card-image catalog-card-image';
-        const imageUrl = item.image_url || item.image;
-        if (imageUrl) {
-          cover.style.backgroundImage = `url('${imageUrl}')`;
-          cover.textContent = '';
-        } else {
-          cover.textContent = item.category_name || 'Мастер-классы';
+        cover.className = 'course-card__image-wrapper catalog-card-image';
+        const coverImage = document.createElement('img');
+        coverImage.className = 'course-card__image';
+        const coverPlaceholder = document.createElement('div');
+        coverPlaceholder.className = 'course-card__placeholder';
+        coverPlaceholder.textContent = item.category_name || 'Мастер-классы';
+        cover.append(coverImage, coverPlaceholder);
+
+        const images = item.images && item.images.length ? item.images : [];
+        let currentImageIndex = 0;
+
+        const prevBtn = document.createElement('button');
+        prevBtn.type = 'button';
+        prevBtn.className = 'course-card__nav course-card__nav--prev';
+        prevBtn.textContent = '‹';
+
+        const nextBtn = document.createElement('button');
+        nextBtn.type = 'button';
+        nextBtn.className = 'course-card__nav course-card__nav--next';
+        nextBtn.textContent = '›';
+
+        if (images.length > 1) {
+          cover.append(prevBtn, nextBtn);
         }
+
+        const updateCardImage = () => {
+          if (images.length) {
+            currentImageIndex = (currentImageIndex + images.length) % images.length;
+            coverImage.src = images[currentImageIndex];
+            coverImage.style.display = 'block';
+            coverPlaceholder.style.display = 'none';
+          } else {
+            coverImage.removeAttribute('src');
+            coverImage.style.display = 'none';
+            coverPlaceholder.style.display = 'flex';
+          }
+
+          const showNav = images.length > 1;
+          prevBtn.style.display = showNav ? '' : 'none';
+          nextBtn.style.display = showNav ? '' : 'none';
+        };
+
+        prevBtn.addEventListener('click', () => {
+          if (!images.length) return;
+          currentImageIndex = (currentImageIndex - 1 + images.length) % images.length;
+          updateCardImage();
+        });
+
+        nextBtn.addEventListener('click', () => {
+          if (!images.length) return;
+          currentImageIndex = (currentImageIndex + 1) % images.length;
+          updateCardImage();
+        });
+
+        updateCardImage();
 
         const body = document.createElement('div');
         body.className = 'catalog-card-body course-card-body';
@@ -231,7 +309,7 @@
         detailsBtn.type = 'button';
         detailsBtn.className = 'btn secondary';
         detailsBtn.textContent = 'Подробнее';
-        detailsBtn.addEventListener('click', () => openCourseModal(item.id));
+        detailsBtn.addEventListener('click', () => openCourseModal(item.id, currentImageIndex));
 
         if (Number(item.price || 0) === 0 || hasAccess) {
           const openBtn = document.createElement('a');
@@ -288,7 +366,7 @@
       try {
         const params = { type: 'course' };
         if (active) params.category_slug = active;
-        courses = await apiGet('/products', params);
+        courses = (await apiGet('/products', params)).map((item) => normalizeImages(item, ['masterclass_images']));
         courseMap = new Map(courses.map((c) => [c.id, c]));
         renderCards();
       } catch (e) {
@@ -302,18 +380,17 @@
       courseModal.classList.add('hidden');
       courseModal.setAttribute('aria-hidden', 'true');
       currentCourse = null;
+      courseModalIndex = 0;
       if (courseModalActions) courseModalActions.innerHTML = '';
     }
 
-    function openCourseModal(courseId) {
-      if (!courseModal) return;
-      const item = courseMap.get(courseId);
-      if (!item) return;
-      currentCourse = item;
+    function setCourseModalImage() {
+      if (!courseModalImage) return;
+      const images = currentCourse?.images || [];
 
-      const imageUrl = item.image_url || item.image;
-      if (imageUrl) {
-        courseModalImage.src = imageUrl;
+      if (images.length) {
+        courseModalIndex = (courseModalIndex + images.length) % images.length;
+        courseModalImage.src = images[courseModalIndex];
         courseModalImage.style.display = 'block';
         courseModalPlaceholder.style.display = 'none';
       } else {
@@ -321,6 +398,21 @@
         courseModalImage.style.display = 'none';
         courseModalPlaceholder.style.display = 'block';
       }
+
+      const showNav = images.length > 1;
+      [courseModalPrev, courseModalNext].forEach((btn) => {
+        if (btn) btn.style.display = showNav ? '' : 'none';
+      });
+    }
+
+    function openCourseModal(courseId, startIndex = 0) {
+      if (!courseModal) return;
+      const item = courseMap.get(courseId);
+      if (!item) return;
+      currentCourse = item;
+      courseModalIndex = Math.max(0, Math.min(startIndex || 0, (item.images?.length || 1) - 1));
+
+      setCourseModalImage();
 
       courseModalTitle.textContent = item.name || 'Мастер-класс';
       courseModalMeta.textContent = metaBySlug[item.category_slug] || '';
@@ -365,6 +457,16 @@
       courseModal.classList.remove('hidden');
       courseModal.setAttribute('aria-hidden', 'false');
     }
+
+    [courseModalPrev, courseModalNext].forEach((btn, index) => {
+      btn?.addEventListener('click', () => {
+        const images = currentCourse?.images || [];
+        if (!images.length) return;
+        const step = index === 0 ? -1 : 1;
+        courseModalIndex = (courseModalIndex + step + images.length) % images.length;
+        setCourseModalImage();
+      });
+    });
 
     [courseModalClose, courseModalBackdrop].forEach((el) => {
       el?.addEventListener('click', closeCourseModal);

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -51,8 +51,10 @@
     <div class="product-modal__content" role="dialog" aria-modal="true">
       <button class="product-modal__close" type="button" id="product-modal-close" aria-label="Закрыть">×</button>
       <div class="product-modal__media" id="product-modal-media">
+        <button class="product-modal__nav product-modal__nav--prev" type="button" id="product-modal-prev" aria-label="Предыдущее изображение">‹</button>
         <img id="product-modal-image" alt="" />
         <div id="product-modal-placeholder" style="display:none; color: var(--muted); padding: 12px; text-align:center;">Нет изображения</div>
+        <button class="product-modal__nav product-modal__nav--next" type="button" id="product-modal-next" aria-label="Следующее изображение">›</button>
       </div>
       <div class="product-modal__info">
         <h3 id="product-modal-title" style="margin:0;"></h3>
@@ -142,6 +144,8 @@
     const productModalAdd = document.getElementById('product-modal-add');
       const productModalImage = document.getElementById('product-modal-image');
       const productModalPlaceholder = document.getElementById('product-modal-placeholder');
+      const productModalPrev = document.getElementById('product-modal-prev');
+      const productModalNext = document.getElementById('product-modal-next');
       const reviewPhotoModal = document.getElementById('review-photo-modal');
       const reviewPhotoModalBackdrop = document.getElementById('review-photo-modal-backdrop');
       const reviewPhotoModalClose = document.getElementById('review-photo-modal-close');
@@ -173,6 +177,7 @@
     let active = null;
     let productMap = new Map();
     let currentProduct = null;
+    let productModalIndex = 0;
 
     const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
     if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
@@ -194,6 +199,32 @@
       if (item?.short_description) return item.short_description;
       const fallback = item?.description ? truncateText(item.description, 140) : '';
       return fallback || 'Описание появится позже.';
+    }
+
+    function normalizeImages(item, extraFields = []) {
+      const urls = [];
+      const pushUrl = (value) => {
+        if (!value) return;
+        if (typeof value === 'string') {
+          urls.push(value);
+          return;
+        }
+        if (typeof value === 'object') {
+          const maybe = value.image_url || value.url || value.path;
+          if (maybe) urls.push(maybe);
+        }
+      };
+
+      pushUrl(item.image_url || item.image);
+      (Array.isArray(item.images) ? item.images : []).forEach(pushUrl);
+      (extraFields || []).forEach((field) => {
+        const value = item[field];
+        if (Array.isArray(value)) value.forEach(pushUrl);
+      });
+
+      const unique = Array.from(new Set(urls.filter(Boolean)));
+      item.images = unique;
+      return item;
     }
 
     function formatReviewDate(value) {
@@ -330,14 +361,61 @@
         card.className = 'catalog-card product-card';
 
         const cover = document.createElement('div');
-        cover.className = 'product-card-image catalog-card-image';
-        const imageUrl = item.image_url || item.image;
-        if (imageUrl) {
-          cover.style.backgroundImage = `url('${imageUrl}')`;
-          cover.textContent = '';
-        } else {
-          cover.textContent = item.category_name || 'Товары';
+        cover.className = 'product-card__image-wrapper catalog-card-image';
+        const coverImage = document.createElement('img');
+        coverImage.className = 'product-card__image';
+        const coverPlaceholder = document.createElement('div');
+        coverPlaceholder.className = 'product-card__placeholder';
+        coverPlaceholder.textContent = item.category_name || 'Товары';
+        cover.append(coverImage, coverPlaceholder);
+
+        const images = item.images && item.images.length ? item.images : [];
+        let currentImageIndex = 0;
+
+        const prevBtn = document.createElement('button');
+        prevBtn.type = 'button';
+        prevBtn.className = 'product-card__nav product-card__nav--prev';
+        prevBtn.textContent = '‹';
+
+        const nextBtn = document.createElement('button');
+        nextBtn.type = 'button';
+        nextBtn.className = 'product-card__nav product-card__nav--next';
+        nextBtn.textContent = '›';
+
+        if (images.length > 1) {
+          cover.append(prevBtn, nextBtn);
         }
+
+        const updateCardImage = () => {
+          if (images.length) {
+            currentImageIndex = (currentImageIndex + images.length) % images.length;
+            coverImage.src = images[currentImageIndex];
+            coverImage.style.display = 'block';
+            coverPlaceholder.style.display = 'none';
+          } else {
+            coverImage.removeAttribute('src');
+            coverImage.style.display = 'none';
+            coverPlaceholder.style.display = 'flex';
+          }
+
+          const showNav = images.length > 1;
+          prevBtn.style.display = showNav ? '' : 'none';
+          nextBtn.style.display = showNav ? '' : 'none';
+        };
+
+        prevBtn.addEventListener('click', () => {
+          if (!images.length) return;
+          currentImageIndex = (currentImageIndex - 1 + images.length) % images.length;
+          updateCardImage();
+        });
+
+        nextBtn.addEventListener('click', () => {
+          if (!images.length) return;
+          currentImageIndex = (currentImageIndex + 1) % images.length;
+          updateCardImage();
+        });
+
+        updateCardImage();
 
         const body = document.createElement('div');
         body.className = 'catalog-card-body product-card-body';
@@ -369,7 +447,7 @@
         detailsBtn.type = 'button';
         detailsBtn.className = 'btn secondary';
         detailsBtn.textContent = 'Подробнее';
-        detailsBtn.addEventListener('click', () => openProductModal(item.id));
+        detailsBtn.addEventListener('click', () => openProductModal(item.id, currentImageIndex));
 
         const btn = document.createElement('button');
         btn.className = 'btn';
@@ -407,7 +485,7 @@
       try {
         const params = { type: 'basket' };
         if (active) params.category_slug = active;
-        products = await apiGet('/products', params);
+        products = (await apiGet('/products', params)).map((item) => normalizeImages(item, ['product_images']));
         productMap = new Map(products.map((p) => [p.id, p]));
         renderTabs();
         renderCards();
@@ -422,13 +500,36 @@
       productModal.classList.add('hidden');
       productModal.setAttribute('aria-hidden', 'true');
       currentProduct = null;
+      productModalIndex = 0;
     }
 
-    function openProductModal(productId) {
+    function setProductModalImage() {
+      if (!productModalImage) return;
+      const images = currentProduct?.images || [];
+
+      if (images.length) {
+        productModalIndex = (productModalIndex + images.length) % images.length;
+        productModalImage.src = images[productModalIndex];
+        productModalImage.style.display = 'block';
+        productModalPlaceholder.style.display = 'none';
+      } else {
+        productModalImage.removeAttribute('src');
+        productModalImage.style.display = 'none';
+        productModalPlaceholder.style.display = 'block';
+      }
+
+      const showNav = images.length > 1;
+      [productModalPrev, productModalNext].forEach((btn) => {
+        if (btn) btn.style.display = showNav ? '' : 'none';
+      });
+    }
+
+    function openProductModal(productId, startIndex = 0) {
       if (!productModal) return;
       const item = productMap.get(productId);
       if (!item) return;
       currentProduct = item;
+      productModalIndex = Math.max(0, Math.min(startIndex || 0, (item.images?.length || 1) - 1));
 
       resetReviewForm();
       updateReviewFormVisibility();
@@ -438,17 +539,7 @@
         renderReviewsList(item.id);
         loadProductReviews(item.id);
       }
-
-      const imageUrl = item.image_url || item.image;
-      if (imageUrl) {
-        productModalImage.src = imageUrl;
-        productModalImage.style.display = 'block';
-        productModalPlaceholder.style.display = 'none';
-      } else {
-        productModalImage.removeAttribute('src');
-        productModalImage.style.display = 'none';
-        productModalPlaceholder.style.display = 'block';
-      }
+      setProductModalImage();
 
       productModalTitle.textContent = item.name || 'Товар';
       productModalDescription.textContent = item.description || item.short_description || 'Описание появится позже.';
@@ -461,6 +552,16 @@
       productModal.classList.remove('hidden');
       productModal.setAttribute('aria-hidden', 'false');
     }
+
+      [productModalPrev, productModalNext].forEach((btn, index) => {
+        btn?.addEventListener('click', () => {
+          const images = currentProduct?.images || [];
+          if (!images.length) return;
+          const step = index === 0 ? -1 : 1;
+          productModalIndex = (productModalIndex + step + images.length) % images.length;
+          setProductModalImage();
+        });
+      });
 
       [productModalClose, productModalCloseBtn, productModalBackdrop].forEach((el) => {
         el?.addEventListener('click', closeProductModal);


### PR DESCRIPTION
## Summary
- normalize product and masterclass image data into arrays for consistent rendering
- add carousel navigation to catalog cards with fallback placeholders when only one image is available
- enable carousel controls inside product and masterclass modals with synchronized starting indices

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f19d5b7a083269883b438ca6ad2ae)