### PR TITLE
Fix async declarations in admin renderProductTable

### DIFF
--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -1611,7 +1611,7 @@
       if (titleEl) titleEl.textContent = defaultTitle;
     }
 
-    function renderProductTable(items, targetTable, type) {
+    async function renderProductTable(items, targetTable, type) {
       targetTable.innerHTML = '';
       if (!items || !items.length) {
         const row = document.createElement('tr');


### PR DESCRIPTION
## Summary
- declare renderProductTable as async to allow awaited calls in its body

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e88c22c88326aaa641f38f93a6c7)