### PR TITLE
Ensure basket maps always initialized in list_products

### DIFF
--- a/services/products.py
+++ b/services/products.py
@@ -418,10 +418,11 @@ def list_products(
     else:
         models = [(ProductBasket, "basket"), (ProductCourse, "course")]
 
-    basket_map_by_id, basket_map_by_slug = ({}
-        if product_type == "course"
-        else _load_category_maps("basket")
-    )
+    basket_map_by_id: dict[int, dict[str, Any]] = {}
+    basket_map_by_slug: dict[str, dict[str, Any]] = {}
+
+    if product_type != "course":
+        basket_map_by_id, basket_map_by_slug = _load_category_maps("basket")
 
     results: list[dict[str, Any]] = []
     for model, p_type in models:


### PR DESCRIPTION
## Summary
- initialize basket_map_by_id and basket_map_by_slug with empty dicts in list_products
- only load basket category maps when basket products are involved

## Testing
- python -m compileall services/products.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f31342de48326b59f93b0e3274ea4)