### PR TITLE
Add GET fallback for manager reply endpoint

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -400,3 +400,9 @@ Legacy
 Исправлено: бот отправляет ответы менеджера на сайт через POST /api/webchat/manager_reply, раньше ошибочно использовался GET и backend отвечал 405 Method Not Allowed.
 Исправлено: в handlers/site_chat.py функция _post_json теперь реально делает POST-запрос.
 Это устранило 405 Method Not Allowed при отправке ответа менеджера на /api/webchat/manager_reply.
+Исправлена отправка ответов менеджера в веб-чат:
+- Бот отправляет manager_reply через POST /api/webchat/manager_reply.
+- В backend добавлен GET fallback для /api/webchat/manager_reply (на случай ошибочного метода),
+  принимающий session_id и text из query.
+- POST /api/webchat/manager_reply теперь принимает JSON как словарь и валидирует поля вручную,
+  чтобы избежать 422.


### PR DESCRIPTION
## Summary
- add shared manager reply handler that validates POST payload and allows GET fallback for compatibility
- simplify manager reply schema usage and reuse logic for status updates
- document the updated manager reply handling in README

## Testing
- python -m compileall handlers/site_chat.py webapi.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c46c9d324832691e6bae54a423322)