### PR TITLE
Fix Telegram WebApp flag redeclaration

### DIFF
--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -109,7 +109,6 @@
     const commentInput = document.getElementById('customer-comment');
 
     let profile = null;
-    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
     if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
       window.Telegram.WebApp.ready();
     }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -158,7 +158,6 @@
     const switchUserBtn = document.getElementById('switch-user-btn');
     const adminLink = document.getElementById('admin-link');
     const loginButton = document.getElementById('btn-login-telegram');
-    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
 
     function updateAdminLinkVisibility(profile) {
       if (!adminLink) return;

--- a/webapp/js/api.js
+++ b/webapp/js/api.js
@@ -47,9 +47,7 @@ async function apiPost(path, body) {
   return handleResponse(res);
 }
 
-function isTelegramWebApp() {
-  return Boolean(window.Telegram?.WebApp);
-}
+const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
 
 function normalizeError(message, status) {
   const error = new Error(message);
@@ -130,7 +128,7 @@ async function fetchAuthSession(includeNotes) {
 }
 
 async function ensureTelegramWebAppAuth() {
-  if (!isTelegramWebApp()) {
+  if (!isTelegramWebApp) {
     return { status: "skipped" };
   }
 
@@ -240,7 +238,7 @@ async function ensureTelegramWebAppAuth() {
   return authPromise;
 }
 
-if (isTelegramWebApp()) {
+if (isTelegramWebApp) {
   ensureTelegramWebAppAuth();
 }
 
@@ -251,7 +249,7 @@ async function getCurrentUser(options = {}) {
 
   const includeNotes = Boolean(options.includeNotes);
 
-  if (isTelegramWebApp()) {
+  if (isTelegramWebApp) {
     await ensureTelegramWebAppAuth();
     if (window._currentUser && !options.forceRefresh) {
       return window._currentUser;
@@ -283,7 +281,7 @@ async function getCurrentUserProfile(options = {}) {
 
   const includeNotes = Boolean(options.includeNotes);
 
-  if (isTelegramWebApp()) {
+  if (isTelegramWebApp) {
     await ensureTelegramWebAppAuth();
     if (window._currentProfile && !options.forceRefresh) {
       window._currentProfileLoaded = true;

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -96,7 +96,6 @@
     let currentCourse = null;
     let courseModalIndex = 0;
 
-    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
     if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
       window.Telegram.WebApp.ready();
     }

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -193,7 +193,6 @@
     let currentProduct = null;
     let productModalIndex = 0;
 
-    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
     if (isTelegramWebApp && window.Telegram?.WebApp?.ready) {
       window.Telegram.WebApp.ready();
     }

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -130,7 +130,6 @@
     const editPhoneBtn = document.getElementById('edit-phone');
 
     let currentUser = null;
-    const isTelegramWebApp = Boolean(window.Telegram?.WebApp);
     if (isTelegramWebApp) {
       loginButton?.style.setProperty('display', 'none');
     }


### PR DESCRIPTION
## Summary
- declare the Telegram WebApp flag once in the shared api.js helper
- remove duplicate inline declarations across frontend pages to avoid SyntaxError and restore scripts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693482602e688326987aed7cdc145a45)