### PR TITLE
Handle webchat payloads as dicts

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -388,3 +388,8 @@ Legacy
 - WebChatMessagePayload
 - WebChatManagerReplyPayload
 Этим исправлена ошибка 422 при вызове /api/webchat/start и /api/webchat/message.
+Добавлен фикс веб-чата:
+- эндпоинты /api/webchat/start и /api/webchat/message теперь принимают JSON
+  как словарь (payload: dict = Body(...));
+- поля session_key и text/page читаются вручную, поэтому больше не возникает
+  ошибки 422 Unprocessable Entity при несовпадении Pydantic-схем.


### PR DESCRIPTION
## Summary
- switch /api/webchat/start and /api/webchat/message handlers to accept JSON dictionaries via `Body(...)` and validate required fields manually
- avoid 422 validation errors by reading `session_key` and `text/page` directly from the payload
- document the web chat change in README.txt

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c2e5663c08326a1a3d16593d6c8cc)