### PR TITLE
Fix homepage rendering and add deployment config

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,48 @@
+# MiniDeN deployment runbook
+
+## Services and entrypoints
+- Backend app: `webapi:app` (FastAPI), launched by `uvicorn`.
+- Systemd unit template: `deploy/miniden-api.service`.
+- Nginx config template: `deploy/miniden-nginx.conf`.
+
+## Deploy / update steps
+1. Upload the repository to `/opt/miniden` on the server (including updated templates and static files).
+2. Install dependencies in the project virtualenv if needed:
+   ```bash
+   cd /opt/miniden
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+3. Update the systemd unit (first time or after edits):
+   ```bash
+   sudo cp /opt/miniden/deploy/miniden-api.service /etc/systemd/system/miniden-api.service
+   sudo systemctl daemon-reload
+   sudo systemctl enable miniden-api.service
+   sudo systemctl restart miniden-api.service
+   ```
+4. Deploy nginx config:
+   ```bash
+   sudo cp /opt/miniden/deploy/miniden-nginx.conf /etc/nginx/sites-available/miniden.conf
+   sudo ln -sf /etc/nginx/sites-available/miniden.conf /etc/nginx/sites-enabled/miniden.conf
+   sudo nginx -t
+   sudo systemctl reload nginx
+   ```
+
+## Post-deploy checks
+Run locally against uvicorn (replace host with domain for live checks):
+- `curl -s http://127.0.0.1:8000/api/health` → `{ "ok": true }`
+- `curl -I http://127.0.0.1:8000/adminbot/login` → HTTP 200
+- `curl -I http://127.0.0.1:8000/` → `Content-Type: text/html`
+
+Through nginx / domain:
+- `curl -I https://miniden.ru/` → HTTP 200, `Content-Type: text/html`
+- `curl -I https://miniden.ru/adminbot/login` → HTTP 200
+
+Services:
+- `sudo systemctl status miniden-api --no-pager -l`
+- `sudo systemctl restart miniden-api`
+- `sudo systemctl reload nginx`
+
+## Notes
+- Static assets are served via nginx aliases for `/static`, `/css`, and `/js` and from uvicorn for dynamic pages.
+- Media uploads are read from `/opt/miniden/media` via nginx `alias /media/` and by FastAPI.

--- a/deploy/miniden-nginx.conf
+++ b/deploy/miniden-nginx.conf
@@ -1,0 +1,48 @@
+server {
+    listen 80;
+    server_name miniden.ru www.miniden.ru;
+
+    client_max_body_size 32m;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_redirect off;
+
+    location /media/ {
+        alias /opt/miniden/media/;
+        add_header Cache-Control "public, max-age=3600";
+    }
+
+    location /adminbot/ {
+        proxy_pass http://127.0.0.1:8000/adminbot/;
+    }
+
+    location /adminsite/ {
+        proxy_pass http://127.0.0.1:8000/adminsite/;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000/api/;
+    }
+
+    location /static/ {
+        alias /opt/miniden/static/;
+        add_header Cache-Control "public, max-age=86400";
+    }
+
+    location /css/ {
+        alias /opt/miniden/webapp/css/;
+        add_header Cache-Control "public, max-age=86400";
+    }
+
+    location /js/ {
+        alias /opt/miniden/webapp/js/;
+        add_header Cache-Control "public, max-age=86400";
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+    }
+}


### PR DESCRIPTION
## Summary
- Serve the site homepage via Jinja templates while keeping the API health check under `/api/health`
- Mount public CSS/JS/static assets so the homepage and AdminBot assets load correctly
- Add nginx config and deployment runbook documenting the `webapi:app` uvicorn entrypoint and service

## Testing
- python -m compileall webapi.py admin_panel


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b0383f888326b5dea2f0df01590b)