### PR TITLE
Add trigger management for AdminBot

### DIFF
--- a/admin_panel/routes/adminbot.py
+++ b/admin_panel/routes/adminbot.py
@@ -9,7 +9,7 @@ from admin_panel.dependencies import get_db_session, require_admin
 from admin_panel.routes import auth as auth_routes
 from models.admin_user import AdminRole
 
-from . import adminbot_buttons, adminbot_nodes, adminbot_runtime
+from . import adminbot_buttons, adminbot_nodes, adminbot_runtime, adminbot_triggers
 
 router = APIRouter(prefix="/adminbot", tags=["AdminBot"])
 
@@ -59,4 +59,5 @@ async def logout(request: Request, db: Session = Depends(get_db_session)):
 
 router.include_router(adminbot_nodes.router)
 router.include_router(adminbot_buttons.router)
+router.include_router(adminbot_triggers.router)
 router.include_router(adminbot_runtime.router)

--- a/admin_panel/routes/adminbot_triggers.py
+++ b/admin_panel/routes/adminbot_triggers.py
@@ -1,0 +1,320 @@
+from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from admin_panel import TEMPLATES
+from admin_panel.dependencies import get_db_session, require_admin
+from models import BotTrigger
+from models.admin_user import AdminRole
+
+router = APIRouter(tags=["AdminBot"])
+
+ALLOWED_ROLES = (AdminRole.superadmin, AdminRole.admin_bot)
+TRIGGER_TYPES = {
+    "COMMAND": "Команда (например /start)",
+    "TEXT": "Текст (сообщение пользователя)",
+    "FALLBACK": "По умолчанию (если ничего не подошло)",
+}
+MATCH_MODES = {
+    "EXACT": "Точно равно",
+    "CONTAINS": "Содержит",
+    "STARTS_WITH": "Начинается с",
+}
+
+
+def _login_redirect(next_url: str | None = None) -> RedirectResponse:
+    target = next_url or "/adminbot"
+    return RedirectResponse(url=f"/login?next={target}", status_code=303)
+
+
+def _next_from_request(request: Request) -> str:
+    query = f"?{request.url.query}" if request.url.query else ""
+    return f"{request.url.path}{query}"
+
+
+def _validate_trigger_payload(
+    *,
+    trigger_type: str,
+    trigger_value: str | None,
+    match_mode: str | None,
+    target_node_code: str,
+    priority: int,
+    is_enabled: bool,
+) -> tuple[str | None, dict]:
+    normalized_type = (trigger_type or "").strip().upper()
+    normalized_value = (trigger_value or "").strip()
+    normalized_mode = (match_mode or "EXACT").strip().upper() or "EXACT"
+    normalized_target = (target_node_code or "").strip()
+    normalized_priority = priority if isinstance(priority, int) else 100
+
+    if normalized_type not in TRIGGER_TYPES:
+        return "Некорректный тип триггера", {}
+
+    if normalized_type == "COMMAND":
+        if not normalized_value:
+            return "Для команды укажите значение без символа '/'", {}
+        if " " in normalized_value or normalized_value.startswith("/"):
+            return "Команда не должна содержать пробелы и символ '/'", {}
+    elif normalized_type == "TEXT":
+        if not normalized_value:
+            return "Для текстового триггера укажите значение", {}
+        if normalized_mode not in MATCH_MODES:
+            return "Выберите режим совпадения", {}
+    elif normalized_type == "FALLBACK":
+        if normalized_value:
+            return "Для триггера по умолчанию значение должно быть пустым", {}
+        normalized_value = None
+        normalized_mode = "EXACT"
+
+    if not normalized_target:
+        return "Укажите код узла назначения", {}
+
+    payload = {
+        "trigger_type": normalized_type,
+        "trigger_value": normalized_value,
+        "match_mode": normalized_mode if normalized_type == "TEXT" else "EXACT",
+        "target_node_code": normalized_target,
+        "priority": normalized_priority,
+        "is_enabled": bool(is_enabled),
+    }
+
+    return None, payload
+
+
+def _ensure_single_fallback(db: Session, *, current_id: int | None, is_enabled: bool) -> str | None:
+    if not is_enabled:
+        return None
+
+    existing = (
+        db.query(BotTrigger)
+        .filter(BotTrigger.trigger_type == "FALLBACK", BotTrigger.is_enabled.is_(True))
+        .filter(BotTrigger.id != (current_id or 0))
+        .first()
+    )
+    if existing:
+        return "Разрешён только один включённый триггер по умолчанию"
+    return None
+
+
+@router.get("/triggers")
+async def list_triggers(
+    request: Request,
+    trigger_type: str | None = Query(None),
+    search: str | None = Query(None),
+    db: Session = Depends(get_db_session),
+):
+    user = require_admin(request, db, roles=ALLOWED_ROLES)
+    if not user:
+        return _login_redirect(_next_from_request(request))
+
+    query = db.query(BotTrigger)
+    if trigger_type:
+        query = query.filter(BotTrigger.trigger_type == trigger_type.upper())
+    if search:
+        query = query.filter(BotTrigger.trigger_value.ilike(f"%{search.strip()}%"))
+
+    triggers = query.order_by(BotTrigger.trigger_type, BotTrigger.priority, BotTrigger.id).all()
+
+    return TEMPLATES.TemplateResponse(
+        "adminbot_triggers_list.html",
+        {
+            "request": request,
+            "user": user,
+            "triggers": triggers,
+            "selected_type": trigger_type or "",
+            "search": search or "",
+            "trigger_types": TRIGGER_TYPES,
+            "match_modes": MATCH_MODES,
+        },
+    )
+
+
+@router.get("/triggers/new")
+async def new_trigger_form(request: Request, db: Session = Depends(get_db_session)):
+    user = require_admin(request, db, roles=ALLOWED_ROLES)
+    if not user:
+        return _login_redirect(_next_from_request(request))
+
+    return TEMPLATES.TemplateResponse(
+        "adminbot_trigger_edit.html",
+        {
+            "request": request,
+            "user": user,
+            "trigger": None,
+            "trigger_types": TRIGGER_TYPES,
+            "match_modes": MATCH_MODES,
+            "form": None,
+            "error": None,
+        },
+    )
+
+
+@router.post("/triggers/new")
+async def create_trigger(
+    request: Request,
+    trigger_type: str = Form(...),
+    trigger_value: str | None = Form(None),
+    match_mode: str | None = Form("EXACT"),
+    target_node_code: str = Form(...),
+    priority: int = Form(100),
+    is_enabled: bool = Form(False),
+    db: Session = Depends(get_db_session),
+):
+    user = require_admin(request, db, roles=ALLOWED_ROLES)
+    if not user:
+        return _login_redirect(_next_from_request(request))
+
+    try:
+        priority_value = int(priority)
+    except Exception:
+        priority_value = 100
+
+    error, payload = _validate_trigger_payload(
+        trigger_type=trigger_type,
+        trigger_value=trigger_value,
+        match_mode=match_mode,
+        target_node_code=target_node_code,
+        priority=priority_value,
+        is_enabled=is_enabled,
+    )
+    if not error:
+        error = _ensure_single_fallback(
+            db, current_id=None, is_enabled=is_enabled and (trigger_type or "").upper() == "FALLBACK"
+        )
+
+    if error:
+        return TEMPLATES.TemplateResponse(
+            "adminbot_trigger_edit.html",
+            {
+                "request": request,
+                "user": user,
+                "trigger": None,
+                "trigger_types": TRIGGER_TYPES,
+                "match_modes": MATCH_MODES,
+                "error": error,
+                "form": {
+                    "trigger_type": trigger_type,
+                    "trigger_value": trigger_value,
+                    "match_mode": match_mode,
+                    "target_node_code": target_node_code,
+                    "priority": priority_value,
+                    "is_enabled": is_enabled,
+                },
+            },
+            status_code=400,
+        )
+
+    db.add(BotTrigger(**payload))
+    db.commit()
+
+    return RedirectResponse(url="/adminbot/triggers", status_code=303)
+
+
+@router.get("/triggers/{trigger_id}/edit")
+async def edit_trigger_form(
+    request: Request,
+    trigger_id: int,
+    db: Session = Depends(get_db_session),
+):
+    user = require_admin(request, db, roles=ALLOWED_ROLES)
+    if not user:
+        return _login_redirect(_next_from_request(request))
+
+    trigger = db.get(BotTrigger, trigger_id)
+    if not trigger:
+        return RedirectResponse(url="/adminbot/triggers", status_code=303)
+
+    return TEMPLATES.TemplateResponse(
+        "adminbot_trigger_edit.html",
+        {
+            "request": request,
+            "user": user,
+            "trigger": trigger,
+            "trigger_types": TRIGGER_TYPES,
+            "match_modes": MATCH_MODES,
+            "form": None,
+            "error": None,
+        },
+    )
+
+
+@router.post("/triggers/{trigger_id}/edit")
+async def update_trigger(
+    request: Request,
+    trigger_id: int,
+    trigger_type: str = Form(...),
+    trigger_value: str | None = Form(None),
+    match_mode: str | None = Form("EXACT"),
+    target_node_code: str = Form(...),
+    priority: int = Form(100),
+    is_enabled: bool = Form(False),
+    db: Session = Depends(get_db_session),
+):
+    user = require_admin(request, db, roles=ALLOWED_ROLES)
+    if not user:
+        return _login_redirect(_next_from_request(request))
+
+    trigger = db.get(BotTrigger, trigger_id)
+    if not trigger:
+        return RedirectResponse(url="/adminbot/triggers", status_code=303)
+
+    try:
+        priority_value = int(priority)
+    except Exception:
+        priority_value = 100
+
+    error, payload = _validate_trigger_payload(
+        trigger_type=trigger_type,
+        trigger_value=trigger_value,
+        match_mode=match_mode,
+        target_node_code=target_node_code,
+        priority=priority_value,
+        is_enabled=is_enabled,
+    )
+    if not error:
+        error = _ensure_single_fallback(
+            db, current_id=trigger.id, is_enabled=is_enabled and (trigger_type or "").upper() == "FALLBACK"
+        )
+
+    if error:
+        return TEMPLATES.TemplateResponse(
+            "adminbot_trigger_edit.html",
+            {
+                "request": request,
+                "user": user,
+                "trigger": trigger,
+                "trigger_types": TRIGGER_TYPES,
+                "match_modes": MATCH_MODES,
+                "error": error,
+                "form": {
+                    "trigger_type": trigger_type,
+                    "trigger_value": trigger_value,
+                    "match_mode": match_mode,
+                    "target_node_code": target_node_code,
+                    "priority": priority_value,
+                    "is_enabled": is_enabled,
+                },
+            },
+            status_code=400,
+        )
+
+    for key, value in payload.items():
+        setattr(trigger, key, value)
+    db.add(trigger)
+    db.commit()
+
+    return RedirectResponse(url="/adminbot/triggers", status_code=303)
+
+
+@router.post("/triggers/{trigger_id}/delete")
+async def delete_trigger(request: Request, trigger_id: int, db: Session = Depends(get_db_session)):
+    user = require_admin(request, db, roles=ALLOWED_ROLES)
+    if not user:
+        return _login_redirect(_next_from_request(request))
+
+    trigger = db.get(BotTrigger, trigger_id)
+    if trigger:
+        db.delete(trigger)
+        db.commit()
+
+    return RedirectResponse(url="/adminbot/triggers", status_code=303)

--- a/admin_panel/templates/adminbot/dashboard.html
+++ b/admin_panel/templates/adminbot/dashboard.html
@@ -16,6 +16,7 @@
     <div>AdminBot Dashboard</div>
     <div style="display:flex; gap:12px; align-items:center;">
         <a href="/adminbot/nodes" style="color:#0b1220;">Узлы</a>
+        <a href="/adminbot/triggers" style="color:#0b1220;">Триггеры</a>
         <a href="/adminbot/runtime" style="color:#0b1220;">Runtime</a>
         <a href="/admin/users" style="color:#0b1220;">Админы</a>
         <a href="/admin/profile" style="color:#0b1220;">Профиль</a>

--- a/admin_panel/templates/adminbot_button_edit.html
+++ b/admin_panel/templates/adminbot_button_edit.html
@@ -18,7 +18,9 @@
 <body>
 <header>
     <a href="/adminbot/nodes/{{ node.id }}/buttons" class="button">Назад к кнопкам</a>
+    <a href="/adminbot/triggers" class="button">Триггеры</a>
     <a href="/adminbot/runtime" class="button">Runtime</a>
+    <a href="/adminbot/logout" class="button" style="background:#dc2626;">Выйти</a>
 </header>
 <h2>{% if button %}Редактирование кнопки{% else %}Новая кнопка{% endif %} для {{ node.code }}</h2>
 {% if error %}<div class="error">{{ error }}</div>{% endif %}

--- a/admin_panel/templates/adminbot_buttons_list.html
+++ b/admin_panel/templates/adminbot_buttons_list.html
@@ -16,7 +16,9 @@
 <body>
 <header>
     <a href="/adminbot/nodes" class="button">Назад к узлам</a>
+    <a href="/adminbot/triggers" class="button">Триггеры</a>
     <a href="/adminbot/runtime" class="button">Runtime</a>
+    <a href="/adminbot/logout" class="button" style="background:#dc2626;">Выйти</a>
 </header>
 <h2>Кнопки: {{ node.title }} ({{ node.code }})</h2>
 <div style="margin:12px 0;">

--- a/admin_panel/templates/adminbot_node_edit.html
+++ b/admin_panel/templates/adminbot_node_edit.html
@@ -29,6 +29,7 @@
 <body>
 <header>
     <a href="/adminbot/nodes" class="button">Назад к списку</a>
+    <a href="/adminbot/triggers" class="button">Триггеры</a>
     <a href="/adminbot/runtime" class="button">Runtime</a>
 </header>
 <h2>{% if node %}Редактирование: {{ node.code }}{% else %}Новый узел{% endif %}</h2>

--- a/admin_panel/templates/adminbot_nodes_list.html
+++ b/admin_panel/templates/adminbot_nodes_list.html
@@ -18,6 +18,7 @@
 <header>
     <a href="/adminbot" class="button">Главная</a>
     <a href="/adminbot/nodes" class="button">Узлы</a>
+    <a href="/adminbot/triggers" class="button">Триггеры</a>
     <a href="/adminbot/runtime" class="button">Runtime</a>
     <a href="/adminbot/logout" class="button" style="background:#dc2626;">Выйти</a>
 </header>

--- a/admin_panel/templates/adminbot_runtime.html
+++ b/admin_panel/templates/adminbot_runtime.html
@@ -15,6 +15,8 @@
 <header>
     <a href="/adminbot" class="button">Главная</a>
     <a href="/adminbot/nodes" class="button">Узлы</a>
+    <a href="/adminbot/triggers" class="button">Триггеры</a>
+    <a href="/adminbot/runtime" class="button" style="background:#0ea5e9;">Runtime</a>
     <a href="/adminbot/logout" class="button" style="background:#dc2626;">Выйти</a>
 </header>
 <div class="card">

--- a/admin_panel/templates/adminbot_trigger_edit.html
+++ b/admin_panel/templates/adminbot_trigger_edit.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ 'Редактировать триггер' if trigger else 'Создать триггер' }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 16px; background: #f8fafc; }
+        header { display: flex; gap: 12px; margin-bottom: 16px; }
+        form { background: #fff; padding: 16px; border: 1px solid #cbd5e1; border-radius: 8px; max-width: 720px; }
+        label { display: block; margin-bottom: 12px; }
+        input[type="text"], input[type="number"], select { width: 100%; padding: 8px; border: 1px solid #cbd5e1; border-radius: 4px; }
+        .actions { display: flex; gap: 8px; margin-top: 16px; }
+        a.button, button { padding: 8px 12px; background: #2563eb; color: #fff; text-decoration: none; border: none; border-radius: 4px; cursor: pointer; }
+        .error { color: #dc2626; margin-bottom: 12px; }
+        small { color: #475569; }
+        .checkbox { display: flex; align-items: center; gap: 8px; }
+    </style>
+</head>
+<body>
+<header>
+    <a href="/adminbot" class="button">Главная</a>
+    <a href="/adminbot/nodes" class="button">Узлы</a>
+    <a href="/adminbot/triggers" class="button">Триггеры</a>
+    <a href="/adminbot/runtime" class="button">Runtime</a>
+    <a href="/adminbot/logout" class="button" style="background:#dc2626;">Выйти</a>
+</header>
+<h2>{{ 'Редактировать триггер' if trigger else 'Создать триггер' }}</h2>
+{% if error %}
+<p class="error">{{ error }}</p>
+{% endif %}
+<form method="post" action="{{ '/adminbot/triggers/' ~ trigger.id ~ '/edit' if trigger else '/adminbot/triggers/new' }}">
+    <label>
+        Тип триггера
+        <select name="trigger_type" id="trigger_type" required>
+            {% for key, label in trigger_types.items() %}
+            {% set selected = (form.trigger_type if form else (trigger.trigger_type if trigger else '')) %}
+            <option value="{{ key }}" {% if selected == key %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
+    </label>
+
+    <div id="value_block">
+        <label>
+            Значение
+            {% set current_value = form.trigger_value if form else (trigger.trigger_value if trigger else '') %}
+            <input type="text" name="trigger_value" id="trigger_value" value="{{ current_value or '' }}" placeholder="Например: start (без /)" />
+            <small>Для команды вводите без символа '/'.</small>
+        </label>
+    </div>
+
+    <div id="match_mode_block">
+        <label>
+            Режим совпадения
+            {% set current_mode = form.match_mode if form else (trigger.match_mode if trigger else 'EXACT') %}
+            <select name="match_mode" id="match_mode">
+                {% for key, label in match_modes.items() %}
+                <option value="{{ key }}" {% if current_mode == key %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+        </label>
+    </div>
+
+    <label>
+        Код узла назначения
+        {% set current_target = form.target_node_code if form else (trigger.target_node_code if trigger else '') %}
+        <input type="text" name="target_node_code" required value="{{ current_target }}" placeholder="например: MAIN_MENU" />
+    </label>
+
+    <label>
+        Приоритет
+        {% set current_priority = form.priority if form else (trigger.priority if trigger else 100) %}
+        <input type="number" name="priority" value="{{ current_priority }}" />
+        <small>Чем меньше число — тем раньше сработает.</small>
+    </label>
+
+    <label class="checkbox">
+        {% set enabled = form.is_enabled if form is defined else (trigger.is_enabled if trigger else True) %}
+        <input type="checkbox" name="is_enabled" value="true" {% if enabled %}checked{% endif %} />
+        Включен
+    </label>
+
+    <div class="actions">
+        <button type="submit">Сохранить</button>
+        <a href="/adminbot/triggers" class="button">Назад</a>
+    </div>
+</form>
+
+<script>
+function updateVisibility() {
+    const typeSelect = document.getElementById('trigger_type');
+    const valueBlock = document.getElementById('value_block');
+    const matchModeBlock = document.getElementById('match_mode_block');
+    const valueInput = document.getElementById('trigger_value');
+
+    if (!typeSelect) return;
+    const currentType = typeSelect.value;
+
+    if (currentType === 'FALLBACK') {
+        valueBlock.style.display = 'none';
+        valueInput.value = '';
+    } else {
+        valueBlock.style.display = 'block';
+    }
+
+    matchModeBlock.style.display = currentType === 'TEXT' ? 'block' : 'none';
+}
+
+document.getElementById('trigger_type').addEventListener('change', updateVisibility);
+updateVisibility();
+</script>
+</body>
+</html>

--- a/admin_panel/templates/adminbot_triggers_list.html
+++ b/admin_panel/templates/adminbot_triggers_list.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Триггеры</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 16px; background: #f8fafc; }
+        header { display: flex; gap: 12px; margin-bottom: 16px; }
+        a.button, button { padding: 6px 10px; background: #2563eb; color: #fff; text-decoration: none; border: none; border-radius: 4px; cursor: pointer; }
+        table { border-collapse: collapse; width: 100%; background: #fff; }
+        th, td { border: 1px solid #cbd5e1; padding: 8px; text-align: left; }
+        th { background: #e2e8f0; }
+        .muted { color: #475569; font-size: 14px; }
+        .badge { padding: 2px 6px; border-radius: 4px; font-size: 12px; background: #e0f2fe; color: #0369a1; }
+        form.inline { display: inline; }
+        .filter { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; }
+        input[type="text"], select { padding: 6px; border: 1px solid #cbd5e1; border-radius: 4px; }
+    </style>
+</head>
+<body>
+<header>
+    <a href="/adminbot" class="button">Главная</a>
+    <a href="/adminbot/nodes" class="button">Узлы</a>
+    <a href="/adminbot/triggers" class="button" style="background:#0ea5e9;">Триггеры</a>
+    <a href="/adminbot/runtime" class="button">Runtime</a>
+    <a href="/adminbot/logout" class="button" style="background:#dc2626;">Выйти</a>
+</header>
+<h2>Триггеры</h2>
+<div class="filter">
+    <form method="get" action="/adminbot/triggers" style="display:flex; gap:8px; align-items:center;">
+        <label>Тип:
+            <select name="trigger_type">
+                <option value="">Все</option>
+                {% for key, label in trigger_types.items() %}
+                <option value="{{ key }}" {% if selected_type == key %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label>Поиск по значению:
+            <input type="text" name="search" value="{{ search }}" placeholder="Например: start или каталог" />
+        </label>
+        <button type="submit">Фильтр</button>
+    </form>
+    <a href="/adminbot/triggers/new" class="button">Создать триггер</a>
+</div>
+<table>
+    <thead>
+    <tr>
+        <th>Тип</th>
+        <th>Значение</th>
+        <th>Режим</th>
+        <th>Узел назначения</th>
+        <th>Приоритет</th>
+        <th>Включен</th>
+        <th>Действия</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for trigger in triggers %}
+    <tr>
+        <td>{{ trigger_types.get(trigger.trigger_type, trigger.trigger_type) }}</td>
+        <td>{{ trigger.trigger_value or '—' }}</td>
+        <td>{{ match_modes.get(trigger.match_mode or 'EXACT', trigger.match_mode) if trigger.trigger_type == 'TEXT' else 'Точно равно' }}</td>
+        <td>{{ trigger.target_node_code }}</td>
+        <td>{{ trigger.priority }}</td>
+        <td>{{ '✅' if trigger.is_enabled else '⛔' }}</td>
+        <td>
+            <a href="/adminbot/triggers/{{ trigger.id }}/edit">Редактировать</a>
+            |
+            <form action="/adminbot/triggers/{{ trigger.id }}/delete" method="post" class="inline" onsubmit="return confirm('Удалить триггер?');">
+                <button type="submit" style="background:#dc2626;">Удалить</button>
+            </form>
+        </td>
+    </tr>
+    {% else %}
+    <tr><td colspan="7">Триггеры не найдены</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+</body>
+</html>

--- a/bot.py
+++ b/bot.py
@@ -50,12 +50,12 @@ async def main() -> None:
     dp.callback_query.middleware(EnsureUserMiddleware())
 
     # Подключаем актуальные роутеры
-    dp.include_router(start.router)
     dp.include_router(admin.router)
     dp.include_router(webapp.router)
     dp.include_router(faq.faq_router)
     dp.include_router(site_chat.site_chat_router)
     dp.include_router(support.support_router)
+    dp.include_router(start.router)
 
     # Старт поллинга
     await bot.delete_webhook(drop_pending_updates=True)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -110,6 +110,20 @@ class BotRuntime(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=func.now(), nullable=True)
 
 
+class BotTrigger(Base):
+    __tablename__ = "bot_triggers"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    trigger_type = Column(String(16), nullable=False)
+    trigger_value = Column(Text, nullable=True)
+    match_mode = Column(String(16), nullable=False, default="EXACT", server_default="EXACT")
+    target_node_code = Column(String(64), nullable=False)
+    priority = Column(Integer, nullable=False, default=100, server_default="100")
+    is_enabled = Column(Boolean, default=True, nullable=False, server_default="true")
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=func.now(), nullable=False)
+
+
 class ProductBasket(Base):
     __tablename__ = "products_baskets"
 


### PR DESCRIPTION
## Summary
- add BotTrigger model with default seed entries and caching alongside nodes
- implement AdminBot UI and routes to manage command/text/fallback triggers
- route incoming bot messages through priority-based triggers with config error handling

## Testing
- python -m compileall admin_panel/routes/adminbot_triggers.py handlers/start.py services/bot_config.py database.py bot.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694710072e9483268b948b4ccd0bdca0)