### PR TITLE
Revamp product card layout and marketplaces display

### DIFF
--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -537,6 +537,10 @@ footer a {
   overflow: hidden;
 }
 
+.product-card {
+  min-height: 420px;
+}
+
 .product-card__image-wrapper,
 .course-card__image-wrapper {
   background: var(--color-bg-card);
@@ -561,6 +565,22 @@ footer a {
   align-items: center;
   justify-content: center;
   padding: 12px;
+}
+
+.product-card__image-wrapper {
+  height: 260px;
+}
+
+@media (max-width: 1024px) {
+  .product-card__image-wrapper {
+    height: 240px;
+  }
+}
+
+@media (max-width: 640px) {
+  .product-card__image-wrapper {
+    height: 220px;
+  }
 }
 
 .product-card__nav,
@@ -629,6 +649,24 @@ footer a {
   max-height: 3.6em;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.product-card-body {
+  gap: 12px;
+}
+
+.product-card__actions {
+  margin-top: auto;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.product-card__actions .btn {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .market-links {
@@ -886,6 +924,11 @@ footer a {
   font-weight: 800;
   color: #ffdf80;
   font-size: 20px;
+}
+
+.product-modal__markets {
+  color: var(--color-text-muted);
+  font-size: 14px;
 }
 
 .product-modal__actions,

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -62,6 +62,7 @@
         <div class="product-modal__price-row">
           <div class="product-modal__price" id="product-modal-price"></div>
         </div>
+        <div class="product-modal__markets" id="product-modal-markets"></div>
         <div class="product-modal__actions">
           <button class="btn" type="button" id="product-modal-add">Добавить в корзину</button>
           <button class="btn secondary" type="button" id="product-modal-close-btn">Закрыть</button>
@@ -141,6 +142,7 @@
     const productModalTitle = document.getElementById('product-modal-title');
     const productModalDescription = document.getElementById('product-modal-description');
     const productModalPrice = document.getElementById('product-modal-price');
+    const productModalMarkets = document.getElementById('product-modal-markets');
     const productModalAdd = document.getElementById('product-modal-add');
       const productModalImage = document.getElementById('product-modal-image');
       const productModalPlaceholder = document.getElementById('product-modal-placeholder');
@@ -320,18 +322,18 @@
       });
     }
 
+    const MARKETPLACES = [
+      { key: 'wb_url', label: 'WB' },
+      { key: 'ozon_url', label: 'Ozon' },
+      { key: 'yandex_url', label: 'Яндекс' },
+      { key: 'avito_url', label: 'Авито' },
+    ];
+
     function createMarketLinks(item) {
       const links = document.createElement('div');
       links.className = 'market-links';
 
-      const marketplaces = [
-        { key: 'wb_url', label: 'WB' },
-        { key: 'ozon_url', label: 'Ozon' },
-        { key: 'yandex_url', label: 'Яндекс' },
-        { key: 'avito_url', label: 'Авито' },
-      ];
-
-      marketplaces.forEach(({ key, label }) => {
+      MARKETPLACES.forEach(({ key, label }) => {
         if (!item[key]) return;
         const link = document.createElement('a');
         link.href = item[key];
@@ -344,6 +346,12 @@
       });
 
       return links;
+    }
+
+    function getMarketLabels(item) {
+      return MARKETPLACES.filter(({ key }) => Boolean(item[key]))
+        .map(({ label }) => label)
+        .join(', ');
     }
 
     function renderCards() {
@@ -424,24 +432,12 @@
         title.className = 'catalog-card-title';
         title.textContent = item.name;
 
-        const desc = document.createElement('p');
-        desc.className = 'catalog-card-description product-card__short-desc';
-        desc.textContent = shortDescription(item);
-
-        const marketLinks = createMarketLinks(item);
-
-        const footer = document.createElement('div');
-        footer.className = 'product-card__footer';
-
         const price = document.createElement('div');
         price.className = 'price';
         price.textContent = formatPrice(item.price);
 
         const actions = document.createElement('div');
-        actions.className = 'catalog-card-actions';
-
-        const buttonsRow = document.createElement('div');
-        buttonsRow.className = 'product-card__buttons';
+        actions.className = 'product-card__actions';
 
         const detailsBtn = document.createElement('button');
         detailsBtn.type = 'button';
@@ -454,15 +450,9 @@
         btn.textContent = 'В корзину';
         btn.addEventListener('click', () => handleAddToCart(item));
 
-        buttonsRow.append(detailsBtn, btn);
-        footer.append(price);
-        actions.append(footer, buttonsRow);
+        actions.append(detailsBtn, btn);
 
-        body.append(title, desc);
-        if (marketLinks.childElementCount) {
-          body.appendChild(marketLinks);
-        }
-        body.appendChild(actions);
+        body.append(title, price, actions);
 
         card.append(cover, body);
         cardsEl.appendChild(card);
@@ -544,6 +534,17 @@
       productModalTitle.textContent = item.name || 'Товар';
       productModalDescription.textContent = item.description || item.short_description || 'Описание появится позже.';
       productModalPrice.textContent = formatPrice(item.price);
+
+      if (productModalMarkets) {
+        const marketText = getMarketLabels(item);
+        if (marketText) {
+          productModalMarkets.textContent = `Площадки: ${marketText}`;
+          productModalMarkets.style.display = '';
+        } else {
+          productModalMarkets.textContent = '';
+          productModalMarkets.style.display = 'none';
+        }
+      }
 
       if (productModalAdd) {
         productModalAdd.onclick = () => handleAddToCart(item);


### PR DESCRIPTION
## Summary
- reduce product card content to focus on photo, name, price and horizontal action buttons
- adjust product card styling so images dominate the layout and buttons align along the bottom
- surface marketplace labels only inside the product modal with a dedicated block

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2580581c83269da84dd46fe6c7d4)