### PR TITLE
Добавить поддержку узлов ожидания ввода в AdminBot

### DIFF
--- a/admin_panel/routes/adminbot_nodes.py
+++ b/admin_panel/routes/adminbot_nodes.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, Depends, Form, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
+import re
 
 from admin_panel import TEMPLATES
 from admin_panel.dependencies import get_db_session, require_admin
@@ -14,6 +15,10 @@ router = APIRouter(tags=["AdminBot"])
 
 ALLOWED_ROLES = (AdminRole.superadmin, AdminRole.admin_bot)
 
+NODE_TYPES = {"MESSAGE", "INPUT"}
+INPUT_TYPES = {"TEXT", "NUMBER", "PHONE_TEXT", "CONTACT"}
+INPUT_KEY_REGEX = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]{1,32}$")
+
 
 def _login_redirect(next_url: str | None = None) -> RedirectResponse:
     target = next_url or "/adminbot"
@@ -23,6 +28,71 @@ def _login_redirect(next_url: str | None = None) -> RedirectResponse:
 def _next_from_request(request: Request) -> str:
     query = f"?{request.url.query}" if request.url.query else ""
     return f"{request.url.path}{query}"
+
+
+def _prepare_node_payload(
+    *,
+    title: str,
+    message_text: str,
+    parse_mode: str,
+    image_url: str | None,
+    is_enabled: bool,
+    node_type: str,
+    input_type: str | None,
+    input_var_key: str | None,
+    input_required: bool,
+    input_min_len: int | None,
+    input_error_text: str | None,
+    next_node_code_success: str | None,
+    next_node_code_cancel: str | None,
+) -> tuple[str | None, dict]:
+    normalized_node_type = (node_type or "MESSAGE").strip().upper()
+    normalized_input_type = (input_type or "").strip().upper() or None
+    normalized_var_key = (input_var_key or "").strip() or None
+    normalized_next_success = (next_node_code_success or "").strip() or None
+    normalized_next_cancel = (next_node_code_cancel or "").strip() or None
+
+    if normalized_node_type not in NODE_TYPES:
+        return "Некорректный тип узла", {}
+
+    if normalized_node_type == "INPUT":
+        if normalized_input_type not in INPUT_TYPES:
+            return "Укажите тип ввода", {}
+        if not normalized_var_key or not INPUT_KEY_REGEX.match(normalized_var_key):
+            return "Ключ переменной должен содержать латиницу, цифры и подчёркивание", {}
+        if not normalized_next_success:
+            return "Укажите код узла для перехода при успешном вводе", {}
+
+    payload = {
+        "title": title,
+        "message_text": message_text,
+        "parse_mode": parse_mode or "HTML",
+        "image_url": image_url or None,
+        "is_enabled": is_enabled,
+        "node_type": normalized_node_type,
+        "input_type": normalized_input_type,
+        "input_var_key": normalized_var_key,
+        "input_required": bool(input_required),
+        "input_min_len": input_min_len,
+        "input_error_text": input_error_text or None,
+        "next_node_code_success": normalized_next_success,
+        "next_node_code_cancel": normalized_next_cancel,
+    }
+
+    if normalized_node_type != "INPUT":
+        payload.update(
+            {
+                "input_type": None,
+                "input_var_key": None,
+                "input_required": True,
+                "input_min_len": None,
+                "input_error_text": None,
+                "next_node_code_success": None,
+                "next_node_code_cancel": None,
+            }
+        )
+
+    return None, payload
 
 
 @router.get("/nodes")
@@ -73,6 +143,14 @@ async def create_node(
     parse_mode: str = Form("HTML"),
     image_url: str | None = Form(None),
     is_enabled: bool = Form(False),
+    node_type: str = Form("MESSAGE"),
+    input_type: str | None = Form(None),
+    input_var_key: str | None = Form(None),
+    input_required: bool = Form(True),
+    input_min_len: int | None = Form(None),
+    input_error_text: str | None = Form(None),
+    next_node_code_success: str | None = Form(None),
+    next_node_code_cancel: str | None = Form(None),
     db: Session = Depends(get_db_session),
 ):
     user = require_admin(request, db, roles=ALLOWED_ROLES)
@@ -93,16 +171,36 @@ async def create_node(
             status_code=400,
         )
 
-    db.add(
-        BotNode(
-            code=code,
-            title=title,
-            message_text=message_text,
-            parse_mode=parse_mode or "HTML",
-            image_url=image_url or None,
-            is_enabled=is_enabled,
-        )
+    error, payload = _prepare_node_payload(
+        title=title,
+        message_text=message_text,
+        parse_mode=parse_mode,
+        image_url=image_url,
+        is_enabled=is_enabled,
+        node_type=node_type,
+        input_type=input_type,
+        input_var_key=input_var_key,
+        input_required=input_required,
+        input_min_len=input_min_len,
+        input_error_text=input_error_text,
+        next_node_code_success=next_node_code_success,
+        next_node_code_cancel=next_node_code_cancel,
     )
+
+    if error:
+        draft_node = BotNode(code=code, **payload)
+        return TEMPLATES.TemplateResponse(
+            "adminbot_node_edit.html",
+            {
+                "request": request,
+                "user": user,
+                "node": draft_node,
+                "error": error,
+            },
+            status_code=400,
+        )
+
+    db.add(BotNode(code=code, **payload))
     db.commit()
 
     return RedirectResponse(url="/adminbot/nodes", status_code=303)
@@ -142,6 +240,14 @@ async def edit_node(
     parse_mode: str = Form("HTML"),
     image_url: str | None = Form(None),
     is_enabled: bool = Form(False),
+    node_type: str = Form("MESSAGE"),
+    input_type: str | None = Form(None),
+    input_var_key: str | None = Form(None),
+    input_required: bool = Form(True),
+    input_min_len: int | None = Form(None),
+    input_error_text: str | None = Form(None),
+    next_node_code_success: str | None = Form(None),
+    next_node_code_cancel: str | None = Form(None),
     db: Session = Depends(get_db_session),
 ):
     user = require_admin(request, db, roles=ALLOWED_ROLES)
@@ -152,11 +258,38 @@ async def edit_node(
     if not node:
         return RedirectResponse(url="/adminbot/nodes", status_code=303)
 
-    node.title = title
-    node.message_text = message_text
-    node.parse_mode = parse_mode or "HTML"
-    node.image_url = image_url or None
-    node.is_enabled = is_enabled
+    error, payload = _prepare_node_payload(
+        title=title,
+        message_text=message_text,
+        parse_mode=parse_mode,
+        image_url=image_url,
+        is_enabled=is_enabled,
+        node_type=node_type,
+        input_type=input_type,
+        input_var_key=input_var_key,
+        input_required=input_required,
+        input_min_len=input_min_len,
+        input_error_text=input_error_text,
+        next_node_code_success=next_node_code_success,
+        next_node_code_cancel=next_node_code_cancel,
+    )
+
+    if error:
+        draft_node = BotNode(code=node.code, **payload)
+        draft_node.id = node.id
+        return TEMPLATES.TemplateResponse(
+            "adminbot_node_edit.html",
+            {
+                "request": request,
+                "user": user,
+                "node": draft_node,
+                "error": error,
+            },
+            status_code=400,
+        )
+
+    for field, value in payload.items():
+        setattr(node, field, value)
 
     db.add(node)
     db.commit()

--- a/admin_panel/templates/adminbot_node_edit.html
+++ b/admin_panel/templates/adminbot_node_edit.html
@@ -6,13 +6,17 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 16px; background: #f5f5f5; }
         header { display: flex; gap: 12px; margin-bottom: 16px; }
-        form { background: #fff; padding: 16px; border: 1px solid #cbd5e1; border-radius: 6px; max-width: 800px; }
-        label { display: block; margin-top: 10px; font-weight: bold; }
-        input[type="text"], textarea { width: 100%; padding: 8px; border: 1px solid #cbd5e1; border-radius: 4px; }
+        form { background: #fff; padding: 16px; border: 1px solid #cbd5e1; border-radius: 6px; max-width: 900px; }
+        label { display: block; margin-top: 12px; font-weight: bold; }
+        input[type="text"], input[type="number"], textarea, select { width: 100%; padding: 8px; border: 1px solid #cbd5e1; border-radius: 4px; }
         textarea { min-height: 140px; }
         .actions { margin-top: 16px; display: flex; gap: 8px; }
         .button { padding: 8px 12px; border: none; background: #2563eb; color: #fff; border-radius: 4px; text-decoration: none; cursor: pointer; }
         .error { color: #dc2626; margin-top: 8px; }
+        .hint { color: #475569; font-size: 13px; margin-top: 4px; }
+        .card { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 12px; margin-top: 12px; }
+        .row { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; }
+        .checkbox { display: flex; align-items: center; gap: 8px; margin-top: 12px; }
     </style>
 </head>
 <body>
@@ -23,27 +27,110 @@
 <h2>{% if node %}Редактирование: {{ node.code }}{% else %}Новый узел{% endif %}</h2>
 {% if error %}<div class="error">{{ error }}</div>{% endif %}
 <form method="post" action="{% if node %}/adminbot/nodes/{{ node.id }}/edit{% else %}/adminbot/nodes/new{% endif %}">
-    <label>Code</label>
+    <label>Код узла</label>
     <input type="text" name="code" value="{{ node.code if node else '' }}" {% if node %}readonly{% endif %} required>
 
-    <label>Title</label>
-    <input type="text" name="title" value="{{ node.title if node else '' }}" required>
+    <div class="row">
+        <div>
+            <label>Название</label>
+            <input type="text" name="title" value="{{ node.title if node else '' }}" required>
+        </div>
+        <div>
+            <label>Тип узла</label>
+            <select name="node_type" id="node_type_select">
+                <option value="MESSAGE" {% if node is none or node.node_type == 'MESSAGE' %}selected{% endif %}>Сообщение</option>
+                <option value="INPUT" {% if node and node.node_type == 'INPUT' %}selected{% endif %}>Ожидание ввода</option>
+            </select>
+            <div class="hint">Выберите поведение узла.</div>
+        </div>
+    </div>
 
-    <label>Message text</label>
+    <label>Текст сообщения</label>
     <textarea name="message_text" required>{{ node.message_text if node else '' }}</textarea>
+    <div class="hint">Можно использовать переменные: {{'{{'}}name{{'}}'}}, {{'{{'}}phone{{'}}'}}</div>
 
-    <label>Parse mode</label>
-    <input type="text" name="parse_mode" value="{{ node.parse_mode if node else 'HTML' }}" placeholder="HTML">
+    <div class="row">
+        <div>
+            <label>Parse mode</label>
+            <input type="text" name="parse_mode" value="{{ node.parse_mode if node else 'HTML' }}" placeholder="HTML">
+        </div>
+        <div>
+            <label>Image URL</label>
+            <input type="text" name="image_url" value="{{ node.image_url if node else '' }}" placeholder="https://...">
+        </div>
+    </div>
 
-    <label>Image URL</label>
-    <input type="text" name="image_url" value="{{ node.image_url if node else '' }}" placeholder="https://...">
+    <div class="checkbox">
+        <input type="checkbox" id="is_enabled" name="is_enabled" {% if node is none or node.is_enabled %}checked{% endif %}>
+        <label for="is_enabled" style="margin:0; font-weight:normal;">Включен</label>
+    </div>
 
-    <label><input type="checkbox" name="is_enabled" {% if node is none or node.is_enabled %}checked{% endif %}> Enabled</label>
+    <div id="input_settings" class="card" style="display:none;">
+        <h3>Настройки ввода</h3>
+        <div class="row">
+            <div>
+                <label>Тип ввода</label>
+                <select name="input_type" id="input_type_select">
+                    <option value="" disabled {% if node is none or not node.input_type %}selected{% endif %}>Выберите</option>
+                    <option value="TEXT" {% if node and node.input_type == 'TEXT' %}selected{% endif %}>Текст</option>
+                    <option value="NUMBER" {% if node and node.input_type == 'NUMBER' %}selected{% endif %}>Число</option>
+                    <option value="PHONE_TEXT" {% if node and node.input_type == 'PHONE_TEXT' %}selected{% endif %}>Телефон (текст)</option>
+                    <option value="CONTACT" {% if node and node.input_type == 'CONTACT' %}selected{% endif %}>Контакт Telegram</option>
+                </select>
+            </div>
+            <div>
+                <label>Сохранить в переменную</label>
+                <input type="text" name="input_var_key" value="{{ node.input_var_key if node else '' }}" placeholder="например: phone или name">
+                <div class="hint">Ключ переменной (латиница, цифры, underscore).</div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="checkbox">
+                <input type="checkbox" id="input_required" name="input_required" {% if node is none or node.input_required %}checked{% endif %}>
+                <label for="input_required" style="margin:0; font-weight:normal;">Обязательно</label>
+            </div>
+            <div>
+                <label>Минимальная длина</label>
+                <input type="number" name="input_min_len" value="{{ node.input_min_len if node and node.input_min_len is not none else '' }}" placeholder="Например 2 для имени.">
+            </div>
+        </div>
+
+        <label>Текст ошибки</label>
+        <textarea name="input_error_text" placeholder="Пожалуйста, введите корректное значение.">{{ node.input_error_text if node else '' }}</textarea>
+
+        <div class="row">
+            <div>
+                <label>Переход при успехе (код узла)</label>
+                <input type="text" name="next_node_code_success" value="{{ node.next_node_code_success if node else '' }}" placeholder="например: MAIN_MENU">
+            </div>
+            <div>
+                <label>Переход при отмене (код узла)</label>
+                <input type="text" name="next_node_code_cancel" value="{{ node.next_node_code_cancel if node else '' }}" placeholder="например: MAIN_MENU">
+            </div>
+        </div>
+    </div>
 
     <div class="actions">
         <button type="submit" class="button">Сохранить</button>
         <a href="/adminbot/nodes" class="button" style="background:#6b7280;">Назад</a>
     </div>
 </form>
+
+<script>
+    const nodeTypeSelect = document.getElementById('node_type_select');
+    const inputSettings = document.getElementById('input_settings');
+
+    function toggleInputSettings() {
+        if (nodeTypeSelect.value === 'INPUT') {
+            inputSettings.style.display = 'block';
+        } else {
+            inputSettings.style.display = 'none';
+        }
+    }
+
+    nodeTypeSelect.addEventListener('change', toggleInputSettings);
+    toggleInputSettings();
+</script>
 </body>
 </html>

--- a/admin_panel/templates/adminbot_nodes_list.html
+++ b/admin_panel/templates/adminbot_nodes_list.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <title>Bot Nodes</title>
+    <title>Узлы бота</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 16px; background: #f5f5f5; }
         header { display: flex; gap: 12px; margin-bottom: 16px; }
@@ -11,6 +11,7 @@
         th { background: #e2e8f0; }
         a.button, button { padding: 6px 10px; background: #2563eb; color: #fff; text-decoration: none; border: none; border-radius: 4px; cursor: pointer; }
         .muted { color: #475569; font-size: 14px; }
+        .badge { padding: 2px 6px; border-radius: 4px; font-size: 12px; background: #e0f2fe; color: #0369a1; }
     </style>
 </head>
 <body>
@@ -28,10 +29,11 @@
     <thead>
     <tr>
         <th>Code</th>
-        <th>Title</th>
-        <th>Enabled</th>
-        <th>Updated</th>
-        <th>Actions</th>
+        <th>Название</th>
+        <th>Тип</th>
+        <th>Включен</th>
+        <th>Обновлён</th>
+        <th>Действия</th>
     </tr>
     </thead>
     <tbody>
@@ -39,15 +41,16 @@
     <tr>
         <td>{{ node.code }}</td>
         <td>{{ node.title }}</td>
+        <td><span class="badge">{{ 'Ожидание ввода' if node.node_type == 'INPUT' else 'Сообщение' }}</span></td>
         <td>{{ '✅' if node.is_enabled else '⛔' }}</td>
         <td class="muted">{{ node.updated_at }}</td>
         <td>
-            <a href="/adminbot/nodes/{{ node.id }}/edit">Edit</a> |
-            <a href="/adminbot/nodes/{{ node.id }}/buttons">Buttons</a>
+            <a href="/adminbot/nodes/{{ node.id }}/edit">Редактировать</a> |
+            <a href="/adminbot/nodes/{{ node.id }}/buttons">Кнопки</a>
         </td>
     </tr>
     {% else %}
-    <tr><td colspan="5">Нет узлов</td></tr>
+    <tr><td colspan="6">Нет узлов</td></tr>
     {% endfor %}
     </tbody>
 </table>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -37,6 +37,14 @@ class BotNode(Base):
     message_text = Column(Text, nullable=False)
     parse_mode = Column(String, nullable=False, default="HTML", server_default="HTML")
     image_url = Column(Text, nullable=True)
+    node_type = Column(String, nullable=False, default="MESSAGE", server_default="MESSAGE")
+    input_type = Column(String, nullable=True)
+    input_var_key = Column(String, nullable=True)
+    input_required = Column(Boolean, nullable=False, default=True, server_default="true")
+    input_min_len = Column(Integer, nullable=True)
+    input_error_text = Column(Text, nullable=True)
+    next_node_code_success = Column(String, nullable=True)
+    next_node_code_cancel = Column(String, nullable=True)
     is_enabled = Column(Boolean, default=True, nullable=False, server_default="true")
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=func.now(), nullable=False)
@@ -264,6 +272,32 @@ class Favorite(Base):
 
 
 Index("ix_favorites_user_product_type", Favorite.user_id, Favorite.product_id, Favorite.type, unique=True)
+
+
+class UserVar(Base):
+    __tablename__ = "user_vars"
+
+    __table_args__ = (
+        Index("ix_user_vars_user_key", "user_id", "key", unique=True),
+    )
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, index=True, nullable=False)
+    key = Column(String, index=True, nullable=False)
+    value = Column(Text, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=func.now(), nullable=False)
+
+
+class UserState(Base):
+    __tablename__ = "user_state"
+
+    user_id = Column(BigInteger, primary_key=True)
+    waiting_node_code = Column(String, nullable=True)
+    waiting_input_type = Column(String, nullable=True)
+    waiting_var_key = Column(String, nullable=True)
+    next_node_code_success = Column(String, nullable=True)
+    next_node_code_cancel = Column(String, nullable=True)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=func.now(), nullable=False)
 
 
 class CartItem(Base):

--- a/services/bot_config.py
+++ b/services/bot_config.py
@@ -23,6 +23,14 @@ class NodeView:
     parse_mode: str
     image_url: str | None
     keyboard: InlineKeyboardMarkup | None
+    node_type: str
+    input_type: str | None
+    input_var_key: str | None
+    input_required: bool
+    input_min_len: int | None
+    input_error_text: str | None
+    next_node_code_success: str | None
+    next_node_code_cancel: str | None
 
 
 _cache: dict[str, object] = {"version": None, "nodes": {}}
@@ -87,6 +95,14 @@ def _reload_cache(session, version: int) -> None:
             parse_mode=node.parse_mode or "HTML",
             image_url=node.image_url,
             keyboard=keyboard,
+            node_type=node.node_type or "MESSAGE",
+            input_type=node.input_type,
+            input_var_key=node.input_var_key,
+            input_required=bool(node.input_required),
+            input_min_len=node.input_min_len,
+            input_error_text=node.input_error_text,
+            next_node_code_success=node.next_node_code_success,
+            next_node_code_cancel=node.next_node_code_cancel,
         )
 
     _cache["version"] = version


### PR DESCRIPTION
## Summary
- add input node fields and validation in the admin UI with Russian labels
- store user variables and waiting state for input-driven bot flows
- extend bot runtime to render variables, handle input validation, and transitions

## Testing
- python -m compileall handlers/start.py admin_panel/routes/adminbot_nodes.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f969db94832690a5902094bc158f)