### PR TITLE
Send manager replies via POST with JSON

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -410,3 +410,5 @@ Legacy
 - Бот отправляет ответ менеджера через POST /api/webchat/manager_reply с JSON {session_id, text}.
 - Backend /api/webchat/manager_reply (POST) принимает payload как dict через Body(...) и валидирует вручную (без 422).
 - GET fallback оставлен, но параметры session_id/text сделаны optional и при отсутствии возвращается 400 вместо 422.
+Исправлено: бот отправляет ответы менеджера в веб-чат строго через POST /api/webchat/manager_reply
+с JSON телом {session_id, text}. Убран вызов GET без query параметров, который приводил к 400/422.


### PR DESCRIPTION
## Summary
- ensure the site chat manager reply uses a POST request with JSON payload to the backend
- add logging and error details for manager reply requests
- document the enforced POST JSON behaviour in README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c5c3f526c8326938c259dee4304af)