### PR TITLE
Switch webapp login to Telegram auth flow

### DIFF
--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241217" />
+  <link rel="stylesheet" href="css/theme.css?v=20241220" />
 
 </head>
 <body data-theme="purple" class="page-admin">
@@ -530,8 +530,8 @@
     </main>
   </div>
 
-  <script src="js/app.js?v=20241217"></script>
-  <script src="js/api.js?v=20241217"></script>
+  <script src="js/app.js?v=20241220"></script>
+  <script src="js/api.js?v=20241220"></script>
   <script>
     const statusBox = document.getElementById('status');
     const accessDenied = document.getElementById('access-denied');

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241217" />
+  <link rel="stylesheet" href="css/theme.css?v=20241220" />
 
 </head>
 <body data-theme="purple" class="page-cart">
@@ -87,8 +87,8 @@
     </div>
   </main>
 
-  <script src="js/app.js?v=20241217"></script>
-  <script src="js/api.js?v=20241217"></script>
+  <script src="js/app.js?v=20241220"></script>
+  <script src="js/api.js?v=20241220"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const noteEl = document.getElementById('note');

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241217" />
+  <link rel="stylesheet" href="css/theme.css?v=20241220" />
 </head>
 <body data-theme="purple" class="page-index">
   <header class="top-nav">
@@ -136,7 +136,7 @@
       Чтобы синхронизировать корзину и профиль с ботом MiniDeN, войдите через Telegram. После успешного входа вы будете перенаправлены в профиль (profile.html), где увидите ваши заказы, корзину и курсы.
     </p>
     <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
-      <script async src="https://telegram.org/js/telegram-widget.js?19" data-telegram-login="BotMiniden_bot" data-size="large" data-auth-url="/api/auth/telegram-login" data-request-access="write"></script>
+      <button class="btn" id="btn-login-telegram" type="button">Войти через Telegram</button>
     </div>
   </section>
 
@@ -149,14 +149,16 @@
     </div>
   </section>
 
-  <script src="js/app.js?v=20241217"></script>
-  <script src="js/api.js?v=20241217"></script>
+  <script src="js/app.js?v=20241220"></script>
+  <script src="js/api.js?v=20241220"></script>
   <script>
     const loginSection = document.getElementById('telegram-login-section');
     const authStatus = document.getElementById('auth-status');
     const authUsername = document.getElementById('auth-username');
     const switchUserBtn = document.getElementById('switch-user-btn');
     const adminLink = document.getElementById('admin-link');
+    const loginButton = document.getElementById('btn-login-telegram');
+    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
 
     function updateAdminLinkVisibility(profile) {
       if (!adminLink) return;
@@ -180,7 +182,7 @@
         const user = await getCurrentUserProfile();
         updateAdminLinkVisibility(user);
 
-        if (user?.ok) {
+        if (user) {
           loginSection?.style.setProperty('display', 'none');
           authStatus?.style.setProperty('display', 'block');
           const displayName = user.full_name || (user.telegram_username ? '@' + user.telegram_username : user.telegram_id);
@@ -188,6 +190,9 @@
         } else {
           loginSection?.style.setProperty('display', 'block');
           authStatus?.style.setProperty('display', 'none');
+          if (!isTelegramWebApp) {
+            loginButton?.style.setProperty('display', 'inline-flex');
+          }
         }
       } catch (e) {
         console.error('Failed to load auth status', e);
@@ -196,6 +201,27 @@
         authStatus?.style.setProperty('display', 'none');
       }
     }
+
+    loginButton?.addEventListener('click', () => {
+      startTelegramOAuthFlow();
+    });
+
+    processTelegramAuthFromUrl()
+      .then((res) => {
+        if (res?.status === 'ok') {
+          return loadSession();
+        }
+        return null;
+      })
+      .catch((error) => {
+        console.error('Telegram auth via browser failed', error);
+        showToast(error?.message || 'Не удалось авторизоваться через Telegram');
+      })
+      .finally(() => {
+        if (isTelegramWebApp) {
+          loginButton?.style.setProperty('display', 'none');
+        }
+      });
 
     loadSession();
   </script>

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241217" />
+  <link rel="stylesheet" href="css/theme.css?v=20241220" />
 
 </head>
 <body data-theme="purple" class="page-masterclasses">
@@ -68,8 +68,8 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=20241217"></script>
-  <script src="js/api.js?v=20241217"></script>
+  <script src="js/app.js?v=20241220"></script>
+  <script src="js/api.js?v=20241220"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const tabsEl = document.getElementById('tabs');

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241217" />
+  <link rel="stylesheet" href="css/theme.css?v=20241220" />
 
 </head>
 <body data-theme="purple" class="page-products">
@@ -136,8 +136,8 @@
       </div>
     </div>
 
-    <script src="js/app.js?v=20241217"></script>
-    <script src="js/api.js?v=20241217"></script>
+    <script src="js/app.js?v=20241220"></script>
+    <script src="js/api.js?v=20241220"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const tabsEl = document.getElementById('tabs');

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241217" />
+  <link rel="stylesheet" href="css/theme.css?v=20241220" />
 
 </head>
 <body data-theme="purple" class="page-profile">
@@ -102,8 +102,8 @@
     <a class="btn" href="products.html">Перейти в каталог</a>
   </div>
 
-  <script src="js/app.js?v=20241217"></script>
-  <script src="js/api.js?v=20241217"></script>
+  <script src="js/app.js?v=20241220"></script>
+  <script src="js/api.js?v=20241220"></script>
   <script>
     const statusEl = document.getElementById('status');
     const loginHint = document.getElementById('login-hint');
@@ -131,6 +131,9 @@
 
     let currentUser = null;
     const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
+    if (isTelegramWebApp) {
+      loginButton?.style.setProperty('display', 'none');
+    }
 
     function updateAdminLinkVisibility() {
       if (!adminLink) return;
@@ -507,14 +510,21 @@
         return;
       }
 
-      window.location.href = '/index.html';
+      startTelegramOAuthFlow();
     });
 
     if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
       window.Telegram.WebApp.ready();
     }
 
-    initProfile();
+    processTelegramAuthFromUrl()
+      .catch((error) => {
+        console.error('Failed to authorize via Telegram auth params', error);
+        showToast(error?.message || 'Не удалось авторизоваться через Telegram');
+      })
+      .finally(() => {
+        initProfile();
+      });
   </script>
 
 </body>


### PR DESCRIPTION
## Summary
- replace main page Telegram widget with an explicit "Войти через Telegram" button and handle auth query callbacks
- add shared browser/WebApp Telegram auth helpers including initData auto-login and OAuth redirect handling
- update profile login hint and static assets cache-busting versions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346f6f7b9883269d5f19157f9d7b85)