### PR TITLE
Add production deployment contract and server configuration templates

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -41,6 +41,14 @@ MiniDeN — Telegram-бот и веб-магазин
 - Проверка: sudo systemctl status miniden-api --no-pager
 - Проверка URL: http://127.0.0.1:8000/adminbot/login (с сервера) и https://домен/adminbot/login (через nginx)
 
+Production деплой одной командой
+--------------------------------
+- Контракт: `deploy/DEPLOY_CONTRACT.md` описывает, что именно обновляет `deploy.sh` и какие каталоги запрещено трогать.
+- Эталонные конфиги для прод-сервера лежат в `deploy/nginx/miniden.conf` и `deploy/systemd/*.service`; скрипт деплоя копирует их в `/etc/nginx/` и `/etc/systemd/system/`.
+- Ожидаемая команда на сервере: `sudo /opt/miniden/deploy.sh` (обновляет код, зависимости, webapp и перезапускает сервисы по контракту).
+- Защищённые пути (деплой не трогает): `/opt/miniden/.env`, `/opt/miniden/media/`, `/opt/miniden/data/`.
+- Быстрый чек после деплоя: `curl http://127.0.0.1:8000/api/health`.
+
 Почему 405 на curl -I — это нормально
 -------------------------------------
 - Ответ 405 на `curl -I` (HEAD) для страниц авторизации — ожидаемое поведение. Используйте GET/браузер для проверки (`curl -v http://127.0.0.1:8000/adminbot/login`).

--- a/deploy/DEPLOY_CONTRACT.md
+++ b/deploy/DEPLOY_CONTRACT.md
@@ -1,0 +1,26 @@
+# Контракт деплоя MiniDeN (production)
+
+## Источник правды
+Репозиторий GitHub содержит:
+- код API
+- код Telegram-бота
+- webapp (HTML/JS/CSS) для раздачи nginx
+- эталонные server-конфиги (deploy/nginx и deploy/systemd)
+
+## Одна команда деплоя на сервере
+sudo /opt/miniden/deploy.sh
+
+## Что деплой ОБЯЗАН обновлять
+- git pull в /opt/miniden
+- зависимости Python (если менялся requirements.txt)
+- webapp -> /opt/miniden/webapp
+- nginx config -> /etc/nginx/sites-available/miniden.conf (+ symlink sites-enabled)
+- systemd units -> /etc/systemd/system/
+- restart: miniden-api, miniden-bot
+- reload: nginx
+- post-check: curl http://127.0.0.1:8000/api/health
+
+## Что деплой НЕ ИМЕЕТ ПРАВА трогать
+- /opt/miniden/.env
+- /opt/miniden/media/
+- /opt/miniden/data/

--- a/deploy/nginx/miniden.conf
+++ b/deploy/nginx/miniden.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    server_name miniden.ru www.miniden.ru;
+
+    root /opt/miniden/webapp;
+    index index.html;
+
+    access_log /var/log/nginx/miniden.access.log;
+    error_log /var/log/nginx/miniden.error.log;
+
+    client_max_body_size 25m;
+
+    location /.well-known/acme-challenge/ {
+        alias /var/www/letsencrypt/.well-known/acme-challenge/;
+        try_files $uri =404;
+    }
+
+    location /media/ {
+        alias /opt/miniden/media/;
+        add_header Cache-Control "public, max-age=86400";
+        autoindex off;
+    }
+
+    location ~ ^/(api|adminbot|adminsite)/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/systemd/miniden-api.service
+++ b/deploy/systemd/miniden-api.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=MiniDeN FastAPI backend
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/miniden
+EnvironmentFile=/opt/miniden/.env
+ExecStart=/opt/miniden/venv/bin/uvicorn webapi:app --host 127.0.0.1 --port 8000
+Restart=on-failure
+RestartSec=5s
+User=miniden
+Group=miniden
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/miniden-bot.service
+++ b/deploy/systemd/miniden-bot.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=MiniDeN Telegram bot
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/miniden
+EnvironmentFile=/opt/miniden/.env
+ExecStart=/opt/miniden/venv/bin/python bot.py
+Restart=on-failure
+RestartSec=5s
+User=miniden
+Group=miniden
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add deployment contract describing one-command production rollout and protected paths
- provide nginx and systemd reference configs under deploy/
- document one-command production deployment flow in README

## Testing
- not run (docs/config templates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948542a65288326a980e28eddfc94b7)