### PR TITLE
Send manager reply session_id in query

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -420,3 +420,7 @@ Legacy
 - /api/webchat/messages возвращает сообщения user и manager с полем sender.
 - manager_reply сохраняет сообщение в ту же историю по session_key.
 - support_widget.js отображает сообщения manager и не фильтрует их.
+[FIX] WebChat manager_reply
+Исправлена отправка ответов менеджера с Telegram на сайт.
+session_id теперь передаётся как query-параметр, как ожидает FastAPI.
+Ошибка 400 session_id is required устранена.

--- a/handlers/site_chat.py
+++ b/handlers/site_chat.py
@@ -28,8 +28,8 @@ def _extract_session_id(text: str) -> int | None:
 async def _post_manager_reply(
     backend_url: str, session_id: int, text: str, timeout: int = 15
 ):
-    url = f"{backend_url}/api/webchat/manager_reply"
-    payload = {"session_id": session_id, "text": text}
+    url = f"{backend_url}/api/webchat/manager_reply?session_id={session_id}"
+    payload = {"text": text}
     logging.info("MANAGER_REPLY POST %s payload=%s", url, payload)
 
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
## Summary
- send manager_reply requests with session_id in the query string instead of the JSON body
- keep message text in the JSON payload only
- note the fix in README.txt

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c61e336c88326a51f35bcf4c1bc0c)