### PR TITLE
Fix handling of empty numeric fields in admin bot node forms

### DIFF
--- a/admin_panel/routes/adminbot_buttons.py
+++ b/admin_panel/routes/adminbot_buttons.py
@@ -50,6 +50,18 @@ def _get_node(db: Session, node_id: int) -> BotNode | None:
     return db.get(BotNode, node_id)
 
 
+def _normalize_int(value: str | None, default: int = 0) -> int:
+    if value is None:
+        return default
+    value = value.strip()
+    if not value:
+        return default
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
 @router.get("/nodes/{node_id}/buttons")
 async def list_buttons(
     request: Request,
@@ -116,8 +128,8 @@ async def create_button(
     title: str = Form(...),
     button_type: str = Form(..., alias="type"),
     payload: str = Form(...),
-    row: int = Form(0),
-    pos: int = Form(0),
+    row: str | None = Form(None),
+    pos: str | None = Form(None),
     is_enabled: bool = Form(False),
     db: Session = Depends(get_db_session),
 ):
@@ -129,12 +141,8 @@ async def create_button(
     if not node:
         return RedirectResponse(url="/adminbot/nodes", status_code=303)
 
-    try:
-        row_value = int(row)
-        pos_value = int(pos)
-    except ValueError:
-        row_value = 0
-        pos_value = 0
+    row_value = _normalize_int(row)
+    pos_value = _normalize_int(pos)
 
     error = _validate_button_payload(button_type, payload)
     if error:
@@ -205,8 +213,8 @@ async def update_button(
     title: str = Form(...),
     button_type: str = Form(..., alias="type"),
     payload: str = Form(...),
-    row: int = Form(0),
-    pos: int = Form(0),
+    row: str | None = Form(None),
+    pos: str | None = Form(None),
     is_enabled: bool = Form(False),
     db: Session = Depends(get_db_session),
 ):
@@ -218,12 +226,8 @@ async def update_button(
     if not button:
         return RedirectResponse(url="/adminbot/nodes", status_code=303)
 
-    try:
-        row_value = int(row)
-        pos_value = int(pos)
-    except ValueError:
-        row_value = 0
-        pos_value = 0
+    row_value = _normalize_int(row)
+    pos_value = _normalize_int(pos)
 
     error = _validate_button_payload(button_type, payload)
     if error:

--- a/admin_panel/routes/adminbot_nodes.py
+++ b/admin_panel/routes/adminbot_nodes.py
@@ -58,6 +58,19 @@ def _next_from_request(request: Request) -> str:
     return f"{request.url.path}{query}"
 
 
+def _to_optional_int(value: int | str | None) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
 def _prepare_node_payload(
     *,
     title: str,
@@ -69,7 +82,7 @@ def _prepare_node_payload(
     input_type: str | None,
     input_var_key: str | None,
     input_required: bool,
-    input_min_len: int | None,
+    input_min_len: int | str | None,
     input_error_text: str | None,
     next_node_code_success: str | None,
     next_node_code_cancel: str | None,
@@ -142,7 +155,7 @@ def _prepare_node_payload(
         "input_type": normalized_input_type,
         "input_var_key": normalized_var_key,
         "input_required": bool(input_required),
-        "input_min_len": input_min_len,
+        "input_min_len": _to_optional_int(input_min_len),
         "input_error_text": input_error_text or None,
         "next_node_code_success": normalized_next_success,
         "next_node_code_cancel": normalized_next_cancel,
@@ -357,7 +370,7 @@ async def create_node(
     input_type: str | None = Form(None),
     input_var_key: str | None = Form(None),
     input_required: bool = Form(True),
-    input_min_len: int | None = Form(None),
+    input_min_len: str | None = Form(None),
     input_error_text: str | None = Form(None),
     next_node_code_success: str | None = Form(None),
     next_node_code_cancel: str | None = Form(None),
@@ -485,7 +498,7 @@ async def edit_node(
     input_type: str | None = Form(None),
     input_var_key: str | None = Form(None),
     input_required: bool = Form(True),
-    input_min_len: int | None = Form(None),
+    input_min_len: str | None = Form(None),
     input_error_text: str | None = Form(None),
     next_node_code_success: str | None = Form(None),
     next_node_code_cancel: str | None = Form(None),

--- a/admin_panel/templates/adminbot_node_edit.html
+++ b/admin_panel/templates/adminbot_node_edit.html
@@ -191,6 +191,7 @@
 <script type="application/json" id="initial_actions_data">{{ actions_json|default([])|tojson }}</script>
 
 <script>
+    const form = document.querySelector('form');
     const nodeTypeSelect = document.getElementById('node_type_select');
     const inputSettings = document.getElementById('input_settings');
     const conditionSettings = document.getElementById('condition_settings');
@@ -236,18 +237,35 @@
         { value: 'REQUEST_LOCATION', label: 'Запросить геолокацию' },
     ];
 
-    function toggleInputSettings() {
-        inputSettings.style.display = nodeTypeSelect.value === 'INPUT' ? 'block' : 'none';
-        conditionSettings.style.display = nodeTypeSelect.value === 'CONDITION' ? 'block' : 'none';
-        actionSettings.style.display = nodeTypeSelect.value === 'ACTION' ? 'block' : 'none';
+    function setSectionEnabled(section, enabled) {
+        if (!section) return;
+        section.querySelectorAll('input, select, textarea').forEach((el) => {
+            el.disabled = !enabled;
+        });
+    }
 
-        const conditionRequired = nodeTypeSelect.value === 'CONDITION';
+    function toggleInputSettings() {
+        const nodeType = nodeTypeSelect.value;
+        const isInputNode = nodeType === 'INPUT';
+        const isConditionNode = nodeType === 'CONDITION';
+        const isActionNode = nodeType === 'ACTION';
+
+        inputSettings.style.display = isInputNode ? 'block' : 'none';
+        conditionSettings.style.display = isConditionNode ? 'block' : 'none';
+        actionSettings.style.display = isActionNode ? 'block' : 'none';
+
+        setSectionEnabled(inputSettings, isInputNode);
+        setSectionEnabled(conditionSettings, isConditionNode);
+        setSectionEnabled(actionSettings, isActionNode);
+
+        const conditionRequired = isConditionNode;
         if (condVarKeyInput && condOperatorSelect && nextNodeTrueInput && nextNodeFalseInput && condValueInput) {
             condVarKeyInput.required = conditionRequired;
             condOperatorSelect.required = conditionRequired;
             nextNodeTrueInput.required = conditionRequired;
             nextNodeFalseInput.required = conditionRequired;
             condValueInput.required = conditionRequired && !['EXISTS', 'NOT_EXISTS'].includes(condOperatorSelect.value || '');
+            condValueInput.disabled = !condValueInput.required;
         }
     }
 
@@ -334,7 +352,7 @@
                         <select name="action_type" class="action-type">
                             ${ACTION_OPTIONS.map((opt) => `<option value="${opt.value}" ${opt.value === selectedType ? 'selected' : ''}>${opt.label}</option>`).join('')}
                         </select>
-                        <input type="hidden" name="action_sort" class="action-sort" value="${index}">
+                        <input type="number" name="action_sort" class="action-sort" value="${index}" style="display:none;">
                         <input type="hidden" name="action_enabled" class="action-enabled-value" value="${data.is_enabled === false ? '0' : '1'}">
                         <div class="checkbox">
                             <input type="checkbox" class="action-enabled-toggle" ${data.is_enabled === false ? '' : 'checked'}>
@@ -417,6 +435,26 @@
     nodeTypeSelect.addEventListener('change', toggleInputSettings);
     if (condOperatorSelect) {
         condOperatorSelect.addEventListener('change', toggleInputSettings);
+    }
+
+    function cleanEmptyNumbers(targetForm) {
+        const numericInputs = targetForm.querySelectorAll('input[type="number"]');
+        numericInputs.forEach((input) => {
+            if (input.disabled) {
+                return;
+            }
+            const value = (input.value || '').toString().trim();
+            if (value === '') {
+                input.disabled = true;
+            }
+        });
+    }
+
+    if (form) {
+        form.addEventListener('submit', () => {
+            toggleInputSettings();
+            cleanEmptyNumbers(form);
+        });
     }
 
     initActions();


### PR DESCRIPTION
## Summary
- allow empty numeric values to be safely parsed on the backend for nodes and buttons
- prevent hidden sections and empty numeric fields from being submitted in the admin node form
- ensure action sorting inputs use numeric types for consistency

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69485fda63208326b7eb91f439ca3d27)