### PR TITLE
Add shared base layout for webapp pages

### DIFF
--- a/webapp/base.html
+++ b/webapp/base.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% block title %}MiniDeN{% endblock %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="icon" id="site-favicon" href="/favicon.ico" />
+  <link rel="stylesheet" href="/css/theme.css?v=20251218" />
+  <link rel="stylesheet" href="/css/support_widget.css?v=20250610" />
+  {% block extra_head %}{% endblock %}
+</head>
+<body data-theme="{{ body_theme | default('lifestyle') }}" class="{{ body_class | default('') }}">
+  {% include "components/header.html" %}
+
+  <div class="app-sidebar-overlay"></div>
+  <div id="toast-container"></div>
+
+  {% block breadcrumbs %}
+    {% set breadcrumbs_id = breadcrumbs_id | default('breadcrumbs') %}
+    {% include "components/breadcrumbs.html" %}
+  {% endblock %}
+
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+
+  {% block after_main %}{% endblock %}
+
+  {% block footer %}{% endblock %}
+
+  <script src="/js/app.js?v=20251218"></script>
+  <script src="/js/api.js?v=20250610"></script>
+  <script src="/js/app_shell.js?v=20251220"></script>
+  <script src="/js/support_widget.js?v=20250610" defer></script>
+  {% block extra_scripts %}{% endblock %}
+</body>
+</html>

--- a/webapp/categories.html
+++ b/webapp/categories.html
@@ -1,82 +1,27 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>MiniDeN — Категории</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="icon" id="site-favicon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/theme.css?v=20251218" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250605" />
-</head>
-<body data-theme="lifestyle" class="page-categories">
-  <header class="top-nav">
-    <div class="brand" data-branding-block>
-      <div class="brand__logo-wrapper">
-        <img data-branding-logo class="brand__logo" alt="Логотип MiniDeN" />
-      </div>
-      <div class="brand__text">
-        <div class="brand__title" data-branding-title data-branding-default="MiniDeN">MiniDeN</div>
-        <span data-branding-tagline>уютные корзинки и мастер-классы</span>
-      </div>
-    </div>
-    <div class="header-actions">
-      <div class="theme-switcher">
-        <label for="theme-select">Тема</label>
-        <select id="theme-select">
-          <option value="lifestyle">Lifestyle</option>
-          <option value="purple">Фиолетовая</option>
-          <option value="dark">Тёмная</option>
-          <option value="light">Светлая</option>
-          <option value="cream">Сливочная</option>
-        </select>
-      </div>
-      <button class="menu-toggle" aria-label="Открыть меню">☰</button>
-    </div>
-    <nav class="nav-links app-sidebar">
-      <div class="sidebar-brand" data-branding-block>
-        <div class="brand__logo-wrapper brand__logo-wrapper--sidebar">
-          <img data-branding-logo class="brand__logo brand__logo--sidebar" alt="Логотип MiniDeN" />
-        </div>
-        <div class="brand__text">
-          <strong data-branding-title data-branding-default="Miniden">Miniden</strong>
-          <span data-branding-tagline>уют, семья, вязание</span>
-        </div>
-      </div>
-      <a href="index.html">Главная</a>
-      <a href="/categories" class="active">Категории</a>
-      <a href="products.html">Товары</a>
-      <a href="masterclasses.html">Мастер-классы</a>
-      <a href="cart.html">Корзина</a>
-      <a href="profile.html">Профиль</a>
-      <a href="admin.html" id="admin-link" style="display:none;">Админка</a>
-    </nav>
-  </header>
+{% extends "base.html" %}
+{% set active_page = 'categories' %}
+{% set body_class = 'page-categories' %}
 
-  <div class="app-sidebar-overlay"></div>
-  <div id="toast-container"></div>
+{% block title %}MiniDeN — Категории{% endblock %}
 
-  <main>
-    <div class="breadcrumbs">
-      <a href="/">Главная</a>
-      <span>→</span>
-      <span>Категории</span>
-    </div>
-    <h1>Направления MiniDeN</h1>
-    <p id="categories-note" class="muted">Категории помогают быстро перейти к подходящим корзинкам и урокам.</p>
+{% block breadcrumbs %}
+  {% set breadcrumbs_items = [
+    { 'label': 'Главная', 'url': '/' },
+    { 'label': 'Категории' }
+  ] %}
+  {% include 'components/breadcrumbs.html' %}
+{% endblock %}
 
-    <div id="categories-grid" class="category-grid"></div>
-    <div id="categories-empty" class="category-layout__empty" style="display:none;">
-      Пока нет активных категорий. Добавьте их через админку.
-    </div>
-  </main>
+{% block content %}
+  <h1>Направления MiniDeN</h1>
+  <p id="categories-note" class="muted">Категории помогают быстро перейти к подходящим корзинкам и урокам.</p>
 
-  <script src="js/app.js?v=20251218"></script>
-  <script src="js/api.js?v=20250605"></script>
-  <script src="js/app_shell.js?v=20251220"></script>
-  <script src="js/categories_page.js?v=20250605"></script>
-  <script src="js/support_widget.js?v=20250605" defer></script>
-</body>
-</html>
+  <div id="categories-grid" class="category-grid"></div>
+  <div id="categories-empty" class="category-layout__empty" style="display:none;">
+    Пока нет активных категорий. Добавьте их через админку.
+  </div>
+{% endblock %}
+
+{% block extra_scripts %}
+  <script src="/js/categories_page.js?v=20250605"></script>
+{% endblock %}

--- a/webapp/category.html
+++ b/webapp/category.html
@@ -1,86 +1,31 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>MiniDeN — Категория</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="icon" id="site-favicon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/theme.css?v=20251218" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250605" />
-</head>
-<body data-theme="lifestyle" class="page-category">
-  <header class="top-nav">
-    <div class="brand" data-branding-block>
-      <div class="brand__logo-wrapper">
-        <img data-branding-logo class="brand__logo" alt="Логотип MiniDeN" />
-      </div>
-      <div class="brand__text">
-        <div class="brand__title" data-branding-title data-branding-default="MiniDeN">MiniDeN</div>
-        <span data-branding-tagline>уютные корзинки и мастер-классы</span>
-      </div>
+{% extends "base.html" %}
+{% set active_page = 'category' %}
+{% set body_class = 'page-category' %}
+
+{% block title %}MiniDeN — Категория{% endblock %}
+
+{% block breadcrumbs %}
+  {% set breadcrumbs_id = 'category-breadcrumbs' %}
+  {% include 'components/breadcrumbs.html' %}
+{% endblock %}
+
+{% block content %}
+  <section class="category-hero">
+    <div class="category-hero__content">
+      <h1 id="category-title">Категория</h1>
+      <p id="category-description" class="muted">Описание появится позже.</p>
     </div>
-    <div class="header-actions">
-      <div class="theme-switcher">
-        <label for="theme-select">Тема</label>
-        <select id="theme-select">
-          <option value="lifestyle">Lifestyle</option>
-          <option value="purple">Фиолетовая</option>
-          <option value="dark">Тёмная</option>
-          <option value="light">Светлая</option>
-          <option value="cream">Сливочная</option>
-        </select>
-      </div>
-      <button class="menu-toggle" aria-label="Открыть меню">☰</button>
+    <div class="category-hero__image">
+      <img id="category-image" alt="" />
     </div>
-    <nav class="nav-links app-sidebar">
-      <div class="sidebar-brand" data-branding-block>
-        <div class="brand__logo-wrapper brand__logo-wrapper--sidebar">
-          <img data-branding-logo class="brand__logo brand__logo--sidebar" alt="Логотип MiniDeN" />
-        </div>
-        <div class="brand__text">
-          <strong data-branding-title data-branding-default="Miniden">Miniden</strong>
-          <span data-branding-tagline>уют, семья, вязание</span>
-        </div>
-      </div>
-      <a href="index.html">Главная</a>
-      <a href="/categories" class="active">Категории</a>
-      <a href="products.html">Товары</a>
-      <a href="masterclasses.html">Мастер-классы</a>
-      <a href="cart.html">Корзина</a>
-      <a href="profile.html">Профиль</a>
-      <a href="admin.html" id="admin-link" style="display:none;">Админка</a>
-    </nav>
-  </header>
+  </section>
 
-  <div class="app-sidebar-overlay"></div>
-  <div id="toast-container"></div>
+  <div id="category-note" class="muted" style="margin-bottom:16px;"></div>
 
-  <main>
-    <div class="breadcrumbs" id="category-breadcrumbs"></div>
+  <section id="category-products"></section>
+  <section id="category-masterclasses"></section>
+{% endblock %}
 
-    <section class="category-hero">
-      <div class="category-hero__content">
-        <h1 id="category-title">Категория</h1>
-        <p id="category-description" class="muted">Описание появится позже.</p>
-      </div>
-      <div class="category-hero__image">
-        <img id="category-image" alt="" />
-      </div>
-    </section>
-
-    <div id="category-note" class="muted" style="margin-bottom:16px;"></div>
-
-    <section id="category-products"></section>
-    <section id="category-masterclasses"></section>
-  </main>
-
-  <script src="js/app.js?v=20251218"></script>
-  <script src="js/api.js?v=20250605"></script>
-  <script src="js/app_shell.js?v=20251220"></script>
-  <script src="js/category_page.js?v=20250605"></script>
-  <script src="js/support_widget.js?v=20250605" defer></script>
-</body>
-</html>
+{% block extra_scripts %}
+  <script src="/js/category_page.js?v=20250605"></script>
+{% endblock %}

--- a/webapp/components/breadcrumbs.html
+++ b/webapp/components/breadcrumbs.html
@@ -1,0 +1,13 @@
+{% set breadcrumbs_list = breadcrumbs_items | default([]) %}
+<div class="breadcrumbs" id="{{ breadcrumbs_id | default('breadcrumbs') }}">
+  {% if breadcrumbs_list %}
+    {% for item in breadcrumbs_list %}
+      {% if item.url %}
+        <a href="{{ item.url }}">{{ item.label }}</a>
+      {% else %}
+        <span>{{ item.label }}</span>
+      {% endif %}
+      {% if not loop.last %}<span>→</span>{% endif %}
+    {% endfor %}
+  {% endif %}
+</div>

--- a/webapp/components/header.html
+++ b/webapp/components/header.html
@@ -1,0 +1,43 @@
+{% set current_page = active_page | default('') %}
+<header class="top-nav">
+  <div class="brand" data-branding-block>
+    <div class="brand__logo-wrapper">
+      <img data-branding-logo class="brand__logo" alt="Логотип MiniDeN" />
+    </div>
+    <div class="brand__text">
+      <div class="brand__title" data-branding-title data-branding-default="MiniDeN">MiniDeN</div>
+      <span data-branding-tagline>уютные корзинки и мастер-классы</span>
+    </div>
+  </div>
+  <div class="header-actions">
+    <div class="theme-switcher">
+      <label for="theme-select">Тема</label>
+      <select id="theme-select">
+        <option value="lifestyle">Lifestyle</option>
+        <option value="purple">Фиолетовая</option>
+        <option value="dark">Тёмная</option>
+        <option value="light">Светлая</option>
+        <option value="cream">Сливочная</option>
+      </select>
+    </div>
+    <button class="menu-toggle" aria-label="Открыть меню">☰</button>
+  </div>
+  <nav class="nav-links app-sidebar">
+    <div class="sidebar-brand" data-branding-block>
+      <div class="brand__logo-wrapper brand__logo-wrapper--sidebar">
+        <img data-branding-logo class="brand__logo brand__logo--sidebar" alt="Логотип MiniDeN" />
+      </div>
+      <div class="brand__text">
+        <strong data-branding-title data-branding-default="Miniden">Miniden</strong>
+        <span data-branding-tagline>уют, семья, вязание</span>
+      </div>
+    </div>
+    <a href="/" class="{% if current_page == 'home' %}active{% endif %}">Главная</a>
+    <a href="/categories" class="{% if current_page in ['categories', 'category'] %}active{% endif %}">Категории</a>
+    <a href="/products.html" class="{% if current_page == 'products' %}active{% endif %}">Товары</a>
+    <a href="/masterclasses.html">Мастер-классы</a>
+    <a href="/cart.html">Корзина</a>
+    <a href="/profile.html">Профиль</a>
+    <a href="/admin.html" id="admin-link" style="display:none;">Админка</a>
+  </nav>
+</header>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,66 +1,18 @@
-<!-- Обновляйте номер версии (?v=20241205) в ссылках на js/css после любых правок фронтенда, чтобы сбрасывать кэш в браузерах. -->
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>MiniDeN — уютные корзинки и мастер-классы</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="icon" id="site-favicon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/theme.css?v=20251218" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250610" />
-</head>
-<body data-theme="lifestyle" class="page-index">
-  <header class="top-nav">
-    <div class="brand" data-branding-block>
-      <div class="brand__logo-wrapper">
-        <img data-branding-logo class="brand__logo" alt="Логотип MiniDeN" />
-      </div>
-      <div class="brand__text">
-        <div class="brand__title" data-branding-title data-branding-default="MiniDeN">MiniDeN</div>
-        <span data-branding-tagline>уютные корзинки и мастер-классы</span>
-      </div>
-    </div>
-    <div class="header-actions">
-      <div class="theme-switcher">
-        <label for="theme-select">Тема</label>
-        <select id="theme-select">
-          <option value="lifestyle">Lifestyle</option>
-          <option value="purple">Фиолетовая</option>
-          <option value="dark">Тёмная</option>
-          <option value="light">Светлая</option>
-          <option value="cream">Сливочная</option>
-        </select>
-      </div>
-      <button class="menu-toggle" aria-label="Открыть меню">☰</button>
-    </div>
-    <nav class="nav-links app-sidebar">
-      <div class="sidebar-brand" data-branding-block>
-        <div class="brand__logo-wrapper brand__logo-wrapper--sidebar">
-          <img data-branding-logo class="brand__logo brand__logo--sidebar" alt="Логотип MiniDeN" />
-        </div>
-        <div class="brand__text">
-          <strong data-branding-title data-branding-default="Miniden">Miniden</strong>
-          <span data-branding-tagline>уют, семья, вязание</span>
-        </div>
-      </div>
-      <a href="index.html" class="active">Главная</a>
-      <a href="/categories">Категории</a>
-      <a href="products.html">Товары</a>
-      <a href="masterclasses.html">Мастер-классы</a>
-      <a href="cart.html">Корзина</a>
-      <a href="profile.html">Профиль</a>
-      <a href="admin.html" id="admin-link" style="display:none;">Админка</a>
-    </nav>
-  </header>
+{% extends "base.html" %}
+{% set active_page = 'home' %}
+{% set body_class = 'page-index' %}
 
-  <div class="app-sidebar-overlay"></div>
-  <div id="toast-container"></div>
+{% block title %}MiniDeN — уютные корзинки и мастер-классы{% endblock %}
 
-  <main>
-    <section class="lifestyle-hero reveal">
+{% block breadcrumbs %}
+  {% set breadcrumbs_id = 'home-breadcrumbs' %}
+  {% set breadcrumbs_items = [{'label': 'Главная'}] %}
+  {% include 'components/breadcrumbs.html' %}
+{% endblock %}
+
+{% block content %}
+  <!-- Обновляйте номер версии (?v=20241205) в ссылках на js/css после любых правок фронтенда, чтобы сбрасывать кэш в браузерах. -->
+  <section class="lifestyle-hero reveal">
       <div class="hero-body">
         <span class="hero-eyebrow">Miniden • домашнее вязание</span>
         <h1 class="hero-title">Дом, который вяжется руками</h1>
@@ -95,7 +47,7 @@
         />
         <span>Процесс</span>
       </a>
-      <a class="visual-tile hover-lift" href="products.html" id="tile-baskets">
+      <a class="visual-tile hover-lift" href="/products.html" id="tile-baskets">
         <img
           src="/static/img/home-placeholder.svg"
           data-fallback="/static/img/home-placeholder.svg"
@@ -103,7 +55,7 @@
         />
         <span>Мои корзинки</span>
       </a>
-      <a class="visual-tile hover-lift" href="masterclasses.html" id="tile-learning">
+      <a class="visual-tile hover-lift" href="/masterclasses.html" id="tile-learning">
         <img
           src="/static/img/home-placeholder.svg"
           data-fallback="/static/img/home-placeholder.svg"
@@ -136,7 +88,7 @@
       <div>
         <h3>Корзинки и наборы</h3>
         <p>Небольшие вещи, которые собирают дом воедино: органайзеры, подарочные композиции и акценты для детских комнат.</p>
-        <a class="btn" href="products.html">Перейти в каталог</a>
+        <a class="btn" href="/products.html">Перейти в каталог</a>
       </div>
       <div class="cta-card__media">
         <img
@@ -158,7 +110,7 @@
       <div>
         <h3>Мастер-классы</h3>
         <p>Для тех, кто хочет начать и дойти до результата. Простые шаги, поддержка и вдохновение, чтобы связать своё первое изделие.</p>
-        <a class="btn secondary" href="masterclasses.html">Смотреть обучение</a>
+        <a class="btn secondary" href="/masterclasses.html">Смотреть обучение</a>
       </div>
     </section>
 
@@ -186,8 +138,9 @@
         <button class="btn secondary" type="button" id="switch-user-btn">Сменить пользователя</button>
       </div>
     </section>
-  </main>
+{% endblock %}
 
+{% block footer %}
   <footer class="reveal">
     <div>
       Готовы помочь в Telegram:
@@ -199,12 +152,9 @@
     </div>
     <div>Мы в соцсетях: <a href="https://www.instagram.com/balabanova_knit?igsh=MWhuMWFnOG8zejl6dQ==">Instagram*</a> • <a href="https://vk.com/club233836469">VK</a></div>
   </footer>
+{% endblock %}
 
+{% block extra_scripts %}
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="js/app.js?v=20251218"></script>
-  <script src="js/api.js?v=20250610"></script>
-  <script src="js/app_shell.js?v=20251220"></script>
-  <script src="js/home_page.js?v=20250610"></script>
-  <script src="js/support_widget.js?v=20250610" defer></script>
-</body>
-</html>
+  <script src="/js/home_page.js?v=20250610"></script>
+{% endblock %}

--- a/webapp/products.html
+++ b/webapp/products.html
@@ -1,66 +1,19 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>MiniDeN — Товары</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
-  <link rel="icon" id="site-favicon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/theme.css?v=20251218" />
-  <link rel="stylesheet" href="css/support_widget.css?v=20250605" />
+{% extends "base.html" %}
+{% set active_page = 'products' %}
+{% set body_class = 'page-products' %}
 
-</head>
-<body data-theme="lifestyle" class="page-products">
-  <header class="top-nav">
-    <div class="brand" data-branding-block>
-      <div class="brand__logo-wrapper">
-        <img data-branding-logo class="brand__logo" alt="Логотип MiniDeN" />
-      </div>
-      <div class="brand__text">
-        <div class="brand__title" data-branding-title data-branding-default="MiniDeN">MiniDeN</div>
-        <span data-branding-tagline>уютные корзинки и мастер-классы</span>
-      </div>
-    </div>
-    <div class="header-actions">
-      <div class="theme-switcher">
-        <label for="theme-select">Тема</label>
-        <select id="theme-select">
-          <option value="lifestyle">Lifestyle</option>
-          <option value="purple">Фиолетовая</option>
-          <option value="dark">Тёмная</option>
-          <option value="light">Светлая</option>
-          <option value="cream">Сливочная</option>
-        </select>
-      </div>
-      <button class="menu-toggle" aria-label="Открыть меню">☰</button>
-    </div>
-    <nav class="nav-links app-sidebar">
-      <div class="sidebar-brand" data-branding-block>
-        <div class="brand__logo-wrapper brand__logo-wrapper--sidebar">
-          <img data-branding-logo class="brand__logo brand__logo--sidebar" alt="Логотип MiniDeN" />
-        </div>
-        <div class="brand__text">
-          <strong data-branding-title data-branding-default="Miniden">Miniden</strong>
-          <span data-branding-tagline>уют, семья, вязание</span>
-        </div>
-      </div>
-      <a href="index.html">Главная</a>
-      <a href="/categories">Категории</a>
-      <a href="products.html" class="active">Товары</a>
-      <a href="masterclasses.html">Мастер-классы</a>
-      <a href="cart.html">Корзина</a>
-      <a href="profile.html">Профиль</a>
-      <a href="admin.html" id="admin-link" style="display:none;">Админка</a>
-    </nav>
-  </header>
+{% block title %}MiniDeN — Товары{% endblock %}
 
-  <div class="app-sidebar-overlay"></div>
-  <div id="toast-container"></div>
+{% block breadcrumbs %}
+  {% set breadcrumbs_items = [
+    { 'label': 'Главная', 'url': '/' },
+    { 'label': 'Товары' }
+  ] %}
+  {% include 'components/breadcrumbs.html' %}
+{% endblock %}
 
-  <main>
-    <h1>Товары</h1>
+{% block content %}
+<h1>Товары</h1>
 
     <section class="products-search">
       <label for="product-search-input">Поиск по товарам</label>
@@ -83,9 +36,10 @@
     <section id="products-by-category" class="products-by-category"></section>
 
     <div class="note" id="note"></div>
-  </main>
+{% endblock %}
 
-    <div id="product-modal" class="product-modal hidden" aria-hidden="true">
+{% block after_main %}
+<div id="product-modal" class="product-modal hidden" aria-hidden="true">
     <div class="product-modal__backdrop" id="product-modal-backdrop"></div>
     <div class="product-modal__content" role="dialog" aria-modal="true">
       <button class="product-modal__close" type="button" id="product-modal-close" aria-label="Закрыть">×</button>
@@ -174,13 +128,11 @@
         <img class="review-photo-modal__image" id="review-photo-modal-image" src="" alt="" />
       </div>
     </div>
+{% endblock %}
 
-    <script src="js/app.js?v=20251218"></script>
-    <script src="js/api.js?v=20250605"></script>
-    <script src="js/app_shell.js?v=20251220"></script>
-    <script src="js/support_widget.js?v=20250605" defer></script>
+{% block extra_scripts %}
   <script>
-    const adminLink = document.getElementById('admin-link');
+const adminLink = document.getElementById('admin-link');
     const noteEl = document.getElementById('note');
     const productsByCategoryEl = document.getElementById('products-by-category');
     const categoriesNavEl = document.getElementById('products-categories-nav');
@@ -1144,5 +1096,4 @@
 
     initProductsPage().catch(console.error);
   </script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable base.html with shared assets, layout, and absolute static paths
- extract the navigation header and breadcrumbs into dedicated components
- update index, categories, category, and products pages to extend the base template and share consistent chrome

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444cb68fa08326a8707a131f0edb27)