### PR TITLE
Add admin webchat session endpoints

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,6 +20,12 @@ MiniDeN — Telegram-бот и веб-магазин
 - Эндпоинты веб-чата принимают гибкие JSON-поля: `session_key` и `text` обязательны, остальные поля опциональны; ошибки валидации логируются в backend.
 - В ответе `/api/webchat/start` теперь всегда приходят `session_id` и `session_key`, чтобы виджет и бот могли надёжно продолжать сессию.
 - Эндпоинт `/api/webchat/manager_reply` принимает POST с параметрами в query или JSON-ключами (`session_id`/`session_key`, `text`/`message`/`reply`) и возвращает `{ "ok": true }`.
+- Добавлены отдельные админские эндпоинты для чатов в стиле мессенджера:
+  - `GET /api/webchat/sessions` — список сессий с поиском/статусом/пагинацией;
+  - `GET /api/webchat/sessions/{session_id}` — метаданные сессии и сообщения;
+  - `POST /api/webchat/sessions/{session_id}/reply` — ответ менеджера через body {"text": "..."};
+  - `POST /api/webchat/sessions/{session_id}/read` — отметка прочитанного (опционально `{ "last_read_message_id": N }`);
+  - `POST /api/webchat/sessions/{session_id}/close` — закрытие диалога.
 - Виджет (`webapp/js/api.js`) корректно обрабатывает не-JSON ответы (например, HTML от 502) и больше не падает на JSON.parse.
 - Логи веб-чата стали подробнее: старт, пользовательские сообщения и ответы менеджера пишутся с ключевыми атрибутами, а ошибки валидации фиксируются с перечислением полей.
 

--- a/models/support.py
+++ b/models/support.py
@@ -24,6 +24,11 @@ class SupportSession(BaseModel):
     unread_for_manager: int | None = 0
 
 
+class SupportSessionDetail(BaseModel):
+    session: SupportSession
+    messages: list[SupportMessage]
+
+
 class SupportMessageList(BaseModel):
     items: list[SupportMessage]
 


### PR DESCRIPTION
## Summary
- add messenger-style admin webchat endpoints for listing sessions, loading details, replying, marking read, and closing
- extend support schemas with session detail shape and adjust webchat service to track manager read markers
- document the new admin chat API contract in README

## Testing
- python -m compileall webapi.py services/webchat_service.py models/support.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d07171d788326857217df32bd1707)