### PR TITLE
Revamp admin chat UI and add reopen endpoint

### DIFF
--- a/models/support.py
+++ b/models/support.py
@@ -22,6 +22,8 @@ class SupportSession(BaseModel):
     last_message: str | None = None
     last_sender: str | None = None
     unread_for_manager: int | None = 0
+    user_identifier: str | None = None
+    client_ip: str | None = None
 
 
 class SupportSessionDetail(BaseModel):

--- a/webapi.py
+++ b/webapi.py
@@ -2298,6 +2298,8 @@ def admin_webchat_sessions(
                 "status": session.status,
                 "created_at": session.created_at.isoformat() if session.created_at else None,
                 "updated_at": session.updated_at.isoformat() if session.updated_at else None,
+                "user_identifier": session.user_identifier,
+                "client_ip": session.client_ip,
                 "last_message": last_message.text if last_message else None,
                 "last_sender": last_message.sender if last_message else None,
                 "last_message_at": session.last_message_at.isoformat()
@@ -2354,6 +2356,18 @@ def admin_webchat_close(
     return {"ok": True}
 
 
+@app.post("/api/admin/webchat/reopen")
+def admin_webchat_reopen(
+    payload: AdminWebChatClosePayload, admin: User = Depends(get_admin_user)
+):
+    session = webchat_service.get_session_by_id(payload.session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    webchat_service.mark_open(session)
+    return {"ok": True}
+
+
 @app.get("/api/webchat/sessions", response_model=SupportSessionList)
 def api_admin_webchat_sessions(
     status: str = "open",
@@ -2376,6 +2390,8 @@ def api_admin_webchat_sessions(
                 "status": session.status,
                 "created_at": session.created_at,
                 "updated_at": session.updated_at,
+                "user_identifier": session.user_identifier,
+                "client_ip": session.client_ip,
                 "last_message_at": session.last_message_at,
                 "last_message": last_message.text if last_message else None,
                 "last_sender": last_message.sender if last_message else None,

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -8,122 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="css/theme.css?v=20250521" />
-
-  <style>
-    .support-chat-layout {
-      display: grid;
-      grid-template-columns: minmax(220px, 280px) 1fr;
-      gap: 12px;
-      align-items: start;
-    }
-    .support-sessions {
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      background: rgba(255, 255, 255, 0.03);
-      max-height: 540px;
-      overflow-y: auto;
-    }
-    .support-session-item {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-      padding: 10px 12px;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-      text-align: left;
-      cursor: pointer;
-      transition: background 0.15s ease;
-    }
-    .support-session-item:hover,
-    .support-session-item:focus-visible {
-      background: rgba(255, 255, 255, 0.05);
-    }
-    .support-session-item.active {
-      background: rgba(255, 255, 255, 0.1);
-    }
-    .support-session-meta {
-      display: flex;
-      justify-content: space-between;
-      gap: 6px;
-      font-size: 12px;
-      color: var(--muted-color, #9ea0ab);
-    }
-    .support-session-text {
-      font-size: 14px;
-      color: var(--text-primary, #fff);
-    }
-    .support-chat-pane {
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      background: rgba(255, 255, 255, 0.03);
-      padding: 12px;
-      min-height: 360px;
-    }
-    .support-messages-box {
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 10px;
-      min-height: 260px;
-      max-height: 420px;
-      overflow-y: auto;
-      background: rgba(255, 255, 255, 0.02);
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    .support-chat-message {
-      max-width: 80%;
-      padding: 8px 10px;
-      border-radius: 10px;
-      background: rgba(255, 255, 255, 0.08);
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-    .support-chat-message.user {
-      margin-left: auto;
-      background: rgba(74, 222, 128, 0.12);
-    }
-    .support-chat-message.manager {
-      margin-right: auto;
-      background: rgba(255, 255, 255, 0.12);
-    }
-    .support-chat-message.system {
-      margin: 0 auto;
-      background: transparent;
-      color: var(--muted-color, #9ea0ab);
-      font-size: 13px;
-    }
-    .support-chat-actions {
-      margin-top: 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    .support-chat-buttons {
-      display: flex;
-      gap: 8px;
-      flex-wrap: wrap;
-    }
-    .support-chat-actions textarea {
-      width: 100%;
-      min-height: 70px;
-      border-radius: 8px;
-      border: 1px solid var(--border);
-      padding: 8px;
-      background: rgba(255, 255, 255, 0.04);
-      color: inherit;
-    }
-    @media (max-width: 900px) {
-      .support-chat-layout {
-        grid-template-columns: 1fr;
-      }
-      .support-session-item {
-        padding: 8px 10px;
-      }
-      .support-chat-message {
-        max-width: 100%;
-      }
-    }
-  </style>
+  <link rel="stylesheet" href="css/admin_chats.css?v=20250521" />
 
 </head>
 <body data-theme="purple" class="page-admin">
@@ -857,33 +742,70 @@
         <div class="section-header">
           <div>
             <h2>Чаты</h2>
-            <p class="muted">Отвечайте на вопросы клиентов прямо в админке.</p>
+            <p class="muted">Структура как в мессенджере: выберите диалог слева и переписку справа.</p>
           </div>
-          <div class="filters-row" style="gap:8px; align-items:center;">
-            <label for="support-status-filter" class="muted" style="margin:0;">Статус</label>
-            <select id="support-status-filter">
-              <option value="open">Открытые</option>
-              <option value="waiting_manager">Ожидают ответа</option>
-              <option value="closed">Закрытые</option>
-              <option value="all">Все</option>
-            </select>
-            <button class="btn secondary" type="button" id="support-refresh-btn">Обновить</button>
-          </div>
+          <button class="btn secondary" type="button" id="chat-sidebar-toggle" aria-label="Свернуть список чатов">☰</button>
         </div>
 
-        <div class="support-chat-layout">
-          <div class="support-sessions" id="support-sessions-list" aria-label="Список чатов поддержки"></div>
-          <div class="support-chat-pane">
-            <div id="support-chat-header" class="muted" style="margin-bottom:6px;">Выберите чат слева, чтобы начать диалог.</div>
-            <div id="support-messages" class="support-messages-box" aria-live="polite"></div>
-            <div class="support-chat-actions">
-              <textarea id="support-message-input" placeholder="Ответ менеджера..." aria-label="Ответ менеджера"></textarea>
-              <div class="support-chat-buttons">
-                <button class="btn primary" type="button" id="support-send-btn" disabled>Отправить</button>
-                <button class="btn secondary" type="button" id="support-close-btn" disabled>Закрыть чат</button>
+        <div class="chat-app" id="admin-chat-app">
+          <aside class="chat-sidebar" id="chat-sidebar" aria-label="Список чатов">
+            <div class="chat-sidebar__controls">
+              <div class="chat-search">
+                <input
+                  type="search"
+                  id="chat-search-input"
+                  placeholder="Поиск по имени / user_id / session_key"
+                  aria-label="Поиск по имени или session_key"
+                />
+              </div>
+              <div class="chat-filter-group">
+                <select id="chat-status-filter" aria-label="Фильтр статуса">
+                  <option value="all">Все</option>
+                  <option value="open">Открытые</option>
+                  <option value="waiting_manager">Ожидают ответа</option>
+                  <option value="closed">Закрытые</option>
+                </select>
+                <button class="chat-icon-button" type="button" id="chat-refresh-button" title="Обновить список">↻</button>
               </div>
             </div>
-          </div>
+            <div class="chat-list" id="chat-list" role="listbox" aria-label="Диалоги"></div>
+          </aside>
+
+          <main class="chat-main">
+            <div class="chat-header" id="chat-header">
+              <div class="chat-header__info">
+                <div class="chat-title" id="chat-title">Выберите чат</div>
+                <div class="chat-subtitle" id="chat-subtitle">Чтобы увидеть переписку, выберите диалог слева.</div>
+              </div>
+              <div class="chat-header__actions">
+                <span class="chat-status-badge" id="chat-status-badge">—</span>
+                <button class="chat-icon-button" type="button" id="chat-header-refresh" title="Обновить чат">↻</button>
+                <button class="chat-btn secondary" type="button" id="chat-reopen-button" disabled>Открыть снова</button>
+                <button class="chat-btn primary" type="button" id="chat-close-button" disabled>Закрыть чат</button>
+              </div>
+            </div>
+
+            <div class="chat-main__body">
+              <div class="chat-messages" id="chat-messages" aria-live="polite"></div>
+              <button class="chat-new-indicator hidden" id="chat-new-indicator" type="button">⬇ Новые сообщения</button>
+            </div>
+
+            <div class="chat-composer" id="chat-composer">
+              <textarea
+                id="chat-input"
+                rows="3"
+                placeholder="Напишите ответ..."
+                aria-label="Ответ менеджера"
+                disabled
+              ></textarea>
+              <div class="chat-composer__footer">
+                <div class="chat-composer__hint" id="chat-closed-hint" hidden>
+                  Чат закрыт. Нажмите «Открыть снова», чтобы ответить.
+                </div>
+                <button class="chat-send-button" id="chat-send-button" type="button" title="Отправить" disabled>▶</button>
+              </div>
+            </div>
+          </main>
         </div>
       </section>
 
@@ -893,9 +815,10 @@
       </section>
     </main>
   </div>
-
+  
   <script src="js/app.js?v=20250521"></script>
   <script src="js/api.js?v=20250521"></script>
+  <script src="js/admin_chats.js?v=20250521"></script>
   <script>
     const statusBox = document.getElementById('status');
     const accessDenied = document.getElementById('access-denied');
@@ -938,17 +861,6 @@
     const faqAnswerInput = document.getElementById('faq-answer');
     const faqSortInput = document.getElementById('faq-sort');
     const faqResetBtn = document.getElementById('faq-reset');
-
-    const supportStatusFilter = document.getElementById('support-status-filter');
-    const supportSessionsList = document.getElementById('support-sessions-list');
-    const supportMessagesBox = document.getElementById('support-messages');
-    const supportMessageInput = document.getElementById('support-message-input');
-    const supportSendBtn = document.getElementById('support-send-btn');
-    const supportCloseBtn = document.getElementById('support-close-btn');
-    const supportRefreshBtn = document.getElementById('support-refresh-btn');
-    const supportChatHeader = document.getElementById('support-chat-header');
-
-    if (supportMessageInput) supportMessageInput.disabled = true;
 
     const productCategoryFilter = document.getElementById('products-category');
     const courseCategoryFilter = document.getElementById('courses-category');
@@ -1127,11 +1039,6 @@
     let currentSectionId = null;
     let currentPostId = null;
     let currentFaqId = null;
-    let supportSessions = [];
-    let activeSupportSessionId = null;
-    let supportSessionsTimer = null;
-    let supportMessagesTimer = null;
-    let supportLastMessageId = 0;
     let currentView = 'orders';
     const productSubmitBtn = productForm?.querySelector('button[type="submit"]');
     const courseSubmitBtn = courseForm?.querySelector('button[type="submit"]');
@@ -1201,6 +1108,11 @@
       imageModal.classList.add('hidden');
     }
 
+    window.adminChats?.init({
+      onError: (error, message) => handleError(error || new Error(message)),
+      onStatus: (message, isError) => setStatus(message, isError),
+    });
+
     async function sendJson(path, method = 'GET', body = null) {
       const res = await fetch(`${API_BASE}${path}`, {
         method,
@@ -1208,260 +1120,6 @@
         body: body ? JSON.stringify(body) : undefined,
       });
       return handleResponse(res);
-    }
-
-    function stopSupportMessagesPolling() {
-      if (supportMessagesTimer) {
-        window.clearInterval(supportMessagesTimer);
-        supportMessagesTimer = null;
-      }
-    }
-
-    function stopSupportPolling() {
-      stopSupportMessagesPolling();
-      if (supportSessionsTimer) {
-        window.clearInterval(supportSessionsTimer);
-        supportSessionsTimer = null;
-      }
-    }
-
-    function startSupportSessionsPolling() {
-      if (supportSessionsTimer) window.clearInterval(supportSessionsTimer);
-      supportSessionsTimer = window.setInterval(() => {
-        if (currentView === 'support-chats') {
-          loadSupportSessions();
-        }
-      }, 8000);
-    }
-
-    function startSupportMessagesPolling() {
-      stopSupportMessagesPolling();
-      if (!activeSupportSessionId) return;
-      supportMessagesTimer = window.setInterval(() => {
-        if (currentView === 'support-chats') {
-          loadSupportMessages({ append: true });
-        }
-      }, 3000);
-    }
-
-    function findSupportSession(sessionId) {
-      return supportSessions.find((s) => Number(s.session_id) === Number(sessionId));
-    }
-
-    function renderSupportSessions(items = []) {
-      if (!supportSessionsList) return;
-      supportSessionsList.innerHTML = '';
-      if (!items.length) {
-        const empty = document.createElement('div');
-        empty.className = 'muted';
-        empty.style.padding = '12px';
-        empty.textContent = 'Нет чатов поддержки';
-        supportSessionsList.appendChild(empty);
-        return;
-      }
-
-      items.forEach((session) => {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'support-session-item';
-        if (Number(session.session_id) === Number(activeSupportSessionId)) {
-          btn.classList.add('active');
-        }
-
-        const header = document.createElement('div');
-        header.className = 'support-session-meta';
-        header.style.alignItems = 'center';
-        header.style.gap = '6px';
-        const status = session.status || 'open';
-        const dateLabel = session.last_message_at
-          ? new Date(session.last_message_at).toLocaleString('ru-RU')
-          : session.updated_at
-            ? new Date(session.updated_at).toLocaleString('ru-RU')
-            : session.created_at
-              ? new Date(session.created_at).toLocaleString('ru-RU')
-              : '';
-        header.innerHTML = `<span>#${session.session_id}</span><span>${status}</span>`;
-        const unread = Number(session.unread_for_manager || 0);
-        if (unread > 0) {
-          const unreadBadge = document.createElement('span');
-          unreadBadge.className = 'admin-pill';
-          unreadBadge.textContent = unread > 99 ? '99+' : unread;
-          unreadBadge.title = 'Новые сообщения клиента';
-          header.appendChild(unreadBadge);
-        }
-
-        const text = document.createElement('div');
-        text.className = 'support-session-text';
-        const preview = truncateText(session.last_message || 'Без сообщений', 90);
-        const senderLabel = session.last_sender === 'user' ? 'Клиент' : session.last_sender === 'manager' ? 'Менеджер' : '—';
-        text.textContent = `${senderLabel !== '—' ? senderLabel + ': ' : ''}${preview}`;
-
-        const footer = document.createElement('div');
-        footer.className = 'support-session-meta';
-        footer.innerHTML = `<span>${session.session_key || ''}</span><span>${dateLabel}</span>`;
-
-        btn.appendChild(header);
-        btn.appendChild(text);
-        btn.appendChild(footer);
-
-        btn.addEventListener('click', () => openSupportSession(session.session_id));
-        supportSessionsList.appendChild(btn);
-      });
-    }
-
-    async function loadSupportSessions() {
-      if (!currentUser) return;
-      try {
-        const status = supportStatusFilter?.value || 'open';
-        const data = await apiGet('/admin/webchat/sessions', {
-          status,
-          limit: 50,
-        });
-        supportSessions = data?.items || [];
-        renderSupportSessions(supportSessions);
-
-        if (activeSupportSessionId) {
-          const stillExists = findSupportSession(activeSupportSessionId);
-          if (!stillExists) {
-            activeSupportSessionId = null;
-            stopSupportMessagesPolling();
-            supportSendBtn.disabled = true;
-            supportCloseBtn.disabled = true;
-            if (supportMessageInput) supportMessageInput.disabled = true;
-            supportChatHeader.textContent = 'Выберите чат слева, чтобы начать диалог.';
-            if (supportMessagesBox) supportMessagesBox.innerHTML = '';
-          }
-        }
-      } catch (e) {
-        handleError(e, 'Не удалось загрузить чаты поддержки');
-      }
-    }
-
-    function renderSupportMessages(messages = [], options = {}) {
-      const { append = false } = options;
-      if (!supportMessagesBox) return;
-
-      if (!append) {
-        supportLastMessageId = 0;
-        supportMessagesBox.innerHTML = '';
-      }
-
-      if (!messages.length && !supportMessagesBox.children.length) {
-        const empty = document.createElement('div');
-        empty.className = 'muted';
-        empty.textContent = 'Сообщений пока нет';
-        supportMessagesBox.appendChild(empty);
-        return;
-      }
-
-      messages.forEach((msg) => {
-        const wrapper = document.createElement('div');
-        const sender = msg.sender || 'system';
-        wrapper.className = `support-chat-message ${sender}`;
-
-        const text = document.createElement('div');
-        text.textContent = msg.text || '';
-        wrapper.appendChild(text);
-
-        if (msg.created_at) {
-          const meta = document.createElement('div');
-          meta.className = 'muted';
-          meta.style.fontSize = '11px';
-          meta.style.marginTop = '4px';
-          meta.textContent = new Date(msg.created_at).toLocaleString('ru-RU');
-          wrapper.appendChild(meta);
-        }
-
-        if (msg.id) {
-          supportLastMessageId = Math.max(supportLastMessageId, Number(msg.id));
-        }
-
-        supportMessagesBox.appendChild(wrapper);
-      });
-
-      supportMessagesBox.scrollTop = supportMessagesBox.scrollHeight;
-    }
-
-    async function loadSupportMessages(options = {}) {
-      if (!currentUser || !activeSupportSessionId) return;
-      const { append = false } = options;
-      try {
-        const data = await apiGet('/admin/webchat/messages', {
-          session_id: activeSupportSessionId,
-          after_id: append ? supportLastMessageId : 0,
-        });
-        const items = data?.items || [];
-        if (!items.length && append) return;
-        renderSupportMessages(items, { append });
-        const activeSession = findSupportSession(activeSupportSessionId);
-        if (activeSession) {
-          activeSession.unread_for_manager = 0;
-          renderSupportSessions(supportSessions);
-        }
-      } catch (e) {
-        console.error(e);
-      }
-    }
-
-    async function openSupportSession(sessionId) {
-      activeSupportSessionId = sessionId;
-      const session = findSupportSession(sessionId);
-      supportLastMessageId = 0;
-      if (session) {
-        session.unread_for_manager = 0;
-      }
-      renderSupportSessions(supportSessions);
-      const isClosed = !session || session.status === 'closed';
-      if (supportMessageInput) supportMessageInput.disabled = isClosed;
-      supportSendBtn.disabled = !session || isClosed;
-      supportCloseBtn.disabled = !session || session.status === 'closed';
-      supportChatHeader.textContent = session
-        ? `Чат #${session.session_id} · ${session.status || 'open'}`
-        : 'Чат не найден';
-      await loadSupportMessages();
-      startSupportMessagesPolling();
-    }
-
-    async function sendSupportMessage() {
-      if (!currentUser || !activeSupportSessionId || !supportMessageInput) return;
-      const text = supportMessageInput.value.trim();
-      if (!text) return;
-      try {
-        supportSendBtn.disabled = true;
-        await apiPost('/admin/webchat/send', {
-          session_id: activeSupportSessionId,
-          text,
-        });
-        supportMessageInput.value = '';
-        await Promise.all([loadSupportMessages({ append: true }), loadSupportSessions()]);
-      } catch (e) {
-        handleError(e, 'Не удалось отправить сообщение');
-      } finally {
-        supportSendBtn.disabled = false;
-      }
-    }
-
-    async function closeSupportSession() {
-      if (!currentUser || !activeSupportSessionId) return;
-      try {
-        supportCloseBtn.disabled = true;
-        await apiPost('/admin/webchat/close', {
-          session_id: activeSupportSessionId,
-        });
-        await loadSupportSessions();
-        await loadSupportMessages();
-        const session = findSupportSession(activeSupportSessionId);
-        if (session?.status === 'closed') {
-          supportSendBtn.disabled = true;
-          if (supportMessageInput) supportMessageInput.disabled = true;
-          supportCloseBtn.disabled = true;
-        }
-      } catch (e) {
-        handleError(e, 'Не удалось закрыть чат');
-      } finally {
-        const sessionAfter = findSupportSession(activeSupportSessionId);
-        supportCloseBtn.disabled = sessionAfter?.status === 'closed';
-      }
     }
 
     function showSection(id) {
@@ -1481,7 +1139,7 @@
 
     function handleViewNavigation(view) {
       if (view !== 'support-chats') {
-        stopSupportPolling();
+        window.adminChats?.deactivate();
       }
       showSection(view);
       if (view === 'product-categories') {
@@ -1509,9 +1167,7 @@
         loadFaqItems();
       }
       if (view === 'support-chats') {
-        loadSupportSessions();
-        startSupportSessionsPolling();
-        startSupportMessagesPolling();
+        window.adminChats?.activate();
       }
       if (view === 'home-cms') {
         showHomeTab('banners');
@@ -1570,23 +1226,6 @@
           handleViewNavigation(defaultView);
         }
       });
-    });
-
-    supportStatusFilter?.addEventListener('change', () => {
-      loadSupportSessions();
-    });
-
-    supportRefreshBtn?.addEventListener('click', () => {
-      loadSupportSessions();
-    });
-
-    supportSendBtn?.addEventListener('click', sendSupportMessage);
-    supportCloseBtn?.addEventListener('click', closeSupportSession);
-    supportMessageInput?.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
-        event.preventDefault();
-        sendSupportMessage();
-      }
     });
 
     faqAddBtn?.addEventListener('click', () => {

--- a/webapp/css/admin_chats.css
+++ b/webapp/css/admin_chats.css
@@ -1,0 +1,460 @@
+:root {
+  --chat-bg: #f5f6f7;
+  --chat-card: #ffffff;
+  --chat-border: rgba(0, 0, 0, 0.08);
+  --chat-muted: #667085;
+  --chat-primary: #4f7cff;
+  --chat-success: #2ea24a;
+  --chat-warning: #e6a23c;
+  --chat-danger: #b0b8c4;
+}
+
+#support-chats {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.01), rgba(255, 255, 255, 0.04));
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 10px 30px rgba(17, 24, 39, 0.08);
+}
+
+.chat-app {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 16px;
+  min-height: 520px;
+  background: var(--chat-bg);
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid var(--chat-border);
+}
+
+.chat-sidebar {
+  background: #fbfbfd;
+  border-right: 1px solid var(--chat-border);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  position: relative;
+}
+
+.chat-sidebar__controls {
+  padding: 14px 14px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #fff;
+  border-bottom: 1px solid var(--chat-border);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.chat-search input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--chat-border);
+  font: 400 14px/20px system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  background: #f9fafb;
+}
+
+.chat-filter-group {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+#chat-status-filter {
+  flex: 1;
+  border-radius: 12px;
+  border: 1px solid var(--chat-border);
+  padding: 9px 10px;
+  font-size: 14px;
+  background: #fff;
+}
+
+.chat-icon-button {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid var(--chat-border);
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 16px;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.chat-icon-button:hover {
+  background: #f3f4f6;
+}
+
+.chat-icon-button:active {
+  transform: translateY(1px);
+}
+
+.chat-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 4px 8px;
+}
+
+.chat-list::-webkit-scrollbar,
+.chat-messages::-webkit-scrollbar {
+  width: 8px;
+}
+
+.chat-list::-webkit-scrollbar-thumb,
+.chat-messages::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 6px;
+}
+
+.chat-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 10px;
+  row-gap: 4px;
+  padding: 10px 12px;
+  margin: 4px 6px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-item:hover {
+  background: #f0f4ff;
+  border-color: rgba(79, 124, 255, 0.2);
+}
+
+.chat-item.active {
+  border-color: var(--chat-primary);
+  box-shadow: inset 3px 0 0 var(--chat-primary);
+  background: #eef3ff;
+}
+
+.chat-avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #dfe7ff, #f6f7fb);
+  color: #3b4c7c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  grid-row: 1 / span 2;
+  font-size: 16px;
+}
+
+.chat-item__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.chat-name {
+  font-weight: 700;
+  color: #1f2937;
+  font-size: 15px;
+}
+
+.chat-preview {
+  color: var(--chat-muted);
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--chat-muted);
+  font-size: 12px;
+}
+
+.chat-time {
+  margin-left: auto;
+  color: var(--chat-muted);
+  font-weight: 600;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.status-dot.open {
+  background: var(--chat-success);
+}
+
+.status-dot.waiting_manager {
+  background: var(--chat-warning);
+}
+
+.status-dot.closed {
+  background: var(--chat-danger);
+}
+
+.unread-badge {
+  background: var(--chat-primary);
+  color: #fff;
+  border-radius: 12px;
+  padding: 2px 7px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.chat-main {
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--chat-border);
+  gap: 12px;
+}
+
+.chat-header__info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.chat-title {
+  font-size: 17px;
+  font-weight: 800;
+  color: #1f2937;
+}
+
+.chat-subtitle {
+  color: var(--chat-muted);
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.chat-status-badge {
+  padding: 6px 10px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 700;
+  color: #1f2937;
+  background: #f3f4f6;
+  border: 1px solid var(--chat-border);
+}
+
+.chat-btn {
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--chat-border);
+  background: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-btn.primary {
+  background: var(--chat-primary);
+  color: #fff;
+  border-color: var(--chat-primary);
+}
+
+.chat-btn.secondary {
+  background: #f8f9fb;
+  color: #1f2937;
+}
+
+.chat-btn:disabled,
+.chat-icon-button:disabled,
+.chat-send-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.chat-main__body {
+  flex: 1;
+  position: relative;
+  background: linear-gradient(180deg, #f7f8fc, #eef0f5);
+  padding: 16px;
+  overflow: hidden;
+}
+
+.chat-messages {
+  position: absolute;
+  inset: 16px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-right: 6px;
+}
+
+.chat-message {
+  display: inline-flex;
+  max-width: 70%;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  color: #111827;
+  position: relative;
+  word-break: break-word;
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
+
+.chat-message.manager {
+  margin-left: auto;
+  background: #e7f3ff;
+  color: #0f172a;
+  border-bottom-right-radius: 6px;
+}
+
+.chat-message.user {
+  margin-right: auto;
+  background: #fff;
+  border-bottom-left-radius: 6px;
+}
+
+.chat-message.system {
+  margin: 0 auto;
+  background: transparent;
+  box-shadow: none;
+  color: var(--chat-muted);
+  font-size: 13px;
+}
+
+.message-meta {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--chat-muted);
+  text-align: right;
+}
+
+.chat-new-indicator {
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid var(--chat-border);
+  background: #fff;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.chat-new-indicator.hidden {
+  display: none;
+}
+
+.chat-composer {
+  padding: 14px 18px;
+  border-top: 1px solid var(--chat-border);
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#chat-input {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--chat-border);
+  min-height: 90px;
+  padding: 12px;
+  font-size: 14px;
+  resize: vertical;
+  background: #f9fafb;
+  line-height: 1.4;
+}
+
+.chat-composer__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.chat-send-button {
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  border: none;
+  background: var(--chat-primary);
+  color: #fff;
+  font-size: 18px;
+  cursor: pointer;
+  box-shadow: 0 6px 20px rgba(79, 124, 255, 0.3);
+  transition: transform 0.2s ease;
+}
+
+.chat-send-button:active {
+  transform: translateY(1px);
+}
+
+.chat-composer__hint {
+  color: var(--chat-muted);
+  font-size: 13px;
+}
+
+#chat-sidebar-toggle {
+  display: none;
+}
+
+@media (max-width: 1100px) {
+  .chat-app {
+    grid-template-columns: 300px 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .chat-app {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-sidebar {
+    position: absolute;
+    z-index: 3;
+    width: 100%;
+    max-width: 360px;
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.2);
+    transform: translateX(-110%);
+    transition: transform 0.25s ease;
+  }
+
+  .chat-sidebar.open {
+    transform: translateX(0);
+  }
+
+  #chat-sidebar-toggle {
+    display: inline-flex;
+  }
+}

--- a/webapp/js/admin_chats.js
+++ b/webapp/js/admin_chats.js
@@ -1,0 +1,474 @@
+(function () {
+  const state = {
+    chats: [],
+    activeSessionId: null,
+    activeChat: null,
+    lastMessageId: 0,
+    filter: 'all',
+    search: '',
+    pollingTimers: { list: null, messages: null },
+    viewActive: false,
+  };
+
+  const elements = {};
+  let onError;
+  let onStatus;
+  let searchTimer;
+
+  function qs(id) {
+    return document.getElementById(id);
+  }
+
+  function init(options = {}) {
+    onError = options.onError;
+    onStatus = options.onStatus;
+
+    elements.sidebar = qs('chat-sidebar');
+    elements.sidebarToggle = qs('chat-sidebar-toggle');
+    elements.searchInput = qs('chat-search-input');
+    elements.statusFilter = qs('chat-status-filter');
+    elements.refreshButton = qs('chat-refresh-button');
+    elements.chatList = qs('chat-list');
+    elements.chatHeader = qs('chat-header');
+    elements.chatTitle = qs('chat-title');
+    elements.chatSubtitle = qs('chat-subtitle');
+    elements.chatStatusBadge = qs('chat-status-badge');
+    elements.chatHeaderRefresh = qs('chat-header-refresh');
+    elements.closeButton = qs('chat-close-button');
+    elements.reopenButton = qs('chat-reopen-button');
+    elements.messagesBox = qs('chat-messages');
+    elements.newIndicator = qs('chat-new-indicator');
+    elements.textarea = qs('chat-input');
+    elements.sendButton = qs('chat-send-button');
+    elements.closedHint = qs('chat-closed-hint');
+    elements.composer = qs('chat-composer');
+
+    bindEvents();
+  }
+
+  function bindEvents() {
+    elements.sidebarToggle?.addEventListener('click', () => {
+      elements.sidebar?.classList.toggle('open');
+    });
+
+    elements.searchInput?.addEventListener('input', () => {
+      const value = elements.searchInput.value.trim();
+      clearTimeout(searchTimer);
+      searchTimer = window.setTimeout(() => {
+        state.search = value;
+        if (state.viewActive) {
+          loadChats();
+        }
+      }, 250);
+    });
+
+    elements.statusFilter?.addEventListener('change', () => {
+      state.filter = elements.statusFilter.value || 'all';
+      if (state.viewActive) {
+        loadChats();
+      }
+    });
+
+    elements.refreshButton?.addEventListener('click', () => {
+      refreshAll();
+    });
+
+    elements.chatHeaderRefresh?.addEventListener('click', () => {
+      refreshActive();
+    });
+
+    elements.sendButton?.addEventListener('click', sendMessage);
+    elements.textarea?.addEventListener('input', updateSendAvailability);
+    elements.textarea?.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        sendMessage();
+      }
+    });
+
+    elements.closeButton?.addEventListener('click', closeChat);
+    elements.reopenButton?.addEventListener('click', reopenChat);
+
+    elements.messagesBox?.addEventListener('scroll', () => {
+      if (!elements.messagesBox) return;
+      if (isNearBottom()) {
+        hideNewIndicator();
+      }
+    });
+
+    elements.newIndicator?.addEventListener('click', () => {
+      scrollToBottom();
+    });
+  }
+
+  function activate() {
+    state.viewActive = true;
+    loadChats();
+    startListPolling();
+    if (state.activeSessionId) {
+      startMessagePolling();
+    }
+  }
+
+  function deactivate() {
+    state.viewActive = false;
+    stopPolling();
+  }
+
+  async function loadChats() {
+    if (!elements.chatList) return;
+    try {
+      const params = { status: state.filter || 'all', limit: 100 };
+      if (state.search) params.search = state.search;
+      const data = await apiGet('/admin/webchat/sessions', params);
+      state.chats = data?.items || [];
+      renderChatList();
+      syncActiveChat();
+    } catch (error) {
+      handleError('Не удалось загрузить чаты', error);
+    }
+  }
+
+  function renderChatList() {
+    elements.chatList.innerHTML = '';
+    if (!state.chats.length) {
+      const empty = document.createElement('div');
+      empty.className = 'chat-empty muted';
+      empty.textContent = 'Чатов не найдено';
+      elements.chatList.appendChild(empty);
+      return;
+    }
+
+    state.chats.forEach((chat) => {
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'chat-item';
+      item.setAttribute('role', 'option');
+      if (Number(chat.session_id) === Number(state.activeSessionId)) {
+        item.classList.add('active');
+      }
+
+      const avatar = document.createElement('div');
+      avatar.className = 'chat-avatar';
+      avatar.textContent = getAvatarLetter(chat);
+
+      const top = document.createElement('div');
+      top.className = 'chat-item__top';
+
+      const name = document.createElement('div');
+      name.className = 'chat-name';
+      name.textContent = getDisplayName(chat);
+
+      const meta = document.createElement('div');
+      meta.className = 'chat-meta';
+
+      const statusDot = document.createElement('span');
+      statusDot.className = `status-dot ${chat.status || 'open'}`;
+      statusDot.title = chat.status || 'open';
+      meta.appendChild(statusDot);
+
+      if (chat.unread_for_manager) {
+        const unread = document.createElement('span');
+        unread.className = 'unread-badge';
+        unread.textContent = Number(chat.unread_for_manager) > 99 ? '99+' : chat.unread_for_manager;
+        meta.appendChild(unread);
+      }
+
+      const time = document.createElement('div');
+      time.className = 'chat-time';
+      time.textContent = formatTime(chat.last_message_at || chat.updated_at || chat.created_at);
+
+      top.appendChild(name);
+      top.appendChild(time);
+
+      const preview = document.createElement('div');
+      preview.className = 'chat-preview';
+      preview.textContent = chat.last_message || 'Без сообщений';
+
+      const footer = document.createElement('div');
+      footer.className = 'chat-meta';
+      footer.innerHTML = `<span>${chat.session_key || chat.session_id}</span>`;
+      footer.appendChild(meta);
+
+      item.appendChild(avatar);
+      item.appendChild(top);
+      item.appendChild(preview);
+      item.appendChild(footer);
+
+      item.addEventListener('click', () => {
+        openChat(chat.session_id);
+        elements.sidebar?.classList.remove('open');
+      });
+
+      elements.chatList.appendChild(item);
+    });
+  }
+
+  function getDisplayName(chat) {
+    if (!chat) return 'Гость';
+    if (chat.user_identifier) {
+      return chat.user_identifier.split('|')[1] || chat.user_identifier || 'Гость';
+    }
+    return 'Гость';
+  }
+
+  function getAvatarLetter(chat) {
+    const name = getDisplayName(chat);
+    return (name || 'Г')[0].toUpperCase();
+  }
+
+  function formatTime(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    const now = new Date();
+    const sameDay =
+      date.getFullYear() === now.getFullYear() &&
+      date.getMonth() === now.getMonth() &&
+      date.getDate() === now.getDate();
+    const options = sameDay ? { hour: '2-digit', minute: '2-digit' } : { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' };
+    return date.toLocaleString('ru-RU', options);
+  }
+
+  async function openChat(sessionId) {
+    state.activeSessionId = sessionId;
+    state.lastMessageId = 0;
+    syncActiveChat();
+    await refreshActive();
+    startMessagePolling();
+  }
+
+  function syncActiveChat() {
+    state.activeChat = state.chats.find((c) => Number(c.session_id) === Number(state.activeSessionId)) || null;
+    renderHeader();
+  }
+
+  async function refreshActive() {
+    if (!state.activeSessionId) return;
+    await Promise.all([loadMessages(), loadChats()]);
+  }
+
+  async function refreshAll() {
+    await Promise.all([loadChats(), loadMessages({ append: false, skipIfNoActive: true })]);
+  }
+
+  function renderHeader() {
+    if (!state.activeChat) {
+      elements.chatTitle.textContent = 'Выберите чат';
+      elements.chatSubtitle.textContent = 'Чтобы увидеть переписку, выберите диалог слева.';
+      elements.chatStatusBadge.textContent = '—';
+      elements.closeButton.disabled = true;
+      elements.reopenButton.disabled = true;
+      toggleComposer(false, true);
+      updateSendAvailability();
+      return;
+    }
+
+    const chat = state.activeChat;
+    elements.chatTitle.textContent = getDisplayName(chat);
+    elements.chatSubtitle.textContent = `${chat.user_identifier || 'Гость'} · ${chat.session_key || chat.session_id || ''}`;
+    elements.chatStatusBadge.textContent = getStatusLabel(chat.status);
+    elements.closeButton.disabled = chat.status === 'closed';
+    elements.reopenButton.disabled = chat.status !== 'closed';
+    toggleComposer(chat.status !== 'closed', chat.status === 'closed');
+    updateSendAvailability();
+  }
+
+  function getStatusLabel(status) {
+    switch (status) {
+      case 'closed':
+        return 'Закрыт';
+      case 'waiting_manager':
+        return 'Ожидает ответа';
+      default:
+        return 'Открыт';
+    }
+  }
+
+  function toggleComposer(enabled, isClosed) {
+    if (elements.textarea) {
+      elements.textarea.disabled = !enabled;
+      if (!enabled) {
+        elements.textarea.value = '';
+      }
+    }
+    if (elements.sendButton) {
+      elements.sendButton.disabled = !enabled;
+    }
+    if (elements.closedHint) {
+      elements.closedHint.hidden = !isClosed;
+    }
+    updateSendAvailability();
+  }
+
+  function updateSendAvailability() {
+    if (!elements.sendButton) return;
+    const hasText = Boolean(elements.textarea && elements.textarea.value.trim());
+    const isClosed = state.activeChat?.status === 'closed';
+    elements.sendButton.disabled = !state.activeSessionId || !hasText || isClosed;
+  }
+
+  async function loadMessages(options = {}) {
+    const { append = false, skipIfNoActive = false } = options;
+    if (!state.activeSessionId) {
+      if (!skipIfNoActive && elements.messagesBox) {
+        elements.messagesBox.innerHTML = '';
+      }
+      return;
+    }
+
+    try {
+      const params = { session_id: state.activeSessionId, after_id: append ? state.lastMessageId : 0 };
+      const data = await apiGet('/admin/webchat/messages', params);
+      const items = data?.items || [];
+      if (!append) {
+        state.lastMessageId = 0;
+        elements.messagesBox.innerHTML = '';
+      }
+      renderMessages(items, { append });
+      if (state.activeChat) {
+        state.activeChat.unread_for_manager = 0;
+      }
+    } catch (error) {
+      handleError('Не удалось загрузить сообщения', error);
+    }
+  }
+
+  function renderMessages(messages, { append }) {
+    if (!elements.messagesBox) return;
+    if (!append && !messages.length) {
+      elements.messagesBox.innerHTML = '<div class="chat-empty muted">Сообщений пока нет</div>';
+      return;
+    }
+
+    const shouldStickToBottom = isNearBottom();
+
+    messages.forEach((msg) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = `chat-message ${msg.sender || 'system'}`;
+      wrapper.textContent = msg.text || '';
+
+      const meta = document.createElement('div');
+      meta.className = 'message-meta';
+      meta.textContent = msg.created_at ? formatTime(msg.created_at) : '';
+      wrapper.appendChild(meta);
+
+      if (msg.id) {
+        state.lastMessageId = Math.max(state.lastMessageId, Number(msg.id));
+      }
+
+      elements.messagesBox.appendChild(wrapper);
+    });
+
+    if (shouldStickToBottom) {
+      scrollToBottom();
+    } else if (messages.length) {
+      showNewIndicator();
+    }
+  }
+
+  async function sendMessage() {
+    if (!state.activeSessionId || !elements.textarea) return;
+    const text = elements.textarea.value.trim();
+    if (!text) return;
+    elements.sendButton.disabled = true;
+    try {
+      await apiPost('/admin/webchat/send', { session_id: state.activeSessionId, text });
+      elements.textarea.value = '';
+      await Promise.all([loadMessages({ append: true }), loadChats()]);
+      scrollToBottom();
+    } catch (error) {
+      handleError('Не удалось отправить сообщение', error);
+    } finally {
+      updateSendAvailability();
+    }
+  }
+
+  async function closeChat() {
+    if (!state.activeSessionId) return;
+    try {
+      elements.closeButton.disabled = true;
+      await apiPost('/admin/webchat/close', { session_id: state.activeSessionId });
+      await loadChats();
+      syncActiveChat();
+    } catch (error) {
+      handleError('Не удалось закрыть чат', error);
+    }
+  }
+
+  async function reopenChat() {
+    if (!state.activeSessionId) return;
+    try {
+      elements.reopenButton.disabled = true;
+      await apiPost('/admin/webchat/reopen', { session_id: state.activeSessionId });
+      await loadChats();
+      syncActiveChat();
+      await loadMessages();
+    } catch (error) {
+      handleError('Не удалось открыть чат заново', error);
+    } finally {
+      elements.reopenButton.disabled = state.activeChat?.status !== 'closed';
+    }
+  }
+
+  function isNearBottom() {
+    if (!elements.messagesBox) return true;
+    const { scrollTop, scrollHeight, clientHeight } = elements.messagesBox;
+    return scrollHeight - (scrollTop + clientHeight) < 120;
+  }
+
+  function scrollToBottom() {
+    if (!elements.messagesBox) return;
+    elements.messagesBox.scrollTop = elements.messagesBox.scrollHeight;
+    hideNewIndicator();
+  }
+
+  function showNewIndicator() {
+    elements.newIndicator?.classList.remove('hidden');
+  }
+
+  function hideNewIndicator() {
+    elements.newIndicator?.classList.add('hidden');
+  }
+
+  function startListPolling() {
+    stopListPolling();
+    state.pollingTimers.list = window.setInterval(loadChats, 3000);
+  }
+
+  function startMessagePolling() {
+    stopMessagePolling();
+    if (!state.activeSessionId) return;
+    state.pollingTimers.messages = window.setInterval(() => loadMessages({ append: true }), 2500);
+  }
+
+  function stopListPolling() {
+    if (state.pollingTimers.list) {
+      clearInterval(state.pollingTimers.list);
+      state.pollingTimers.list = null;
+    }
+  }
+
+  function stopMessagePolling() {
+    if (state.pollingTimers.messages) {
+      clearInterval(state.pollingTimers.messages);
+      state.pollingTimers.messages = null;
+    }
+  }
+
+  function stopPolling() {
+    stopListPolling();
+    stopMessagePolling();
+  }
+
+  function handleError(message, error) {
+    console.error(error);
+    if (typeof onError === 'function') {
+      onError(error, message);
+    }
+    if (typeof onStatus === 'function') {
+      onStatus(message || 'Ошибка', true);
+    }
+  }
+
+  window.adminChats = { init, activate, deactivate };
+})();


### PR DESCRIPTION
## Summary
- redesign the admin chat section with a messenger-style two-column layout, dedicated styling, and richer chat metadata
- add chat-side functionality for search/filter, polling, unread/status badges, closed-chat handling, and reopen/refresh controls
- extend webchat admin API responses with user metadata and provide a reopen endpoint for closed chats

## Testing
- python -m compileall webapi.py models/support.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d19795148832693245d2cbb45ac53)