### PR TITLE
Ensure support widget assets load across web pages

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -371,3 +371,8 @@ Legacy
 - Дополнительно добавлены и уточнены Pydantic-модели `WebChatStartPayload`, `WebChatMessagePayload`, `WebChatManagerReplyPayload`.
 - Эти модели используются эндпоинтами `/api/webchat/start`, `/api/webchat/message`, `/api/webchat/manager_reply` для корректной валидации payload'ов.
 - Добавлен виджет помощника (support_widget.css и support_widget.js), подключён на главной и ключевых страницах сайта. На текущем этапе показывает плавающую кнопку и простое окно чата без интеграции с API, чтобы проверить отображение.
+
+Обновления виджета (2025-05-21)
+------------------------------
+- support_widget.css и support_widget.js теперь гарантированно подключены на index.html и других основных страницах веб-приложения.
+- В JS добавлен console.log('Support widget script loaded'), по которому можно проверить загрузку скрипта через консоль браузера.

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -7,8 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/webapp/css/support_widget.css" />
   <link rel="stylesheet" href="css/theme.css?v=20250521" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
 
 </head>
 <body data-theme="purple" class="page-cart">
@@ -594,6 +594,6 @@
 
     initCartPage();
   </script>
-  <script src="/webapp/js/support_widget.js" defer></script>
+  <script src="js/support_widget.js?v=20250521" defer></script>
 </body>
 </html>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -8,8 +8,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/webapp/css/support_widget.css" />
   <link rel="stylesheet" href="css/theme.css?v=20250521" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
 </head>
 <body data-theme="purple" class="page-index">
   <header class="top-nav">
@@ -160,7 +160,7 @@
   <script src="js/app.js?v=20250521"></script>
   <script src="js/api.js?v=20250521"></script>
   <script src="js/home_page.js?v=20250521"></script>
-  <script src="/webapp/js/support_widget.js" defer></script>
+  <script src="js/support_widget.js?v=20250521" defer></script>
   <script>
     const loginSection = document.getElementById('telegram-login-section');
     const authStatus = document.getElementById('auth-status');

--- a/webapp/js/support_widget.js
+++ b/webapp/js/support_widget.js
@@ -1,101 +1,103 @@
 (function () {
-  'use strict';
+  console.log('Support widget script loaded');
 
-  const body = document.body;
-  if (!body || body.querySelector('.support-widget-fab')) {
-    return;
-  }
-
-  function createMessageElement(text, role) {
-    const msg = document.createElement('div');
-    msg.className = `support-widget-msg support-widget-msg--${role}`;
-    msg.textContent = text;
-    return msg;
-  }
-
-  const fab = document.createElement('button');
-  fab.className = 'support-widget-fab';
-  fab.type = 'button';
-  fab.setAttribute('aria-label', 'Открыть помощник MiniDeN');
-  fab.textContent = '?';
-
-  const panel = document.createElement('div');
-  panel.className = 'support-widget-panel';
-
-  const header = document.createElement('div');
-  header.className = 'support-widget-header';
-
-  const title = document.createElement('span');
-  title.textContent = 'Помощник MiniDeN';
-
-  const closeBtn = document.createElement('button');
-  closeBtn.className = 'support-widget-close-btn';
-  closeBtn.type = 'button';
-  closeBtn.textContent = '×';
-
-  header.appendChild(title);
-  header.appendChild(closeBtn);
-
-  const bodyContainer = document.createElement('div');
-  bodyContainer.className = 'support-widget-body';
-
-  const footer = document.createElement('div');
-  footer.className = 'support-widget-footer';
-
-  const input = document.createElement('input');
-  input.className = 'support-widget-input';
-  input.placeholder = 'Напишите вопрос...';
-
-  const sendBtn = document.createElement('button');
-  sendBtn.className = 'support-widget-send-btn';
-  sendBtn.type = 'button';
-  sendBtn.textContent = '▶';
-
-  footer.appendChild(input);
-  footer.appendChild(sendBtn);
-
-  panel.appendChild(header);
-  panel.appendChild(bodyContainer);
-  panel.appendChild(footer);
-
-  let greeted = false;
-
-  function togglePanel(forceOpen) {
-    const isOpen = panel.classList.contains('support-widget-panel--open');
-    const nextState = typeof forceOpen === 'boolean' ? forceOpen : !isOpen;
-    panel.classList.toggle('support-widget-panel--open', nextState);
-    if (nextState && !greeted) {
-      bodyContainer.appendChild(
-        createMessageElement(
-          'Здравствуйте! Здесь вы можете задать вопрос. Я скоро научусь писать менеджеру 🙂',
-          'manager'
-        )
-      );
-      greeted = true;
-    }
-  }
-
-  function addUserMessage() {
-    const value = input.value.trim();
-    if (!value) {
+  const initWidget = () => {
+    const body = document.body;
+    if (!body) {
+      console.warn('Support widget: document.body is missing');
       return;
     }
-    bodyContainer.appendChild(createMessageElement(value, 'user'));
-    bodyContainer.scrollTop = bodyContainer.scrollHeight;
-    input.value = '';
-    // TODO: отправить сообщение в /api/webchat, когда появится бэкенд
-  }
 
-  fab.addEventListener('click', () => togglePanel());
-  closeBtn.addEventListener('click', () => togglePanel(false));
-  sendBtn.addEventListener('click', addUserMessage);
-  input.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      addUserMessage();
+    if (body.querySelector('.support-widget-fab')) {
+      console.log('Support widget: already initialized');
+      return;
     }
-  });
 
-  body.appendChild(fab);
-  body.appendChild(panel);
+    console.log('Support widget: creating FAB');
+    const fab = document.createElement('div');
+    fab.className = 'support-widget-fab';
+    fab.title = 'Помощник';
+    fab.textContent = '?';
+
+    const panel = document.createElement('div');
+    panel.className = 'support-widget-panel';
+    panel.innerHTML = `
+      <div class="support-widget-header">
+        <span>Помощник MiniDeN</span>
+        <button class="support-widget-close-btn" type="button">×</button>
+      </div>
+      <div class="support-widget-body"></div>
+      <div class="support-widget-footer">
+        <input class="support-widget-input" type="text" placeholder="Напишите вопрос..." />
+        <button class="support-widget-send-btn" type="button">▶</button>
+      </div>
+    `;
+
+    const closeBtn = panel.querySelector('.support-widget-close-btn');
+    const bodyContainer = panel.querySelector('.support-widget-body');
+    const input = panel.querySelector('.support-widget-input');
+    const sendBtn = panel.querySelector('.support-widget-send-btn');
+
+    body.appendChild(fab);
+    body.appendChild(panel);
+
+    let initialized = false;
+
+    const ensureGreeting = () => {
+      if (initialized || !bodyContainer) return;
+      const greeting = document.createElement('div');
+      greeting.className = 'support-widget-msg support-widget-msg--manager';
+      greeting.textContent =
+        'Здравствуйте! Я тестовый помощник. Если вы меня видите, значит виджет подключен правильно.';
+      bodyContainer.appendChild(greeting);
+      initialized = true;
+    };
+
+    const togglePanel = () => {
+      const isOpen = panel.classList.toggle('support-widget-panel--open');
+      if (isOpen) {
+        console.log('Support widget: panel opened');
+        ensureGreeting();
+      }
+    };
+
+    const appendUserMessage = (text) => {
+      if (!bodyContainer) return;
+      const msg = document.createElement('div');
+      msg.className = 'support-widget-msg support-widget-msg--user';
+      msg.textContent = text;
+      bodyContainer.appendChild(msg);
+      bodyContainer.scrollTop = bodyContainer.scrollHeight;
+    };
+
+    const handleSend = () => {
+      const value = (input?.value || '').trim();
+      if (!value) return;
+
+      console.log('Support widget: sending message', value);
+      appendUserMessage(value);
+      if (input) {
+        input.value = '';
+      }
+      // TODO: отправить сообщение в /api/webchat/message
+    };
+
+    fab.addEventListener('click', togglePanel);
+    closeBtn?.addEventListener('click', () => {
+      panel.classList.remove('support-widget-panel--open');
+    });
+    sendBtn?.addEventListener('click', handleSend);
+    input?.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleSend();
+      }
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', initWidget);
+  } else {
+    initWidget();
+  }
 })();

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -7,8 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/webapp/css/support_widget.css" />
   <link rel="stylesheet" href="css/theme.css?v=20250521" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
 
 </head>
 <body data-theme="purple" class="page-masterclasses">
@@ -69,6 +69,6 @@
   <script src="js/app.js?v=20250521"></script>
   <script src="js/api.js?v=20250521"></script>
   <script src="js/masterclasses_page.js?v=20250521"></script>
-  <script src="/webapp/js/support_widget.js" defer></script>
+  <script src="js/support_widget.js?v=20250521" defer></script>
 </body>
 </html>

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -7,8 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/webapp/css/support_widget.css" />
   <link rel="stylesheet" href="css/theme.css?v=20250521" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
 
 </head>
 <body data-theme="purple" class="page-products">
@@ -157,6 +157,7 @@
 
     <script src="js/app.js?v=20250521"></script>
     <script src="js/api.js?v=20250521"></script>
+    <script src="js/support_widget.js?v=20250521" defer></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const noteEl = document.getElementById('note');
@@ -1096,6 +1097,5 @@
 
     initProductsPage().catch(console.error);
   </script>
-  <script src="/webapp/js/support_widget.js" defer></script>
 </body>
 </html>

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -7,8 +7,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/webapp/css/support_widget.css" />
   <link rel="stylesheet" href="css/theme.css?v=20250521" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
 
 </head>
 <body data-theme="purple" class="page-profile">
@@ -548,7 +548,7 @@
       await loadProfileData();
     });
   </script>
-  <script src="/webapp/js/support_widget.js" defer></script>
+  <script src="js/support_widget.js?v=20250521" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- align support widget CSS/JS includes with existing static paths across main web pages
- reimplement widget script with DOM-ready init, console logs, and basic messaging interactions
- document the guaranteed connections and logging note in README

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368bf67c8c8326a0c2f5ad147d6205)