### PR TITLE
Fix webchat manager messages rendering

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -416,3 +416,7 @@ Legacy
 - session_id извлекается из reply-сообщения по шаблону 'Новый чат с сайта #ID'
 - ответы отправляются на backend строго POST /api/webchat/manager_reply с JSON {session_id, text}
 - бот сообщает администратору, если reply сделан не на правильное сообщение или не найден #ID
+Веб-чат: исправлено отображение ответов менеджера на сайте.
+- /api/webchat/messages возвращает сообщения user и manager с полем sender.
+- manager_reply сохраняет сообщение в ту же историю по session_key.
+- support_widget.js отображает сообщения manager и не фильтрует их.

--- a/webapi.py
+++ b/webapi.py
@@ -308,6 +308,7 @@ def api_webchat_messages(session_key: str, limit: int = 50):
         "status": session.status,
         "messages": [
             {
+                "id": msg.id,
                 "sender": msg.sender,
                 "text": msg.text,
                 "created_at": msg.created_at.isoformat() if msg.created_at else None,

--- a/webapp/js/support_widget.js
+++ b/webapp/js/support_widget.js
@@ -94,12 +94,14 @@
     function appendMessageToUI(sender, text) {
       if (!bodyEl) return;
       const msg = document.createElement('div');
-      msg.classList.add('support-widget-msg');
+      msg.classList.add('support-widget-msg', 'msg');
+
       if (sender === 'user') {
-        msg.classList.add('support-widget-msg--user');
-      } else if (sender === 'manager' || sender === 'system') {
-        msg.classList.add('support-widget-msg--manager');
+        msg.classList.add('support-widget-msg--user', 'user');
+      } else {
+        msg.classList.add('support-widget-msg--manager', 'manager');
       }
+
       msg.textContent = text;
       bodyEl.appendChild(msg);
       bodyEl.scrollTop = bodyEl.scrollHeight;
@@ -159,7 +161,8 @@
       if (!bodyEl) return;
       bodyEl.innerHTML = '';
       messages.forEach(function (m) {
-        appendMessageToUI(m.sender || 'manager', m.text || '');
+        const sender = m && m.sender ? m.sender : 'manager';
+        appendMessageToUI(sender, m && m.text ? m.text : '');
       });
     }
 


### PR DESCRIPTION
## Summary
- include message identifiers in /api/webchat/messages responses alongside sender, text, and timestamp
- update support widget rendering to display manager messages with appropriate styling classes
- document the manager reply visibility fix in README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c60008b048326a263efb1b2083dc3)