### PR TITLE
Fix home banner schema datetime fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -62,6 +62,10 @@ MiniDeN — Telegram-бот и веб-магазин
 
 - Исправлены Pydantic-модели страниц главной (home_banners, home_posts, home_sections) для совместимости с Pydantic v2. Теперь используются model_config = ConfigDict(from_attributes=True), что позволяет корректно применять from_orm() для SQLAlchemy-объектов. Эндпоинты возвращают корректный JSON.
 
+### Главная страница — баннеры
+
+- Исправлена Pydantic-схема `HomeBannerOut`: поля `created_at` и `updated_at` теперь имеют тип `datetime`, соответствующий типам в ORM-модели. Благодаря этому вызов `HomeBannerOut.from_orm()` больше не вызывает ошибок валидации, и API `/api/admin/home/banners` стабильно возвращает корректный JSON.
+
 Структура проекта
 -----------------
 - `bot.py` — точка входа Telegram-бота.

--- a/schemas/home.py
+++ b/schemas/home.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -13,8 +15,8 @@ class HomeBannerIn(BaseModel):
 
 class HomeBannerOut(HomeBannerIn):
     id: int
-    created_at: str | None = None
-    updated_at: str | None = None
+    created_at: datetime
+    updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -44,7 +46,7 @@ class HomePostIn(BaseModel):
 
 class HomePostOut(HomePostIn):
     id: int
-    created_at: str | None = None
+    created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Summary
- update HomeBannerOut and related home schemas to use datetime fields compatible with ORM
- document the banner schema fix in README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b3c6dfac8326b130b33c3e200b92)