### PR TITLE
Add FAQ backend and bot support

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,6 +18,7 @@ from config import get_settings
 from database import init_db
 
 from handlers import admin, start, webapp
+from handlers import faq, support
 from middlewares.user_registration import EnsureUserMiddleware
 
 
@@ -52,6 +53,8 @@ async def main() -> None:
     dp.include_router(start.router)
     dp.include_router(admin.router)
     dp.include_router(webapp.router)
+    dp.include_router(faq.faq_router)
+    dp.include_router(support.support_router)
 
     # Старт поллинга
     await bot.delete_webhook(drop_pending_updates=True)

--- a/handlers/faq.py
+++ b/handlers/faq.py
@@ -1,0 +1,132 @@
+import os
+from urllib.parse import quote_plus, unquote_plus
+
+import aiohttp
+from aiogram import F, Router, types
+
+from handlers.support import remember_user_question
+
+API_BASE_URL = os.getenv("API_URL") or (os.getenv("BASE_URL", "http://localhost:8000").rstrip("/") + "/api")
+
+faq_router = Router()
+
+
+async def _get_json(path: str, params: dict | None = None):
+    url = f"{API_BASE_URL}{path}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, params=params) as response:
+            if response.status == 404:
+                return None
+            response.raise_for_status()
+            return await response.json()
+
+
+def _build_category_callback(category: str) -> str:
+    return f"faq:cat:{quote_plus(category)}"
+
+
+def _parse_category_callback(data: str) -> str | None:
+    try:
+        return unquote_plus(data.split("faq:cat:", 1)[1])
+    except Exception:
+        return None
+
+
+def _build_question_callback(question_id: int) -> str:
+    return f"faq:q:{question_id}"
+
+
+def _parse_question_callback(data: str) -> int | None:
+    try:
+        return int(data.split("faq:q:", 1)[1])
+    except Exception:
+        return None
+
+
+def _truncate(text: str, limit: int = 60) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit - 1]}…"
+
+
+@faq_router.message(F.text == "❓ Вопросы и ответы")
+async def show_faq_categories(message: types.Message):
+    data = await _get_json("/faq") or []
+    if not data:
+        await message.answer("База знаний пока пуста.")
+        return
+
+    categories = []
+    for item in data:
+        category = item.get("category")
+        if category and category not in categories:
+            categories.append(category)
+
+    if not categories:
+        await message.answer("Категории не найдены.")
+        return
+
+    keyboard = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [types.InlineKeyboardButton(text=category, callback_data=_build_category_callback(category))]
+            for category in categories
+        ]
+    )
+    await message.answer("Выберите раздел", reply_markup=keyboard)
+
+
+@faq_router.callback_query(F.data.startswith("faq:cat:"))
+async def load_category(callback: types.CallbackQuery):
+    category = _parse_category_callback(callback.data)
+    if not category:
+        await callback.answer("Категория не найдена", show_alert=True)
+        return
+
+    data = await _get_json("/faq", params={"category": category}) or []
+    if not data:
+        await callback.message.edit_text("В этой категории пока нет вопросов.")
+        await callback.answer()
+        return
+
+    keyboard = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                types.InlineKeyboardButton(
+                    text=_truncate(item.get("question") or "", 60),
+                    callback_data=_build_question_callback(int(item.get("id"))),
+                )
+            ]
+            for item in data
+        ]
+    )
+    await callback.message.edit_text(f"Раздел: {category}\nВыберите вопрос:", reply_markup=keyboard)
+    await callback.answer()
+
+
+@faq_router.callback_query(F.data.startswith("faq:q:"))
+async def load_question(callback: types.CallbackQuery):
+    question_id = _parse_question_callback(callback.data)
+    if not question_id:
+        await callback.answer("Вопрос не найден", show_alert=True)
+        return
+
+    item = await _get_json(f"/faq/{question_id}")
+    if not item:
+        await callback.answer("Вопрос не найден", show_alert=True)
+        return
+
+    question = item.get("question") or "Вопрос"
+    answer = item.get("answer") or "Ответ"
+    remember_user_question(callback.from_user.id, question)
+
+    keyboard = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                types.InlineKeyboardButton(
+                    text="Связаться с менеджером", callback_data="contact_manager"
+                )
+            ]
+        ]
+    )
+    await callback.message.answer(f"<b>{question}</b>\n\n{answer}", reply_markup=keyboard)
+    await callback.answer()

--- a/handlers/support.py
+++ b/handlers/support.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from aiogram import F, Router, types
+
+from config import ADMIN_IDS, ADMIN_IDS_SET
+from config import get_settings
+
+support_router = Router()
+
+USER_LAST_QUESTION: Dict[int, str] = {}
+ADMIN_REPLY_TARGETS: Dict[int, int] = {}
+
+
+def remember_user_question(user_id: int, question: str) -> None:
+    if question:
+        USER_LAST_QUESTION[user_id] = question
+
+
+@support_router.callback_query(F.data == "contact_manager")
+async def contact_manager(callback: types.CallbackQuery):
+    user = callback.from_user
+    settings = get_settings()
+    question = USER_LAST_QUESTION.get(user.id) or "—"
+    await callback.message.answer("Я передал ваш вопрос менеджеру, скоро он ответит.")
+
+    admin_message = (
+        "Новый запрос от пользователя: "
+        f"{user.username or user.full_name or user.id}.\n"
+        f"Последний вопрос: {question}.\n"
+        "Чтобы ответить, просто напишите ответ в реплай на это сообщение."
+    )
+
+    admin_chat_ids = ADMIN_IDS or ([] if settings.admin_chat_id is None else [settings.admin_chat_id])
+    for chat_id in admin_chat_ids:
+        sent = await callback.bot.send_message(chat_id, admin_message)
+        ADMIN_REPLY_TARGETS[sent.message_id] = user.id
+
+    await callback.answer()
+
+
+@support_router.message(F.reply_to_message)
+async def relay_admin_reply(message: types.Message):
+    if message.from_user.id not in ADMIN_IDS_SET:
+        return
+    reply_to = message.reply_to_message
+    if not reply_to:
+        return
+    target_user_id = ADMIN_REPLY_TARGETS.get(reply_to.message_id)
+    if not target_user_id:
+        return
+
+    response_text = message.text or message.caption
+    if not response_text:
+        return
+
+    await message.bot.send_message(target_user_id, response_text)

--- a/keyboards/main_menu.py
+++ b/keyboards/main_menu.py
@@ -73,6 +73,8 @@ def get_main_menu(is_admin: bool = False) -> ReplyKeyboardMarkup:
     if webapp_row:
         keyboard.append(webapp_row)
 
+    keyboard.append([KeyboardButton(text="❓ Вопросы и ответы")])
+
     if is_admin and getattr(settings, "webapp_admin_url", None):
         keyboard.append(
             [

--- a/models.py
+++ b/models.py
@@ -330,6 +330,23 @@ class HomePost(Base):
     sort_order = Column(Integer, default=0, nullable=False)
 
 
+class FaqItem(Base):
+    __tablename__ = "faq"
+
+    id = Column(Integer, primary_key=True)
+    category = Column(String(64), nullable=False, index=True)
+    question = Column(Text, nullable=False)
+    answer = Column(Text, nullable=False)
+    sort_order = Column(Integer, default=0, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+
 __all__ = [
     "Base",
     "AdminNote",
@@ -350,4 +367,5 @@ __all__ = [
     "HomeBanner",
     "HomeSection",
     "HomePost",
+    "FaqItem",
 ]

--- a/services/faq_service.py
+++ b/services/faq_service.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from sqlalchemy import select
+
+from database import get_session
+from models import FaqItem
+
+
+def _ensure_sort_order(value: int | None) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _apply_updates(record: FaqItem, data: dict) -> None:
+    for field in ("category", "question", "answer", "sort_order"):
+        if field not in data:
+            continue
+        if field == "sort_order":
+            setattr(record, field, _ensure_sort_order(data.get(field)))
+        else:
+            value = data.get(field)
+            if value is not None:
+                setattr(record, field, value)
+
+
+def _serialize(item: FaqItem) -> dict:
+    return {
+        "id": int(item.id),
+        "category": item.category,
+        "question": item.question,
+        "answer": item.answer,
+        "sort_order": int(item.sort_order or 0),
+    }
+
+
+def serialize_many(items: Iterable[FaqItem]) -> list[dict]:
+    return [_serialize(item) for item in items]
+
+
+def get_faq_list(category: str | None = None) -> list[FaqItem]:
+    with get_session() as session:
+        query = select(FaqItem).order_by(FaqItem.sort_order, FaqItem.id)
+        if category:
+            query = query.where(FaqItem.category == category)
+        return session.scalars(query).all()
+
+
+def get_faq_item(faq_id: int) -> FaqItem | None:
+    with get_session() as session:
+        return session.get(FaqItem, faq_id)
+
+
+def create_faq_item(data: dict) -> FaqItem:
+    with get_session() as session:
+        record = FaqItem(
+            category=data.get("category"),
+            question=data.get("question"),
+            answer=data.get("answer"),
+            sort_order=_ensure_sort_order(data.get("sort_order")),
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+        session.add(record)
+        session.flush()
+        session.refresh(record)
+        return record
+
+
+def update_faq_item(faq_id: int, data: dict) -> FaqItem | None:
+    with get_session() as session:
+        record = session.get(FaqItem, faq_id)
+        if not record:
+            return None
+        _apply_updates(record, data)
+        session.flush()
+        session.refresh(record)
+        return record
+
+
+def delete_faq_item(faq_id: int) -> bool:
+    with get_session() as session:
+        record = session.get(FaqItem, faq_id)
+        if not record:
+            return False
+        session.delete(record)
+        return True

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -34,6 +34,7 @@
         </div>
         <button class="nav-btn" data-view="home-cms">Главная страница</button>
         <button class="nav-btn" data-view="reviews">Отзывы</button>
+        <button class="nav-btn" data-view="faq">FAQ (база знаний)</button>
         <div class="nav-group" data-group="promocodes">
           <button class="nav-btn nav-parent" data-group-toggle="promocodes" data-default-view="promocode-list">Промокоды</button>
           <div class="nav-submenu">
@@ -682,6 +683,59 @@
         </div>
       </section>
 
+      <section id="faq" class="card admin-view" data-view="faq" style="display:none;">
+        <div class="section-header">
+          <div>
+            <h2>База знаний / FAQ</h2>
+            <p class="muted">Управляйте разделами и ответами на популярные вопросы.</p>
+          </div>
+          <div class="filters-row">
+            <label for="faq-category-filter" class="muted" style="margin:0;">Категория</label>
+            <select id="faq-category-filter">
+              <option value="">Все категории</option>
+            </select>
+            <button class="btn primary" type="button" id="faq-add-btn">Добавить вопрос</button>
+          </div>
+        </div>
+
+        <div class="table-wrapper" style="margin-bottom:16px;">
+          <table aria-label="FAQ" style="width:100%;">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Категория</th>
+                <th>Вопрос</th>
+                <th>Порядок</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="faq-table"></tbody>
+          </table>
+        </div>
+
+        <div class="card" style="background: rgba(255,255,255,0.03);">
+          <h3 id="faq-form-title">Добавить вопрос</h3>
+          <form id="faq-form" class="stacked-form">
+            <label for="faq-category">Категория</label>
+            <input type="text" id="faq-category" name="category" required />
+
+            <label for="faq-question">Вопрос</label>
+            <textarea id="faq-question" name="question" rows="3" required></textarea>
+
+            <label for="faq-answer">Ответ</label>
+            <textarea id="faq-answer" name="answer" rows="4" required></textarea>
+
+            <label for="faq-sort">Порядок</label>
+            <input type="number" id="faq-sort" name="sort_order" min="0" value="0" />
+
+            <div class="form-actions">
+              <button class="btn primary" type="submit">Сохранить</button>
+              <button class="btn secondary" type="button" id="faq-reset">Сбросить</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
       <section id="stats" class="card admin-view" data-view="stats" style="display:none;">
         <h2>Статистика</h2>
         <p class="muted">Статистика заказов и продаж остаётся доступной через существующий API. Эта вкладка — заглушка для будущего UI.</p>
@@ -722,6 +776,17 @@
     const reviewsCountPending = document.getElementById('reviews-count-pending');
     const reviewsCountApproved = document.getElementById('reviews-count-approved');
     const reviewsCountRejected = document.getElementById('reviews-count-rejected');
+
+    const faqTableBody = document.getElementById('faq-table');
+    const faqCategoryFilter = document.getElementById('faq-category-filter');
+    const faqAddBtn = document.getElementById('faq-add-btn');
+    const faqForm = document.getElementById('faq-form');
+    const faqFormTitle = document.getElementById('faq-form-title');
+    const faqCategoryInput = document.getElementById('faq-category');
+    const faqQuestionInput = document.getElementById('faq-question');
+    const faqAnswerInput = document.getElementById('faq-answer');
+    const faqSortInput = document.getElementById('faq-sort');
+    const faqResetBtn = document.getElementById('faq-reset');
 
     const productCategoryFilter = document.getElementById('products-category');
     const courseCategoryFilter = document.getElementById('courses-category');
@@ -869,6 +934,12 @@
       sort_order: 0,
       is_active: true,
     };
+    const faqDefaults = {
+      category: '',
+      question: '',
+      answer: '',
+      sort_order: 0,
+    };
 
     const productFormState = createSectionFormState(productFormDefaults);
     const courseFormState = createSectionFormState(courseFormDefaults);
@@ -876,10 +947,12 @@
     const homeBannerState = createSectionFormState(homeBannerDefaults);
     const homeSectionState = createSectionFormState(homeSectionDefaults);
     const homePostState = createSectionFormState(homePostDefaults);
+    const faqFormState = createSectionFormState(faqDefaults);
     let editingProductCategoryId = null;
     let editingCourseCategoryId = null;
     let promocodeItems = [];
     let reviewItems = [];
+    let faqItems = [];
     let productItems = [];
     let courseItems = [];
     let homeBannerItems = [];
@@ -891,6 +964,7 @@
     let currentBannerId = null;
     let currentSectionId = null;
     let currentPostId = null;
+    let currentFaqId = null;
     const productSubmitBtn = productForm?.querySelector('button[type="submit"]');
     const courseSubmitBtn = courseForm?.querySelector('button[type="submit"]');
     const promoSubmitBtn = promoCreateForm?.querySelector('button[type="submit"]');
@@ -919,6 +993,26 @@
     function handleError(error, fallback = 'Произошла ошибка') {
       console.error(error);
       setStatus(getErrorMessage(error, fallback), true);
+    }
+
+    async function apiPut(path, body, params) {
+      const res = await fetch(buildUrl(path, params), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      return handleResponse(res);
+    }
+
+    async function apiDelete(path, params) {
+      const res = await fetch(buildUrl(path, params), { method: 'DELETE' });
+      return handleResponse(res);
+    }
+
+    function truncateText(text, limit = 80) {
+      if (!text) return '';
+      if (text.length <= limit) return text;
+      return `${text.slice(0, limit)}…`;
     }
 
     function showImageListPlaceholder(target, message) {
@@ -985,6 +1079,9 @@
       if (view === 'reviews') {
         loadReviews();
       }
+      if (view === 'faq') {
+        loadFaqItems();
+      }
       if (view === 'home-cms') {
         showHomeTab('banners');
         loadHomeBanners();
@@ -1042,6 +1139,44 @@
           handleViewNavigation(defaultView);
         }
       });
+    });
+
+    faqAddBtn?.addEventListener('click', () => {
+      resetFaqFormState();
+      faqForm?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+
+    faqResetBtn?.addEventListener('click', () => {
+      resetFaqFormState();
+    });
+
+    faqCategoryFilter?.addEventListener('change', () => {
+      renderFaqTable(getFilteredFaqItems());
+    });
+
+    faqForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!currentUser) return handleError(new Error('Нет данных пользователя'));
+      const payload = {
+        category: (faqCategoryInput.value || '').trim(),
+        question: (faqQuestionInput.value || '').trim(),
+        answer: (faqAnswerInput.value || '').trim(),
+        sort_order: Number(faqSortInput.value) || 0,
+      };
+
+      try {
+        if (currentFaqId) {
+          await apiPut(`/admin/faq/${currentFaqId}`, payload, { user_id: currentUser.telegram_id });
+          setStatus('Вопрос обновлён');
+        } else {
+          await apiPost(`/admin/faq?user_id=${currentUser.telegram_id}`, payload);
+          setStatus('Вопрос создан');
+        }
+        resetFaqFormState();
+        await loadFaqItems();
+      } catch (error) {
+        handleError(error, 'Не удалось сохранить вопрос');
+      }
     });
 
     function requireAdmin(profile) {
@@ -1193,6 +1328,118 @@
         return userName.includes(query) || userIdMatch;
       });
     }
+
+    function renderFaqCategories(items) {
+      if (!faqCategoryFilter) return;
+      const current = faqCategoryFilter.value;
+      const categories = Array.from(
+        new Set(items.map((item) => item.category).filter(Boolean))
+      ).sort((a, b) => a.localeCompare(b));
+
+      faqCategoryFilter.innerHTML = '<option value="">Все категории</option>';
+      categories.forEach((category) => {
+        const option = document.createElement('option');
+        option.value = category;
+        option.textContent = category;
+        faqCategoryFilter.appendChild(option);
+      });
+
+      if (current) {
+        faqCategoryFilter.value = current;
+      }
+    }
+
+    function renderFaqTable(items) {
+      if (!faqTableBody) return;
+      faqTableBody.innerHTML = '';
+
+      if (!items.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 5;
+        cell.textContent = 'FAQ не найдены';
+        cell.className = 'muted';
+        row.appendChild(cell);
+        faqTableBody.appendChild(row);
+        return;
+      }
+
+      items.forEach((item) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>#${item.id}</td>
+          <td>${item.category || '—'}</td>
+          <td>${truncateText(item.question || '', 80)}</td>
+          <td>${item.sort_order ?? 0}</td>
+          <td></td>
+        `;
+
+        const actionsCell = row.querySelector('td:last-child');
+        const editBtn = document.createElement('button');
+        editBtn.className = 'btn secondary';
+        editBtn.textContent = 'Редактировать';
+        editBtn.addEventListener('click', () => openFaqForm(item));
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'btn secondary danger';
+        deleteBtn.textContent = 'Удалить';
+        deleteBtn.addEventListener('click', () => deleteFaqItem(item));
+
+        actionsCell.appendChild(editBtn);
+        actionsCell.appendChild(deleteBtn);
+        faqTableBody.appendChild(row);
+      });
+    }
+
+    function getFilteredFaqItems() {
+      const category = faqCategoryFilter?.value || '';
+      if (!category) return faqItems;
+      return faqItems.filter((item) => item.category === category);
+    }
+
+    function openFaqForm(item) {
+      currentFaqId = item?.id || null;
+      faqFormState.mode = currentFaqId ? 'edit' : 'create';
+      faqFormState.currentId = currentFaqId;
+      faqFormTitle.textContent = currentFaqId ? 'Редактировать вопрос' : 'Добавить вопрос';
+      resetFormState(faqFormState.formData, { ...faqDefaults, ...(item || {}) });
+      applyStateToForm(faqForm, faqFormState.formData);
+    }
+
+    function resetFaqFormState() {
+      currentFaqId = null;
+      faqFormTitle.textContent = 'Добавить вопрос';
+      faqFormState.mode = 'create';
+      faqFormState.currentId = null;
+      resetFormState(faqFormState.formData, faqDefaults);
+      applyStateToForm(faqForm, faqFormState.formData);
+    }
+
+    async function loadFaqItems() {
+      if (!currentUser) return;
+      try {
+        const data = await apiGet('/admin/faq', { user_id: currentUser.telegram_id });
+        faqItems = data.items || [];
+        renderFaqCategories(faqItems);
+        renderFaqTable(getFilteredFaqItems());
+      } catch (error) {
+        handleError(error, 'Не удалось загрузить FAQ');
+      }
+    }
+
+    async function deleteFaqItem(item) {
+      if (!item?.id || !currentUser) return;
+      const confirmed = window.confirm('Удалить этот вопрос?');
+      if (!confirmed) return;
+      try {
+        await apiDelete(`/admin/faq/${item.id}`, { user_id: currentUser.telegram_id });
+        setStatus('Вопрос удалён');
+        await loadFaqItems();
+      } catch (error) {
+        handleError(error, 'Не удалось удалить вопрос');
+      }
+    }
+
 
     async function loadReviewProducts() {
       try {
@@ -2898,6 +3145,7 @@
         resetHomeBannerForm();
         resetHomeSectionForm();
         resetHomePostForm();
+        resetFaqFormState();
 
         await Promise.all([
           loadCategories(productCategoryFilter, 'basket', { includeAllOption: true }),


### PR DESCRIPTION
## Summary
- add FAQ SQLAlchemy model and service with public/admin API endpoints
- expand admin panel with FAQ navigation, CRUD UI, and filtering
- integrate bot FAQ browsing flow with support contact callbacks and menu button

## Testing
- python -m compileall handlers services webapi.py bot.py keyboards/main_menu.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935cfd37a4c83269252a2949634f0df)