### PR TITLE
Fix Telegram login redirects and harden unauthenticated flows

### DIFF
--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241220" />
+  <link rel="stylesheet" href="css/theme.css?v=20241221" />
 
 </head>
 <body data-theme="purple" class="page-admin">
@@ -530,8 +530,8 @@
     </main>
   </div>
 
-  <script src="js/app.js?v=20241220"></script>
-  <script src="js/api.js?v=20241220"></script>
+  <script src="js/app.js?v=20241221"></script>
+  <script src="js/api.js?v=20241221"></script>
   <script>
     const statusBox = document.getElementById('status');
     const accessDenied = document.getElementById('access-denied');

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241220" />
+  <link rel="stylesheet" href="css/theme.css?v=20241221" />
 
 </head>
 <body data-theme="purple" class="page-cart">
@@ -87,8 +87,8 @@
     </div>
   </main>
 
-  <script src="js/app.js?v=20241220"></script>
-  <script src="js/api.js?v=20241220"></script>
+  <script src="js/app.js?v=20241221"></script>
+  <script src="js/api.js?v=20241221"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const noteEl = document.getElementById('note');

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241220" />
+  <link rel="stylesheet" href="css/theme.css?v=20241221" />
 </head>
 <body data-theme="purple" class="page-index">
   <header class="top-nav">
@@ -149,8 +149,8 @@
     </div>
   </section>
 
-  <script src="js/app.js?v=20241220"></script>
-  <script src="js/api.js?v=20241220"></script>
+  <script src="js/app.js?v=20241221"></script>
+  <script src="js/api.js?v=20241221"></script>
   <script>
     const loginSection = document.getElementById('telegram-login-section');
     const authStatus = document.getElementById('auth-status');

--- a/webapp/js/api.js
+++ b/webapp/js/api.js
@@ -79,9 +79,7 @@ function clearTelegramAuthParamsFromUrl() {
 }
 
 function buildTelegramOAuthUrl() {
-  const returnTo = new URL(window.location.href);
-  returnTo.search = "";
-  returnTo.hash = "";
+  const returnTo = new URL("/api/auth/telegram-login", window.location.origin);
 
   const url = new URL("https://oauth.telegram.org/auth");
   url.searchParams.set("bot", TELEGRAM_BOT_USERNAME);
@@ -115,7 +113,7 @@ async function processTelegramAuthFromUrl() {
 
 function startTelegramOAuthFlow() {
   const url = buildTelegramOAuthUrl();
-  window.open(url, "_blank", "noopener,noreferrer");
+  window.location.href = url;
 }
 
 async function fetchAuthSession(includeNotes) {

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241220" />
+  <link rel="stylesheet" href="css/theme.css?v=20241221" />
 
 </head>
 <body data-theme="purple" class="page-masterclasses">
@@ -68,8 +68,8 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=20241220"></script>
-  <script src="js/api.js?v=20241220"></script>
+  <script src="js/app.js?v=20241221"></script>
+  <script src="js/api.js?v=20241221"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const tabsEl = document.getElementById('tabs');

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241220" />
+  <link rel="stylesheet" href="css/theme.css?v=20241221" />
 
 </head>
 <body data-theme="purple" class="page-products">
@@ -136,8 +136,8 @@
       </div>
     </div>
 
-    <script src="js/app.js?v=20241220"></script>
-    <script src="js/api.js?v=20241220"></script>
+    <script src="js/app.js?v=20241221"></script>
+    <script src="js/api.js?v=20241221"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const tabsEl = document.getElementById('tabs');
@@ -929,7 +929,13 @@
     }
 
     async function initProductsPage() {
-      const currentProfile = await getCurrentUserProfile();
+      let currentProfile = null;
+      try {
+        currentProfile = await getCurrentUserProfile();
+      } catch (error) {
+        console.warn('Не удалось определить сессию пользователя, продолжаем как гость', error);
+      }
+
       await loadProductCategoriesAndItems(currentProfile);
     }
 

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20241220" />
+  <link rel="stylesheet" href="css/theme.css?v=20241221" />
 
 </head>
 <body data-theme="purple" class="page-profile">
@@ -102,8 +102,8 @@
     <a class="btn" href="products.html">Перейти в каталог</a>
   </div>
 
-  <script src="js/app.js?v=20241220"></script>
-  <script src="js/api.js?v=20241220"></script>
+  <script src="js/app.js?v=20241221"></script>
+  <script src="js/api.js?v=20241221"></script>
   <script>
     const statusEl = document.getElementById('status');
     const loginHint = document.getElementById('login-hint');
@@ -480,7 +480,7 @@
         renderProfile(currentUser);
       } catch (e) {
         console.error(e);
-        setStatus('Не удалось загрузить профиль', true);
+        showLoginHint('Не удалось загрузить профиль. Попробуйте войти через Telegram позже.');
       }
     }
 


### PR DESCRIPTION
## Summary
- route Telegram login button through the backend callback to launch authorization reliably
- keep catalog loading for guests even if session lookup fails
- show a clear profile login hint on auth errors and bump frontend cache versions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693480ab1b4883269bfac253d06b0550)