### PR TITLE
Fix webchat API and admin chat UI

### DIFF
--- a/database.py
+++ b/database.py
@@ -72,6 +72,10 @@ def init_db() -> None:
             "ALTER TABLE webchat_sessions ADD COLUMN IF NOT EXISTS user_identifier TEXT",
             "ALTER TABLE webchat_sessions ADD COLUMN IF NOT EXISTS user_agent TEXT",
             "ALTER TABLE webchat_sessions ADD COLUMN IF NOT EXISTS client_ip VARCHAR(64)",
+            "ALTER TABLE webchat_sessions ADD COLUMN IF NOT EXISTS last_message_at TIMESTAMP",
+            "ALTER TABLE webchat_sessions ADD COLUMN IF NOT EXISTS unread_for_manager INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE webchat_messages ADD COLUMN IF NOT EXISTS is_read_by_manager BOOLEAN NOT NULL DEFAULT FALSE",
+            "ALTER TABLE webchat_messages ADD COLUMN IF NOT EXISTS is_read_by_client BOOLEAN NOT NULL DEFAULT FALSE",
         ]
 
         with engine.begin() as conn:
@@ -81,6 +85,16 @@ def init_db() -> None:
             conn.execute(
                 text(
                     "UPDATE webchat_sessions SET session_key = session_id WHERE session_key IS NULL"
+                )
+            )
+
+            conn.execute(
+                text(
+                    """
+                    UPDATE webchat_sessions
+                    SET last_message_at = COALESCE(last_message_at, updated_at, created_at)
+                    WHERE last_message_at IS NULL
+                    """
                 )
             )
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -359,6 +359,8 @@ class WebChatSession(Base):
     status = Column(String(16), default="open", index=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    last_message_at = Column(DateTime, nullable=True, index=True)
+    unread_for_manager = Column(Integer, default=0, nullable=False)
     telegram_thread_message_id = Column(BigInteger, nullable=True)
 
     messages = relationship(
@@ -377,6 +379,8 @@ class WebChatMessage(Base):
     sender = Column(String(16), nullable=False)
     text = Column(Text, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    is_read_by_manager = Column(Boolean, nullable=False, default=False)
+    is_read_by_client = Column(Boolean, nullable=False, default=False)
 
     session = relationship("WebChatSession", back_populates="messages")
 

--- a/models/support.py
+++ b/models/support.py
@@ -8,6 +8,8 @@ class SupportMessage(BaseModel):
     text: str
     sender: str
     created_at: datetime | None = None
+    is_read_by_manager: bool | None = None
+    is_read_by_client: bool | None = None
 
 
 class SupportSession(BaseModel):
@@ -16,8 +18,10 @@ class SupportSession(BaseModel):
     status: str
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    last_message_at: datetime | None = None
     last_message: str | None = None
     last_sender: str | None = None
+    unread_for_manager: int | None = 0
 
 
 class SupportMessageList(BaseModel):

--- a/services/webchat_service.py
+++ b/services/webchat_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Iterable, Optional
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from database import get_session
 from models import WebChatMessage, WebChatSession
@@ -13,26 +13,6 @@ def _refresh_session(db_session, chat_session: WebChatSession) -> WebChatSession
     db_session.flush()
     db_session.refresh(chat_session)
     return chat_session
-
-
-def _add_message(chat_session: WebChatSession, sender: str, text: str) -> WebChatMessage:
-    with get_session() as db:
-        session_obj = db.get(WebChatSession, chat_session.id)
-        if not session_obj:
-            raise ValueError("session_not_found")
-
-        session_obj.updated_at = datetime.utcnow()
-        message = WebChatMessage(
-            session_id=session_obj.id,
-            sender=sender,
-            text=text,
-            created_at=datetime.utcnow(),
-        )
-        db.add(message)
-        _refresh_session(db, session_obj)
-        db.flush()
-        db.refresh(message)
-        return message
 
 
 def _populate_session_key(session: WebChatSession, session_key: str) -> None:
@@ -81,10 +61,12 @@ def get_or_create_session(
         if existing:
             _populate_session_key(existing, session_key)
             _apply_metadata(existing, user_identifier, user_agent, client_ip)
+            existing.last_message_at = existing.last_message_at or existing.updated_at
             db.flush()
             db.refresh(existing)
             return existing
 
+        now = datetime.utcnow()
         new_session = WebChatSession(
             session_id=session_key,
             session_key=session_key,
@@ -92,11 +74,58 @@ def get_or_create_session(
             user_agent=user_agent,
             client_ip=client_ip,
             status="open",
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=now,
+            updated_at=now,
+            last_message_at=now,
+            unread_for_manager=0,
         )
         db.add(new_session)
         return _refresh_session(db, new_session)
+
+
+def _update_read_flags(message: WebChatMessage, sender: str) -> None:
+    if sender == "user":
+        message.is_read_by_client = True
+        message.is_read_by_manager = False
+    elif sender == "manager":
+        message.is_read_by_manager = True
+        message.is_read_by_client = False
+    else:
+        message.is_read_by_manager = True
+        message.is_read_by_client = True
+
+
+def _add_message(chat_session: WebChatSession, sender: str, text: str) -> WebChatMessage:
+    with get_session() as db:
+        session_obj = db.get(WebChatSession, chat_session.id)
+        if not session_obj:
+            raise ValueError("session_not_found")
+
+        now = datetime.utcnow()
+        session_obj.updated_at = now
+        session_obj.last_message_at = now
+
+        if sender == "user":
+            session_obj.unread_for_manager = (session_obj.unread_for_manager or 0) + 1
+            if session_obj.status != "closed":
+                session_obj.status = "waiting_manager"
+        elif sender == "manager":
+            session_obj.unread_for_manager = 0
+            if session_obj.status != "closed":
+                session_obj.status = "open"
+
+        message = WebChatMessage(
+            session_id=session_obj.id,
+            sender=sender,
+            text=text,
+            created_at=now,
+        )
+        _update_read_flags(message, sender)
+        db.add(message)
+        _refresh_session(db, session_obj)
+        db.flush()
+        db.refresh(message)
+        return message
 
 
 def add_user_message(session: WebChatSession, text: str) -> WebChatMessage:
@@ -131,14 +160,68 @@ def get_session_by_id(session_id: int | str) -> WebChatSession | None:
         return db.get(WebChatSession, numeric_id)
 
 
-def get_messages(session: WebChatSession, limit: int = 50) -> list[WebChatMessage]:
+def _mark_messages_read_by_manager(db, session_obj: WebChatSession) -> None:
+    updated = False
+    unread_messages = db.scalars(
+        select(WebChatMessage).where(
+            WebChatMessage.session_id == session_obj.id,
+            WebChatMessage.is_read_by_manager.is_(False),
+        )
+    ).all()
+    for msg in unread_messages:
+        msg.is_read_by_manager = True
+        updated = True
+
+    if session_obj.unread_for_manager:
+        session_obj.unread_for_manager = 0
+        updated = True
+
+    if updated:
+        session_obj.updated_at = datetime.utcnow()
+
+
+def _mark_messages_read_by_client(db, session_obj: WebChatSession) -> None:
+    unread_messages = db.scalars(
+        select(WebChatMessage).where(
+            WebChatMessage.session_id == session_obj.id,
+            WebChatMessage.sender != "user",
+            WebChatMessage.is_read_by_client.is_(False),
+        )
+    ).all()
+    for msg in unread_messages:
+        msg.is_read_by_client = True
+
+    if unread_messages:
+        session_obj.updated_at = datetime.utcnow()
+
+
+def get_messages(
+    session: WebChatSession,
+    limit: int | None = 50,
+    *,
+    after_id: int = 0,
+    mark_read_for: str | None = None,
+) -> list[WebChatMessage]:
     with get_session() as db:
-        query = select(WebChatMessage).where(WebChatMessage.session_id == session.id)
+        session_obj = db.get(WebChatSession, session.id)
+        if not session_obj:
+            return []
+
+        query = select(WebChatMessage).where(WebChatMessage.session_id == session_obj.id)
+        if after_id:
+            query = query.where(WebChatMessage.id > after_id)
         query = query.order_by(WebChatMessage.created_at.asc(), WebChatMessage.id.asc())
         if limit:
             query = query.limit(limit)
 
         records: Iterable[WebChatMessage] = db.scalars(query).all()
+
+        if mark_read_for == "manager":
+            _mark_messages_read_by_manager(db, session_obj)
+        elif mark_read_for == "client":
+            _mark_messages_read_by_client(db, session_obj)
+
+        db.flush()
 
     return list(records)
 
@@ -180,15 +263,31 @@ def set_thread_message_id(session: WebChatSession, message_id: int | None) -> No
 
 
 def list_sessions(
-    *, status: str | None = None, limit: int | None = 100
+    *, status: str | None = None, limit: int | None = 100, search: str | None = None, page: int = 1
 ) -> list[tuple[WebChatSession, WebChatMessage | None]]:
     with get_session() as db:
         query = select(WebChatSession)
         if status and status != "all":
             query = query.where(WebChatSession.status == status)
-        query = query.order_by(WebChatSession.updated_at.desc(), WebChatSession.id.desc())
+        if search:
+            like = f"%{search}%"
+            query = query.where(
+                or_(
+                    WebChatSession.session_key.ilike(like),
+                    WebChatSession.user_identifier.ilike(like),
+                    WebChatSession.client_ip.ilike(like),
+                )
+            )
+
+        page = max(page, 1)
         if limit:
-            query = query.limit(limit)
+            query = query.limit(limit).offset((page - 1) * limit)
+
+        query = query.order_by(
+            WebChatSession.last_message_at.desc().nullslast(),
+            WebChatSession.updated_at.desc(),
+            WebChatSession.id.desc(),
+        )
 
         sessions: list[WebChatSession] = list(db.scalars(query).all())
         last_messages: dict[int, WebChatMessage | None] = {}
@@ -204,11 +303,13 @@ def list_sessions(
     return [(session, last_messages.get(int(session.id))) for session in sessions]
 
 
-def get_messages_by_session_id(session_id: int, limit: int | None = None) -> list[WebChatMessage]:
+def get_messages_by_session_id(
+    session_id: int, *, limit: int | None = None, after_id: int = 0, mark_read_for: str | None = None
+) -> list[WebChatMessage]:
     session = get_session_by_id(session_id)
     if not session:
         return []
-    return get_messages(session, limit=limit or 0)
+    return get_messages(session, limit=limit or 0, after_id=after_id, mark_read_for=mark_read_for)
 
 
 def close_session(session_id: int) -> bool:

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -151,7 +151,7 @@
         <button class="nav-btn" data-view="home-cms">Главная страница</button>
         <button class="nav-btn" data-view="reviews">Отзывы</button>
         <button class="nav-btn" data-view="faq">FAQ (база знаний)</button>
-        <button class="nav-btn" data-view="support-chats">Чаты поддержки</button>
+        <button class="nav-btn" data-view="support-chats">Чаты</button>
         <div class="nav-group" data-group="promocodes">
           <button class="nav-btn nav-parent" data-group-toggle="promocodes" data-default-view="promocode-list">Промокоды</button>
           <div class="nav-submenu">
@@ -856,7 +856,7 @@
       <section id="support-chats" class="card admin-view" data-view="support-chats" style="display:none;">
         <div class="section-header">
           <div>
-            <h2>Чаты поддержки</h2>
+            <h2>Чаты</h2>
             <p class="muted">Отвечайте на вопросы клиентов прямо в админке.</p>
           </div>
           <div class="filters-row" style="gap:8px; align-items:center;">
@@ -1131,6 +1131,7 @@
     let activeSupportSessionId = null;
     let supportSessionsTimer = null;
     let supportMessagesTimer = null;
+    let supportLastMessageId = 0;
     let currentView = 'orders';
     const productSubmitBtn = productForm?.querySelector('button[type="submit"]');
     const courseSubmitBtn = courseForm?.querySelector('button[type="submit"]');
@@ -1238,7 +1239,7 @@
       if (!activeSupportSessionId) return;
       supportMessagesTimer = window.setInterval(() => {
         if (currentView === 'support-chats') {
-          loadSupportMessages();
+          loadSupportMessages({ append: true });
         }
       }, 3000);
     }
@@ -1269,13 +1270,25 @@
 
         const header = document.createElement('div');
         header.className = 'support-session-meta';
+        header.style.alignItems = 'center';
+        header.style.gap = '6px';
         const status = session.status || 'open';
-        const dateLabel = session.updated_at
-          ? new Date(session.updated_at).toLocaleString('ru-RU')
-          : session.created_at
-            ? new Date(session.created_at).toLocaleString('ru-RU')
-            : '';
+        const dateLabel = session.last_message_at
+          ? new Date(session.last_message_at).toLocaleString('ru-RU')
+          : session.updated_at
+            ? new Date(session.updated_at).toLocaleString('ru-RU')
+            : session.created_at
+              ? new Date(session.created_at).toLocaleString('ru-RU')
+              : '';
         header.innerHTML = `<span>#${session.session_id}</span><span>${status}</span>`;
+        const unread = Number(session.unread_for_manager || 0);
+        if (unread > 0) {
+          const unreadBadge = document.createElement('span');
+          unreadBadge.className = 'admin-pill';
+          unreadBadge.textContent = unread > 99 ? '99+' : unread;
+          unreadBadge.title = 'Новые сообщения клиента';
+          header.appendChild(unreadBadge);
+        }
 
         const text = document.createElement('div');
         text.className = 'support-session-text';
@@ -1300,9 +1313,9 @@
       if (!currentUser) return;
       try {
         const status = supportStatusFilter?.value || 'open';
-        const data = await apiGet('/admin/support/sessions', {
-          user_id: currentUser.telegram_id,
+        const data = await apiGet('/admin/webchat/sessions', {
           status,
+          limit: 50,
         });
         supportSessions = data?.items || [];
         renderSupportSessions(supportSessions);
@@ -1324,10 +1337,16 @@
       }
     }
 
-    function renderSupportMessages(messages = []) {
+    function renderSupportMessages(messages = [], options = {}) {
+      const { append = false } = options;
       if (!supportMessagesBox) return;
-      supportMessagesBox.innerHTML = '';
-      if (!messages.length) {
+
+      if (!append) {
+        supportLastMessageId = 0;
+        supportMessagesBox.innerHTML = '';
+      }
+
+      if (!messages.length && !supportMessagesBox.children.length) {
         const empty = document.createElement('div');
         empty.className = 'muted';
         empty.textContent = 'Сообщений пока нет';
@@ -1353,20 +1372,32 @@
           wrapper.appendChild(meta);
         }
 
+        if (msg.id) {
+          supportLastMessageId = Math.max(supportLastMessageId, Number(msg.id));
+        }
+
         supportMessagesBox.appendChild(wrapper);
       });
 
       supportMessagesBox.scrollTop = supportMessagesBox.scrollHeight;
     }
 
-    async function loadSupportMessages() {
+    async function loadSupportMessages(options = {}) {
       if (!currentUser || !activeSupportSessionId) return;
+      const { append = false } = options;
       try {
-        const data = await apiGet('/admin/support/messages', {
-          user_id: currentUser.telegram_id,
+        const data = await apiGet('/admin/webchat/messages', {
           session_id: activeSupportSessionId,
+          after_id: append ? supportLastMessageId : 0,
         });
-        renderSupportMessages(data?.items || []);
+        const items = data?.items || [];
+        if (!items.length && append) return;
+        renderSupportMessages(items, { append });
+        const activeSession = findSupportSession(activeSupportSessionId);
+        if (activeSession) {
+          activeSession.unread_for_manager = 0;
+          renderSupportSessions(supportSessions);
+        }
       } catch (e) {
         console.error(e);
       }
@@ -1375,6 +1406,10 @@
     async function openSupportSession(sessionId) {
       activeSupportSessionId = sessionId;
       const session = findSupportSession(sessionId);
+      supportLastMessageId = 0;
+      if (session) {
+        session.unread_for_manager = 0;
+      }
       renderSupportSessions(supportSessions);
       const isClosed = !session || session.status === 'closed';
       if (supportMessageInput) supportMessageInput.disabled = isClosed;
@@ -1393,13 +1428,12 @@
       if (!text) return;
       try {
         supportSendBtn.disabled = true;
-        await apiPost('/admin/support/message', {
-          user_id: currentUser.telegram_id,
+        await apiPost('/admin/webchat/send', {
           session_id: activeSupportSessionId,
           text,
         });
         supportMessageInput.value = '';
-        await Promise.all([loadSupportMessages(), loadSupportSessions()]);
+        await Promise.all([loadSupportMessages({ append: true }), loadSupportSessions()]);
       } catch (e) {
         handleError(e, 'Не удалось отправить сообщение');
       } finally {
@@ -1411,8 +1445,7 @@
       if (!currentUser || !activeSupportSessionId) return;
       try {
         supportCloseBtn.disabled = true;
-        await apiPost('/admin/support/close', {
-          user_id: currentUser.telegram_id,
+        await apiPost('/admin/webchat/close', {
           session_id: activeSupportSessionId,
         });
         await loadSupportSessions();


### PR DESCRIPTION
## Summary
- stabilize webchat session/message models with unread counters and read flags
- fix public and admin webchat endpoints and manager reply handling
- refresh admin chats UI with polling, unread badges, and JSON-based actions

## Testing
- python -m compileall webapi.py services/webchat_service.py handlers/site_chat.py models/support.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c7e1937dc83269b25dd758197867b)