### PR TITLE
Add safeguards for admin static assets

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,24 @@ MiniDeN — Telegram-бот и веб-магазин
 - Веб-админка (`webapp/admin.html`): позволяет из браузера управлять товарами, мастер-классами и промокодами (создание, редактирование, загрузка фото, переключение активности) через WebApp сайта (miniden.ru/webapp).
 - Legacy shim (`main.py`): прокидывает `app` из `webapi.py` для обратной совместимости; в продакшене запускать `uvicorn webapi:app`.
 
+Запуск backend (FastAPI)
+------------------------
+- cd /opt/miniden
+- source venv/bin/activate
+- pip install -r requirements.txt
+- uvicorn webapi:app --host 0.0.0.0 --port 8000
+- НЕ запускать `python api/main.py` — это legacy shim.
+
+Проверка админок
+----------------
+- /adminbot/login
+- /adminsite/login
+
+Частые ошибки
+-------------
+- Если приложение ругается на static — убедитесь, что существует `admin_panel/static`; при запуске папки создаются автоматически.
+- Если приложение сообщает об отсутствии jinja2 — установите зависимости командой `pip install -r requirements.txt`.
+
 Фронтенд-оболочка
 ------------------
 - Заголовок, переключатель темы и отображение ссылки «Админка» и статуса авторизации вынесены в общий файл `webapp/js/app_shell.js`.

--- a/admin_panel/__init__.py
+++ b/admin_panel/__init__.py
@@ -2,6 +2,11 @@
 
 from pathlib import Path
 
+try:
+    import jinja2  # noqa: F401
+except ImportError as import_error:  # pragma: no cover - defensive guard
+    raise ImportError("Jinja2Templates requires jinja2. Install it via `pip install jinja2`.") from import_error
+
 from fastapi.templating import Jinja2Templates
 
 BASE_DIR = Path(__file__).resolve().parent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiogram>=3
 fastapi
+jinja2>=3.1
 python-multipart>=0.0.9
 uvicorn[standard]
 sqlalchemy

--- a/webapi.py
+++ b/webapi.py
@@ -140,8 +140,28 @@ def ensure_media_dirs() -> None:
         d.mkdir(parents=True, exist_ok=True)
 
 
+def ensure_admin_static_dirs() -> bool:
+    try:
+        STATIC_DIR.mkdir(parents=True, exist_ok=True)
+        (STATIC_DIR / "css").mkdir(parents=True, exist_ok=True)
+        (STATIC_DIR / "js").mkdir(parents=True, exist_ok=True)
+        (STATIC_DIR / "img").mkdir(parents=True, exist_ok=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Admin static directory is unavailable, skipping mount: %s", exc
+        )
+        return False
+
+    return True
+
+
 app.mount("/media", StaticFiles(directory=MEDIA_ROOT), name="media")
-app.mount("/admin/static", StaticFiles(directory=STATIC_DIR), name="admin-static")
+if ensure_admin_static_dirs():
+    app.mount("/admin/static", StaticFiles(directory=STATIC_DIR), name="admin-static")
+else:  # pragma: no cover - defensive
+    logger.warning(
+        "Admin static will not be served because the directory is missing or unreadable."
+    )
 app.include_router(adminbot.router)
 app.include_router(adminsite.router)
 


### PR DESCRIPTION
## Summary
- ensure admin panel static directories are present or gracefully skipped during startup
- add explicit jinja2 dependency and import guard for admin templates
- document backend startup commands and admin URLs and include static placeholder for Git

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446166216c8326818652adfdafbc29)