### PR TITLE
Add lifestyle homepage redesign and theme option

### DIFF
--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -7,11 +7,11 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20250521" />
-  <link rel="stylesheet" href="css/admin_chats.css?v=20250521" />
+  <link rel="stylesheet" href="css/theme.css?v=20250605" />
+  <link rel="stylesheet" href="css/admin_chats.css?v=20250605" />
 
 </head>
-<body data-theme="purple" class="page-admin">
+<body data-theme="lifestyle" class="page-admin">
   <div class="admin-layout">
     <aside class="admin-sidebar">
       <div class="admin-brand">MiniDeN<br /><span>админ-панель</span></div>
@@ -816,9 +816,9 @@
     </main>
   </div>
   
-  <script src="js/app.js?v=20250521"></script>
-  <script src="js/api.js?v=20250521"></script>
-  <script src="js/admin_chats.js?v=20250521"></script>
+  <script src="js/app.js?v=20250605"></script>
+  <script src="js/api.js?v=20250605"></script>
+  <script src="js/admin_chats.js?v=20250605"></script>
   <script>
     const statusBox = document.getElementById('status');
     const accessDenied = document.getElementById('access-denied');

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -7,17 +7,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20250521" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
+  <link rel="stylesheet" href="css/theme.css?v=20250605" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250605" />
 
 </head>
-<body data-theme="purple" class="page-cart">
+<body data-theme="lifestyle" class="page-cart">
   <header class="top-nav">
     <div class="brand">MiniDeN<span>уютные корзинки и мастер-классы</span></div>
     <div class="header-actions">
       <div class="theme-switcher">
         <label for="theme-select">Тема</label>
         <select id="theme-select">
+          <option value="lifestyle">Lifestyle</option>
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
@@ -27,6 +28,10 @@
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
     </div>
     <nav class="nav-links app-sidebar">
+      <div class="sidebar-brand">
+        <strong>Miniden</strong>
+        <span>уют, семья, вязание</span>
+      </div>
       <a href="index.html">Главная</a>
       <a href="products.html">Товары</a>
       <a href="masterclasses.html">Мастер-классы</a>
@@ -88,8 +93,8 @@
     </div>
   </main>
 
-  <script src="js/app.js?v=20250521"></script>
-  <script src="js/api.js?v=20250521"></script>
+  <script src="js/app.js?v=20250605"></script>
+  <script src="js/api.js?v=20250605"></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const noteEl = document.getElementById('note');
@@ -594,6 +599,6 @@
 
     initCartPage();
   </script>
-  <script src="js/support_widget.js?v=20250521" defer></script>
+  <script src="js/support_widget.js?v=20250605" defer></script>
 </body>
 </html>

--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -6,6 +6,11 @@
   --color-accent-success: #3bb273;
   --color-btn-on-accent: #0b0c10;
   --shadow-strong: 0 14px 50px rgba(0, 0, 0, 0.35);
+  --surface-primary: var(--color-bg-card);
+  --surface-secondary: var(--color-bg-card);
+  --tile-gradient: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+  --nav-surface: var(--color-bg-card-elevated);
+  --nav-border: var(--color-border-subtle);
 }
 
 body[data-theme="purple"] {
@@ -65,6 +70,29 @@ body[data-theme="cream"] {
   --shadow-strong: 0 12px 32px rgba(197, 154, 111, 0.2);
 }
 
+body[data-theme="lifestyle"] {
+  --color-bg: radial-gradient(1200px 600px at 20% 0%, rgba(201, 181, 154, 0.35), transparent 55%),
+    radial-gradient(900px 500px at 85% 10%, rgba(191, 160, 122, 0.22), transparent 60%),
+    linear-gradient(180deg, #faf8f5, #f3eee8);
+  --color-bg-card: rgba(255, 255, 255, 0.7);
+  --color-bg-card-elevated: rgba(255, 255, 255, 0.78);
+  --color-text-main: #161616;
+  --color-text-muted: rgba(22, 22, 22, 0.62);
+  --color-border-subtle: rgba(0, 0, 0, 0.06);
+  --color-overlay: rgba(22, 22, 22, 0.4);
+  --color-accent-primary: #c9b59a;
+  --color-accent-primary-strong: #bfa07a;
+  --color-accent-secondary: #d8c7ad;
+  --color-accent-secondary-strong: #bfa07a;
+  --color-btn-on-accent: #1a1a1a;
+  --shadow-strong: 0 14px 38px rgba(0, 0, 0, 0.08);
+  --surface-primary: rgba(255, 255, 255, 0.7);
+  --surface-secondary: rgba(255, 255, 255, 0.55);
+  --tile-gradient: linear-gradient(135deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.35));
+  --nav-surface: rgba(255, 255, 255, 0.68);
+  --nav-border: rgba(0, 0, 0, 0.06);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -91,13 +119,45 @@ a:hover {
   color: var(--color-text-main);
 }
 
+.reveal {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hover-lift {
+  transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+}
+
+.hover-lift:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.08);
+  filter: brightness(1.02);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .reveal.is-visible,
+  .hover-lift,
+  .hover-lift:hover {
+    transition: none !important;
+    transform: none !important;
+  }
+}
+
 .top-nav {
   position: sticky;
   top: 0;
   z-index: 1100;
-  background: var(--color-bg-card-elevated);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--nav-surface);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--nav-border);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.06);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -112,6 +172,10 @@ a:hover {
   gap: 2px;
   font-weight: 800;
   letter-spacing: -0.02em;
+  padding: 8px 12px;
+  border-radius: 14px;
+  background: var(--tile-gradient);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
 }
 
 .brand span {
@@ -179,26 +243,52 @@ a:hover {
   box-shadow: none;
 }
 
+.sidebar-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: var(--tile-gradient);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.05);
+}
+
+.sidebar-brand strong {
+  font-size: 16px;
+  letter-spacing: -0.01em;
+}
+
+.sidebar-brand span {
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
 .app-sidebar a {
   color: var(--color-text-muted);
   text-decoration: none;
   font-weight: 600;
   padding: 10px 12px;
   border-radius: 12px;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
   display: block;
   border: 1px solid transparent;
 }
 
 .app-sidebar a:hover {
   color: var(--color-text-main);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--tile-gradient);
   border-color: var(--color-border-subtle);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.04);
 }
 
 .app-sidebar a.active {
   color: var(--color-text-main);
-  background: linear-gradient(135deg, rgba(255, 184, 0, 0.18), rgba(123, 216, 255, 0.14));
+  background: var(--tile-gradient);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.06);
+  border-color: var(--color-border-subtle);
 }
 
 .app-sidebar-overlay {
@@ -210,9 +300,11 @@ a:hover {
   background: transparent;
   border: 1px solid var(--color-border-subtle);
   color: var(--color-text-main);
-  border-radius: 12px;
+  border-radius: 14px;
   padding: 10px 12px;
   cursor: pointer;
+  background: var(--tile-gradient);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.06);
 }
 
 main {
@@ -257,28 +349,28 @@ main {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 12px 16px;
-  border-radius: 12px;
+  padding: 12px 18px;
+  border-radius: 16px;
   font-weight: 700;
   border: none;
   cursor: pointer;
   text-decoration: none;
-  transition: transform 0.1s ease, box-shadow 0.1s ease, background 0.2s ease;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.2s ease;
   color: var(--color-btn-on-accent);
   background: linear-gradient(135deg, var(--color-accent-primary), var(--color-accent-primary-strong));
-  box-shadow: 0 10px 30px rgba(255, 184, 0, 0.25);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
 }
 
 .btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 32px rgba(255, 184, 0, 0.35);
+  transform: translateY(-3px);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.1);
 }
 
 .btn.secondary {
   color: var(--color-text-main);
-  background: var(--color-bg-card);
+  background: var(--tile-gradient);
   border: 1px solid var(--color-border-subtle);
-  box-shadow: none;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.04);
 }
 
 .btn.danger {
@@ -341,12 +433,12 @@ p {
 }
 
 .card {
-  background: var(--color-bg-card);
+  background: var(--surface-primary);
   border: 1px solid var(--color-border-subtle);
-  border-radius: 16px;
-  padding: 14px;
+  border-radius: 18px;
+  padding: 16px;
   box-shadow: var(--shadow-strong);
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(10px);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -414,11 +506,263 @@ p {
   margin-bottom: 8px;
 }
 
+.page-index main {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding-top: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.page-index section {
+  margin: 0;
+}
+
+.lifestyle-hero {
+  position: relative;
+  overflow: hidden;
+  background: var(--tile-gradient);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 24px;
+  padding: clamp(24px, 5vw, 44px);
+  box-shadow: var(--shadow-strong);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(18px, 3vw, 32px);
+}
+
+.lifestyle-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 10%, rgba(201, 181, 154, 0.24), transparent 45%),
+    radial-gradient(circle at 90% 30%, rgba(191, 160, 122, 0.2), transparent 50%);
+  pointer-events: none;
+}
+
+.hero-body {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.38);
+  border: 1px solid var(--color-border-subtle);
+  font-weight: 700;
+  width: fit-content;
+}
+
+.hero-title {
+  font-size: clamp(32px, 6vw, 48px);
+  margin: 0;
+  letter-spacing: -0.03em;
+}
+
+.hero-subtitle {
+  font-size: clamp(16px, 3vw, 20px);
+  margin: 0;
+  color: var(--color-text-muted);
+  max-width: 520px;
+}
+
+.hero-visual {
+  position: relative;
+  z-index: 1;
+  border-radius: 22px;
+  overflow: hidden;
+  background: var(--tile-gradient);
+  min-height: 240px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.08);
+}
+
+.hero-visual img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.hero-visual:hover img {
+  transform: scale(1.02);
+}
+
+.visual-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.visual-tile {
+  position: relative;
+  overflow: hidden;
+  border-radius: 20px;
+  background: var(--tile-gradient);
+  border: 1px solid var(--color-border-subtle);
+  min-height: 180px;
+  display: flex;
+  align-items: flex-end;
+  padding: 18px;
+  color: var(--color-text-main);
+  text-decoration: none;
+  box-shadow: var(--shadow-strong);
+}
+
+.visual-tile::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.02) 30%, rgba(0, 0, 0, 0.45) 100%);
+  z-index: 1;
+}
+
+.visual-tile img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease, filter 0.4s ease, background-position 0.4s ease;
+}
+
+.visual-tile:hover img {
+  transform: scale(1.03);
+  filter: brightness(1.02);
+}
+
+.visual-tile span {
+  position: relative;
+  z-index: 2;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #ffffff;
+}
+
+.story-strip {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  background: var(--surface-primary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 18px;
+  padding: 18px 20px;
+  box-shadow: var(--shadow-strong);
+}
+
+.story-strip p {
+  margin: 6px 0 0;
+}
+
+.story-avatar {
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+}
+
+.story-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cta-card {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+  align-items: center;
+  background: var(--surface-primary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: var(--shadow-strong);
+  position: relative;
+  overflow: hidden;
+}
+
+.cta-card h3 {
+  margin: 0 0 10px;
+  font-size: 26px;
+}
+
+.cta-card p {
+  margin: 0 0 16px;
+  color: var(--color-text-muted);
+  max-width: 520px;
+}
+
+.cta-card .btn {
+  width: fit-content;
+}
+
+.cta-card--reverse {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.cta-card__media {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--tile-gradient);
+  min-height: 200px;
+  border: 1px solid var(--color-border-subtle);
+}
+
+.cta-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.45s ease;
+}
+
+.cta-card__media:hover img {
+  transform: scale(1.04);
+}
+
+.info-panel,
+#telegram-login-section,
+#auth-status,
+#home-posts {
+  background: var(--surface-primary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: var(--shadow-strong);
+}
+
+.info-panel h2,
+#telegram-login-section h2,
+#auth-status h2,
+#home-posts h2 {
+  margin-top: 0;
+}
+
+.home-posts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
 footer {
   margin-top: 32px;
   padding: 18px 14px;
-  border-radius: 16px;
-  background: var(--color-bg-card);
+  border-radius: 18px;
+  background: var(--surface-primary);
   border: 1px solid var(--color-border-subtle);
   display: flex;
   justify-content: space-between;
@@ -2001,11 +2345,11 @@ td {
     width: 260px;
     height: 100vh;
     padding: 78px 18px 24px;
-    background: var(--color-bg-card-elevated);
+    background: var(--nav-surface);
     transform: translateX(-100%);
     transition: transform 0.25s ease;
     z-index: 1050;
-    box-shadow: 12px 0 30px rgba(0, 0, 0, 0.4);
+    box-shadow: 12px 0 30px rgba(0, 0, 0, 0.25);
   }
 
   .app-sidebar.app-sidebar--open {
@@ -2015,7 +2359,7 @@ td {
   .app-sidebar-overlay {
     position: fixed;
     inset: 0;
-    background: var(--color-overlay);
+    background: linear-gradient(120deg, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.25));
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.2s ease;

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -8,16 +8,17 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20250521" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
+  <link rel="stylesheet" href="css/theme.css?v=20250605" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250605" />
 </head>
-<body data-theme="purple" class="page-index">
+<body data-theme="lifestyle" class="page-index">
   <header class="top-nav">
     <div class="brand">MiniDeN<span>уютные корзинки и мастер-классы</span></div>
     <div class="header-actions">
       <div class="theme-switcher">
         <label for="theme-select">Тема</label>
         <select id="theme-select">
+          <option value="lifestyle">Lifestyle</option>
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
@@ -27,6 +28,10 @@
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
     </div>
     <nav class="nav-links app-sidebar">
+      <div class="sidebar-brand">
+        <strong>Miniden</strong>
+        <span>уют, семья, вязание</span>
+      </div>
       <a href="index.html" class="active">Главная</a>
       <a href="products.html">Товары</a>
       <a href="masterclasses.html">Мастер-классы</a>
@@ -40,92 +45,103 @@
   <div id="toast-container"></div>
 
   <main>
-    <section class="hero">
-      <div>
-        <h1>MiniDeN — уютные корзинки и мастер-классы по вязанию</h1>
-        <p>Авторские наборы для дома и подарков, а также онлайн-уроки, которые помогут связать свои первые корзинки и сумки. Всё в одном тёплом каталоге MiniDeN.</p>
+    <section class="lifestyle-hero reveal">
+      <div class="hero-body">
+        <span class="hero-eyebrow">Miniden • домашнее вязание</span>
+        <h1 class="hero-title">Дом, который вяжется руками</h1>
+        <p class="hero-subtitle">Мини-истории о корзинках, детских комнатах и спокойных вечерах. Всё, что делаю, — про уют, семью и обучение без спешки.</p>
         <div class="hero-cta">
-          <a class="btn" href="products.html">Перейти к товарам</a>
-          <a class="btn secondary" href="masterclasses.html">Мастер-классы</a>
-        </div>
-        <div class="pill-row">
-          <span class="pill">Handmade</span>
-          <span class="pill">Тёмная тема</span>
-          <span class="pill">Доставка и забота</span>
+          <a class="btn secondary" href="#story">Узнать историю</a>
         </div>
       </div>
-      <div class="card home-banner-card" id="home-banner-card">
-        <div class="label">Популярный набор</div>
-        <div class="category-cover" id="home-banner-cover">🧺 «Домашний уют»</div>
-        <h3 id="home-banner-title">Корзинка + свеча + плед</h3>
-        <p id="home-banner-subtitle">Тёплый подарок с фактурной корзинкой, ароматной свечой и мягким пледом. Собираем вручную.</p>
-        <a class="btn" id="home-banner-button" href="products.html">Смотреть в каталоге</a>
+      <div class="hero-visual hover-lift">
+        <img src="https://images.unsplash.com/photo-1513542789411-b6a5d4f31634?auto=format&fit=crop&w=1400&q=80" alt="Уютный дом и вязание" />
       </div>
     </section>
 
-    <h2>Популярные категории</h2>
-    <div class="grid">
-      <div class="card">
-        <div class="category-cover">🧺 Корзинки</div>
-        <h3>Корзинки</h3>
-        <p>Фактурные органайзеры и подарочные наборы. Подойдут для дома и уютных сюрпризов.</p>
-        <a class="btn" href="products.html">Смотреть</a>
+    <section class="visual-grid reveal" aria-label="Темы MiniDeN">
+      <a class="visual-tile hover-lift" href="#story" id="tile-home-kids">
+        <img src="https://images.unsplash.com/photo-1526481280695-3c687fd643ed?auto=format&fit=crop&w=1400&q=80" alt="Дом и дети" />
+        <span>Дом и дети</span>
+      </a>
+      <a class="visual-tile hover-lift" href="#process" id="tile-process">
+        <img src="https://images.unsplash.com/photo-1520975682031-a1a4f852cddf?auto=format&fit=crop&w=1400&q=80" alt="Процесс вязания" />
+        <span>Процесс</span>
+      </a>
+      <a class="visual-tile hover-lift" href="products.html" id="tile-baskets">
+        <img src="https://images.unsplash.com/photo-1526481280695-3c687fd643ed?auto=format&fit=crop&w=1400&q=80" alt="Мои корзинки" />
+        <span>Мои корзинки</span>
+      </a>
+      <a class="visual-tile hover-lift" href="masterclasses.html" id="tile-learning">
+        <img src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1400&q=80" alt="Обучение вязанию" />
+        <span>Обучение</span>
+      </a>
+    </section>
+
+    <section class="story-strip reveal" id="story">
+      <div class="story-avatar">
+        <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80" alt="Миниден" />
       </div>
-      <div class="card">
-        <div class="category-cover">👶 Люльки</div>
-        <h3>Люльки</h3>
-        <p>Мягкие коконы и люльки для малышей, созданные с заботой и безопасными материалами.</p>
-        <a class="btn" href="products.html">Смотреть</a>
+      <div>
+        <strong>Немного обо мне</strong>
+        <p>Я вяжу дома. Учу так, как училась сама: без спешки, в тишине и с акцентом на уютные вещи для семьи.</p>
       </div>
-      <div class="card">
-        <div class="category-cover">👜 Сумки</div>
-        <h3>Сумки</h3>
-        <p>Трендовые вязаные сумки и шопперы, которые собирают комплименты и носятся каждый день.</p>
-        <a class="btn" href="products.html">Смотреть</a>
+    </section>
+
+    <section class="info-panel reveal" id="process">
+      <h2>Процесс</h2>
+      <p class="muted">От выбора пряжи до упаковки — всё делаю сама, небольшими партиями и с вниманием к мелочам. Так изделия получаются тёплыми и долгими в носке.</p>
+    </section>
+
+    <section class="cta-card reveal hover-lift" id="shop-entry">
+      <div>
+        <h3>Корзинки и наборы</h3>
+        <p>Небольшие вещи, которые собирают дом воедино: органайзеры, подарочные композиции и акценты для детских комнат.</p>
+        <a class="btn" href="products.html">Перейти в каталог</a>
       </div>
-      <div class="card">
-        <div class="category-cover">🎓 Мастер-классы</div>
+      <div class="cta-card__media">
+        <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80" alt="Вязаные корзинки" />
+      </div>
+    </section>
+
+    <section class="cta-card cta-card--reverse reveal hover-lift" id="learning-entry">
+      <div class="cta-card__media">
+        <img src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=1200&q=80" alt="Процесс обучения вязанию" />
+      </div>
+      <div>
         <h3>Мастер-классы</h3>
-        <p>Онлайн-уроки MiniDeN: платные и бесплатные форматы с поддержкой и подробными материалами.</p>
-        <a class="btn secondary" href="masterclasses.html">К каталогу курсов</a>
+        <p>Для тех, кто хочет начать и дойти до результата. Простые шаги, поддержка и вдохновение, чтобы связать своё первое изделие.</p>
+        <a class="btn secondary" href="masterclasses.html">Смотреть обучение</a>
       </div>
-    </div>
+    </section>
 
-    <h2>Почему MiniDeN</h2>
-    <div class="benefits" id="why-list">
-      <div class="benefit"><strong>✨ Ручная работа</strong><p>Каждая корзинка собирается вручную: плотные стенки, аккуратные швы и приятные материалы.</p></div>
-      <div class="benefit"><strong>🎁 Готовые подарки</strong><p>Наборы укомплектованы и готовы к вручению: остаётся только выбрать стиль и добавить открытку.</p></div>
-      <div class="benefit"><strong>🧶 Учимся вместе</strong><p>Платные и бесплатные мастер-классы помогут освоить вязание и упаковку с нуля.</p></div>
-      <div class="benefit"><strong>🤝 Поддержка в Telegram</strong><p>Поможем подобрать корзинку, расскажем о доставке и ответим на вопросы прямо в чате.</p></div>
-    </div>
+    <section class="section reveal" id="home-posts" style="display:none;">
+      <h2>Новости и идеи</h2>
+      <div class="home-posts-grid" id="home-posts-grid"></div>
+      <div class="muted" id="home-posts-empty" style="display:none;">Скоро здесь появятся новости</div>
+    </section>
 
-    <h2>Как это работает</h2>
-    <div class="step" id="how-intro">
-      <strong>0) Войдите через Telegram-бота</strong>
+    <section class="section reveal" id="telegram-login-section">
+      <h2>Вход через Telegram</h2>
       <p>
-        Нажмите кнопку ниже, откройте бота MiniDeN в Telegram и нажмите «Старт».
-        После этого каталоги, корзина и профиль на сайте будут связаны с вашим аккаунтом.
+        Чтобы синхронизировать корзину и профиль с ботом MiniDeN, войдите через Telegram. После успешного входа вы будете перенаправлены в профиль (profile.html), где увидите ваши заказы, корзину и курсы.
       </p>
-      <p style="margin-top:8px;">
-        <a class="btn" id="bot-link-hero" href="https://t.me/BotMiniden_bot" target="_blank" rel="noopener">
-          Открыть бота MiniDeN
-        </a>
-      </p>
-    </div>
-    <div class="steps" id="how-list">
-      <div class="step"><strong>1) Выберите товар или курс</strong><p>Откройте раздел «Товары» или «Мастер-классы» и найдите то, что подходит именно вам.</p></div>
-      <div class="step"><strong>2) Добавьте в корзину</strong><p>Нажмите «В корзину» на карточке. В демо пока заглушка, позже привяжем API и Telegram-бота.</p></div>
-      <div class="step"><strong>3) Оформите заказ</strong><p>В финальной версии заказ будет уходить в Telegram: бот уточнит детали и поможет оплатить.</p></div>
-    </div>
+      <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
+        <button class="btn" id="btn-login-telegram" type="button">Войти через Telegram</button>
+      </div>
+    </section>
+
+    <section class="section reveal" id="auth-status" style="display: none;">
+      <h2>Вы уже вошли</h2>
+      <p id="auth-username" class="muted"></p>
+      <div class="hero-cta">
+        <a class="btn" href="/profile.html">Перейти в профиль</a>
+        <button class="btn secondary" type="button" id="switch-user-btn">Сменить пользователя</button>
+      </div>
+    </section>
   </main>
 
-  <section class="section" id="home-posts" style="display:none;">
-    <h2>Новости и идеи</h2>
-    <div class="home-posts-grid" id="home-posts-grid"></div>
-    <div class="muted" id="home-posts-empty" style="display:none;">Скоро здесь появятся новости</div>
-  </section>
-
-  <footer>
+  <footer class="reveal">
     <div>
       Готовы помочь в Telegram:
       <a id="bot-link-footer" href="https://t.me/BotMiniden_bot" target="_blank" rel="noopener">бот MiniDeN</a>
@@ -137,30 +153,11 @@
     <div>Мы в соцсетях: <a href="https://www.instagram.com/balabanova_knit?igsh=MWhuMWFnOG8zejl6dQ==">Instagram*</a> • <a href="https://vk.com/club233836469">VK</a></div>
   </footer>
 
-  <section class="section" id="telegram-login-section">
-    <h2>Вход через Telegram</h2>
-    <p>
-      Чтобы синхронизировать корзину и профиль с ботом MiniDeN, войдите через Telegram. После успешного входа вы будете перенаправлены в профиль (profile.html), где увидите ваши заказы, корзину и курсы.
-    </p>
-    <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
-      <button class="btn" id="btn-login-telegram" type="button">Войти через Telegram</button>
-    </div>
-  </section>
-
-  <section class="section" id="auth-status" style="display: none;">
-    <h2>Вы уже вошли</h2>
-    <p id="auth-username" class="muted"></p>
-    <div class="hero-cta">
-      <a class="btn" href="/profile.html">Перейти в профиль</a>
-      <button class="btn secondary" type="button" id="switch-user-btn">Сменить пользователя</button>
-    </div>
-  </section>
-
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="js/app.js?v=20250521"></script>
-  <script src="js/api.js?v=20250521"></script>
-  <script src="js/home_page.js?v=20250521"></script>
-  <script src="js/support_widget.js?v=20250521" defer></script>
+  <script src="js/app.js?v=20250605"></script>
+  <script src="js/api.js?v=20250605"></script>
+  <script src="js/home_page.js?v=20250605"></script>
+  <script src="js/support_widget.js?v=20250605" defer></script>
   <script>
     const loginSection = document.getElementById('telegram-login-section');
     const authStatus = document.getElementById('auth-status');

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -1,6 +1,6 @@
 const THEME_KEY = 'miniden.theme';
-const DEFAULT_THEME = 'purple';
-const AVAILABLE_THEMES = ['purple', 'dark', 'light', 'cream'];
+const DEFAULT_THEME = 'lifestyle';
+const AVAILABLE_THEMES = ['lifestyle', 'purple', 'dark', 'light', 'cream'];
 
 function applyTheme(theme) {
   const value = AVAILABLE_THEMES.includes(theme) ? theme : DEFAULT_THEME;

--- a/webapp/masterclass.html
+++ b/webapp/masterclass.html
@@ -7,15 +7,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20250521" />
+  <link rel="stylesheet" href="css/theme.css?v=20250605" />
 </head>
-<body data-theme="purple" class="page-masterclass">
+<body data-theme="lifestyle" class="page-masterclass">
   <header class="top-nav">
     <div class="brand">MiniDeN<span>уютные корзинки и мастер-классы</span></div>
     <div class="header-actions">
       <div class="theme-switcher">
         <label for="theme-select">Тема</label>
         <select id="theme-select">
+          <option value="lifestyle">Lifestyle</option>
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
@@ -25,6 +26,10 @@
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
     </div>
     <nav class="nav-links app-sidebar">
+      <div class="sidebar-brand">
+        <strong>Miniden</strong>
+        <span>уют, семья, вязание</span>
+      </div>
       <a href="index.html">Главная</a>
       <a href="products.html">Товары</a>
       <a href="masterclasses.html" class="active">Мастер-классы</a>
@@ -42,9 +47,9 @@
     <div id="masterclass-reviews-root"></div>
   </main>
 
-  <script src="js/app.js?v=20250521"></script>
-  <script src="js/api.js?v=20250521"></script>
-  <script src="js/reviews_widget.js?v=20250521"></script>
-  <script src="js/masterclass_page.js?v=20250521"></script>
+  <script src="js/app.js?v=20250605"></script>
+  <script src="js/api.js?v=20250605"></script>
+  <script src="js/reviews_widget.js?v=20250605"></script>
+  <script src="js/masterclass_page.js?v=20250605"></script>
 </body>
 </html>

--- a/webapp/masterclasses.html
+++ b/webapp/masterclasses.html
@@ -7,17 +7,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20250521" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
+  <link rel="stylesheet" href="css/theme.css?v=20250605" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250605" />
 
 </head>
-<body data-theme="purple" class="page-masterclasses">
+<body data-theme="lifestyle" class="page-masterclasses">
   <header class="top-nav">
     <div class="brand">MiniDeN<span>уютные корзинки и мастер-классы</span></div>
     <div class="header-actions">
       <div class="theme-switcher">
         <label for="theme-select">Тема</label>
         <select id="theme-select">
+          <option value="lifestyle">Lifestyle</option>
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
@@ -27,6 +28,10 @@
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
     </div>
     <nav class="nav-links app-sidebar">
+      <div class="sidebar-brand">
+        <strong>Miniden</strong>
+        <span>уют, семья, вязание</span>
+      </div>
       <a href="index.html">Главная</a>
       <a href="products.html">Товары</a>
       <a href="masterclasses.html" class="active">Мастер-классы</a>
@@ -66,9 +71,9 @@
     <div class="note" id="note"></div>
   </main>
 
-  <script src="js/app.js?v=20250521"></script>
-  <script src="js/api.js?v=20250521"></script>
-  <script src="js/masterclasses_page.js?v=20250521"></script>
-  <script src="js/support_widget.js?v=20250521" defer></script>
+  <script src="js/app.js?v=20250605"></script>
+  <script src="js/api.js?v=20250605"></script>
+  <script src="js/masterclasses_page.js?v=20250605"></script>
+  <script src="js/support_widget.js?v=20250605" defer></script>
 </body>
 </html>

--- a/webapp/product.html
+++ b/webapp/product.html
@@ -7,15 +7,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20250521" />
+  <link rel="stylesheet" href="css/theme.css?v=20250605" />
 </head>
-<body data-theme="purple" class="page-product">
+<body data-theme="lifestyle" class="page-product">
   <header class="top-nav">
     <div class="brand">MiniDeN<span>уютные корзинки и мастер-классы</span></div>
     <div class="header-actions">
       <div class="theme-switcher">
         <label for="theme-select">Тема</label>
         <select id="theme-select">
+          <option value="lifestyle">Lifestyle</option>
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
@@ -25,6 +26,10 @@
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
     </div>
     <nav class="nav-links app-sidebar">
+      <div class="sidebar-brand">
+        <strong>Miniden</strong>
+        <span>уют, семья, вязание</span>
+      </div>
       <a href="index.html">Главная</a>
       <a href="products.html" class="active">Товары</a>
       <a href="masterclasses.html">Мастер-классы</a>
@@ -42,9 +47,9 @@
     <div id="product-reviews-root"></div>
   </main>
 
-  <script src="js/app.js?v=20250521"></script>
-  <script src="js/api.js?v=20250521"></script>
-  <script src="js/reviews_widget.js?v=20250521"></script>
-  <script src="js/product_page.js?v=20250521"></script>
+  <script src="js/app.js?v=20250605"></script>
+  <script src="js/api.js?v=20250605"></script>
+  <script src="js/reviews_widget.js?v=20250605"></script>
+  <script src="js/product_page.js?v=20250605"></script>
 </body>
 </html>

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -7,17 +7,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20250521" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
+  <link rel="stylesheet" href="css/theme.css?v=20250605" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250605" />
 
 </head>
-<body data-theme="purple" class="page-products">
+<body data-theme="lifestyle" class="page-products">
   <header class="top-nav">
     <div class="brand">MiniDeN<span>уютные корзинки и мастер-классы</span></div>
     <div class="header-actions">
       <div class="theme-switcher">
         <label for="theme-select">Тема</label>
         <select id="theme-select">
+          <option value="lifestyle">Lifestyle</option>
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
@@ -27,6 +28,10 @@
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
     </div>
     <nav class="nav-links app-sidebar">
+      <div class="sidebar-brand">
+        <strong>Miniden</strong>
+        <span>уют, семья, вязание</span>
+      </div>
       <a href="index.html">Главная</a>
       <a href="products.html" class="active">Товары</a>
       <a href="masterclasses.html">Мастер-классы</a>
@@ -155,9 +160,9 @@
       </div>
     </div>
 
-    <script src="js/app.js?v=20250521"></script>
-    <script src="js/api.js?v=20250521"></script>
-    <script src="js/support_widget.js?v=20250521" defer></script>
+    <script src="js/app.js?v=20250605"></script>
+    <script src="js/api.js?v=20250605"></script>
+    <script src="js/support_widget.js?v=20250605" defer></script>
   <script>
     const adminLink = document.getElementById('admin-link');
     const noteEl = document.getElementById('note');

--- a/webapp/profile.html
+++ b/webapp/profile.html
@@ -7,17 +7,18 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="css/theme.css?v=20250521" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250521" />
+  <link rel="stylesheet" href="css/theme.css?v=20250605" />
+  <link rel="stylesheet" href="css/support_widget.css?v=20250605" />
 
 </head>
-<body data-theme="purple" class="page-profile">
+<body data-theme="lifestyle" class="page-profile">
   <header class="top-nav">
     <div class="brand">MiniDeN<span>уютные корзинки и мастер-классы</span></div>
     <div class="header-actions">
       <div class="theme-switcher">
         <label for="theme-select">Тема</label>
         <select id="theme-select">
+          <option value="lifestyle">Lifestyle</option>
           <option value="purple">Фиолетовая</option>
           <option value="dark">Тёмная</option>
           <option value="light">Светлая</option>
@@ -27,6 +28,10 @@
       <button class="menu-toggle" aria-label="Открыть меню">☰</button>
     </div>
     <nav class="nav-links app-sidebar">
+      <div class="sidebar-brand">
+        <strong>Miniden</strong>
+        <span>уют, семья, вязание</span>
+      </div>
       <a href="index.html">Главная</a>
       <a href="products.html">Товары</a>
       <a href="masterclasses.html">Мастер-классы</a>
@@ -104,8 +109,8 @@
   </div>
 
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="js/app.js?v=20250521"></script>
-  <script src="js/api.js?v=20250521"></script>
+  <script src="js/app.js?v=20250605"></script>
+  <script src="js/api.js?v=20250605"></script>
   <script>
     const statusEl = document.getElementById('status');
     const loginHint = document.getElementById('login-hint');
@@ -548,7 +553,7 @@
       await loadProfileData();
     });
   </script>
-  <script src="js/support_widget.js?v=20250521" defer></script>
+  <script src="js/support_widget.js?v=20250605" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the new "Lifestyle" theme palette and update shared navigation styling
- redesign the homepage with lifestyle hero, visual grid, story strip, and softer CTA sections
- refresh theme selector options across pages to adopt the new look and animations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d2790ee908326a7c54048775740fe)