### PR TITLE
Fix manager reply forwarding

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -393,3 +393,7 @@ Legacy
   как словарь (payload: dict = Body(...));
 - поля session_key и text/page читаются вручную, поэтому больше не возникает
   ошибки 422 Unprocessable Entity при несовпадении Pydantic-схем.
+Добавлен обратный канал поддержки:
+- Админ отвечает reply на сообщение "Новый чат с сайта #ID" в Telegram.
+- Бот отправляет текст ответа на backend через POST /api/webchat/manager_reply.
+- Ответ отображается в веб-виджете на сайте через polling /api/webchat/messages.

--- a/bot.py
+++ b/bot.py
@@ -54,7 +54,7 @@ async def main() -> None:
     dp.include_router(admin.router)
     dp.include_router(webapp.router)
     dp.include_router(faq.faq_router)
-    dp.include_router(site_chat.router)
+    dp.include_router(site_chat.site_chat_router)
     dp.include_router(support.support_router)
 
     # Старт поллинга

--- a/handlers/site_chat.py
+++ b/handlers/site_chat.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import re
-import logging
 
 import aiohttp
 from aiogram import F, Router
@@ -8,25 +8,25 @@ from aiogram.types import Message
 
 from config import get_settings
 
-API_BASE_URL = os.getenv("API_URL") or (
-    os.getenv("BASE_URL", "http://localhost:8000").rstrip("/") + "/api"
-)
+API_BASE_URL = os.getenv("API_URL") or os.getenv("BASE_URL", "http://localhost:8000")
+API_BASE_URL = (API_BASE_URL or "http://localhost:8000").rstrip("/")
+if API_BASE_URL.endswith("/api"):
+    API_BASE_URL = API_BASE_URL[: -len("/api")]
 
-router = Router()
+site_chat_router = Router()
 
 
-async def _post_json(path: str, payload: dict) -> dict:
-    url = f"{API_BASE_URL}{path}"
-    async with aiohttp.ClientSession() as session:
-        async with session.post(url, json=payload) as response:
-            response.raise_for_status()
-            return await response.json()
+class BackendRequestError(Exception):
+    def __init__(self, status: int, text: str):
+        super().__init__(f"{status} {text}")
+        self.status = status
+        self.text = text
 
 
 def _extract_session_id(text: str | None) -> int | None:
     if not text:
         return None
-    match = re.search(r"#(\d+)", text)
+    match = re.search(r"Новый чат с сайта\s*#(\d+)", text)
     if not match:
         return None
     try:
@@ -35,16 +35,28 @@ def _extract_session_id(text: str | None) -> int | None:
         return None
 
 
-@router.message(F.reply_to_message)
+async def _send_manager_reply(session_id: int, text: str):
+    url = f"{API_BASE_URL}/api/webchat/manager_reply"
+    payload = {"session_id": session_id, "text": text}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=payload) as response:
+            response_text = await response.text()
+            if response.status >= 400:
+                raise BackendRequestError(response.status, response_text)
+
+
+@site_chat_router.message(F.reply_to_message)
 async def handle_manager_reply(message: Message):
     settings = get_settings()
     admin_ids = settings.admin_ids or set()
     primary_admin = settings.admin_chat_id
-    if message.from_user.id not in admin_ids and message.from_user.id != primary_admin:
+    sender_id = message.from_user.id if message.from_user else None
+    if sender_id not in admin_ids and sender_id != primary_admin:
         return
 
     reply = message.reply_to_message
-    session_id = _extract_session_id(reply.text if reply else None)
+    reply_text = (reply.text or reply.caption) if reply else None
+    session_id = _extract_session_id(reply_text)
     if not session_id:
         return
 
@@ -53,12 +65,18 @@ async def handle_manager_reply(message: Message):
         return
 
     try:
-        await _post_json(
-            "/webchat/manager_reply", {"session_id": session_id, "text": text}
-        )
-    except Exception:
+        await _send_manager_reply(session_id, text)
+    except BackendRequestError as exc:
         logging.exception("Failed to send manager reply to backend")
-        await message.answer("Не удалось отправить сообщение в чат. Попробуйте позже.")
+        await message.answer(
+            f"❌ Не удалось отправить ответ на сайт: {exc.status} {exc.text}"
+        )
+        return
+    except Exception as exc:
+        logging.exception("Failed to send manager reply to backend")
+        await message.answer(
+            f"❌ Не удалось отправить ответ на сайт: неизвестная ошибка ({exc})"
+        )
         return
 
-    await message.answer("Сообщение отправлено в веб-чат.")
+    await message.answer(f"✅ Ответ отправлен на сайт (чат #{session_id}).")


### PR DESCRIPTION
## Summary
- handle admin reply messages for site web chats and forward them to the backend
- connect the site chat router in the bot dispatcher
- document the support reply flow for web chat responses

## Testing
- python -m compileall handlers/site_chat.py bot.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c30dec7ac8326aaf9b9d38c35b59a)