### PR TITLE
Add adminbot button dropdown actions and submenu creator

### DIFF
--- a/admin_panel/templates/adminbot_button_edit.html
+++ b/admin_panel/templates/adminbot_button_edit.html
@@ -21,6 +21,7 @@
         .inline-actions { display:flex; gap:8px; align-items:center; margin-top:6px; flex-wrap: wrap; }
         .badge { display:inline-block; padding:2px 8px; border-radius:12px; background:#e0f2fe; color:#0f172a; font-size:12px; }
         .modal { border:1px solid #cbd5e1; border-radius:8px; background:#fff; padding:12px; margin-top:12px; display:none; }
+        .help-title { font-weight: bold; margin-top: 8px; }
     </style>
 </head>
 <body>
@@ -33,74 +34,87 @@
     <a href="/adminbot/logout" class="button" style="background:#dc2626;">Выйти</a>
 </header>
 <h2>{% if button %}Редактирование кнопки{% else %}Новая кнопка{% endif %} для {{ node.code }}</h2>
-<div class="hint">Кнопка управляет сценарием: переход в раздел, открытие ссылки или WebApp. Не нужно помнить коды узлов — выберите из списка.</div>
+<div class="hint">Шаги: выберите тип → настройте действие → сохраните. Все подсказки рядом, коды вводить не нужно.</div>
 {% if error %}<div class="error">{{ error }}</div>{% endif %}
 <form method="post" action="{% if button %}/adminbot/buttons/{{ button.id }}/edit{% else %}/adminbot/nodes/{{ node.id }}/buttons/new{% endif %}">
     <label>Текст кнопки</label>
     <input type="text" name="title" value="{{ button.title if button else '' }}" placeholder="Например: Товары" required>
-    <div class="hint">Что увидит пользователь в Телеграме.</div>
+    <div class="hint">Такой текст увидит пользователь в Telegram.</div>
 
-    <label>Действие кнопки</label>
-    <select name="action_type" id="action_type">
-        {% for value, label in action_types %}
-            <option value="{{ value }}" {% if form_state.action_type == value %}selected{% endif %}>{{ label }}</option>
+    <label>Тип кнопки</label>
+    <select name="type" id="button_type">
+        {% for value, label in button_types %}
+            <option value="{{ value }}" {% if form_state.button_type == value %}selected{% endif %}>{{ label }}</option>
         {% endfor %}
-        {% if form_state.action_type == 'LEGACY' %}
-            <option value="LEGACY" selected>Старый формат (payload как есть)</option>
-        {% endif %}
     </select>
-    <div class="hint">Выберите, что произойдёт при нажатии.</div>
+    <div class="hint">Callback — действие в боте. Ссылка — открытие в браузере. WebApp — сайт внутри Telegram.</div>
 
-    <div id="node_block" class="block" style="display:none;">
-        <div class="field-row">
-            <div>
-                <label>Куда перейти</label>
-                <input type="text" id="node_search" placeholder="Поиск по названию" value="" autocomplete="off">
-                <select name="target_node_code" id="target_node_code">
-                    <option value="">— выберите узел —</option>
-                    {% for group in nodes_groups %}
-                        <optgroup label="{{ group.name }}">
-                            {% for item in group.options %}
-                                <option value="{{ item.code }}" data-label="{{ item.label|lower }}" {% if form_state.target_node_code == item.code %}selected{% endif %}>{{ item.label }} {% if item.usage %}• {{ item.usage }} раз{% endif %}</option>
-                            {% endfor %}
-                        </optgroup>
-                    {% endfor %}
+    <div id="callback_block" class="block" style="display:none;">
+        <label>Действие</label>
+        <select name="callback_action" id="callback_action">
+            {% for value, label in callback_actions %}
+                <option value="{{ value }}" {% if form_state.callback_action == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
+        <div class="hint">Выберите готовое действие — payload сформируется автоматически.</div>
+
+        <div id="node_block" style="display:none;">
+            <div class="field-row">
+                <div>
+                    <label>Куда перейти</label>
+                    <input type="text" id="node_search" placeholder="Поиск по названию" value="" autocomplete="off">
+                    <select name="target_node_code" id="target_node_code">
+                        <option value="">— выберите узел —</option>
+                        {% for group in nodes_groups %}
+                            <optgroup label="{{ group.name }}">
+                                {% for item in group.options %}
+                                    <option value="{{ item.code }}" data-label="{{ item.label|lower }}" {% if form_state.target_node_code == item.code %}selected{% endif %}>{{ item.label }} {% if item.usage %}• {{ item.usage }} раз{% endif %}</option>
+                                {% endfor %}
+                            </optgroup>
+                        {% endfor %}
+                    </select>
+                    <div class="hint">Выберите узел из списка — коды подставятся сами.</div>
+                </div>
+            </div>
+            <div class="inline-actions">
+                <button type="button" class="button" id="toggle_create_node">+ Создать новый узел</button>
+                <span class="muted">Пример: MAIN_MENU → Товары → Категории.</span>
+            </div>
+            <div id="create_node_modal" class="modal">
+                <h4>Создать новый узел</h4>
+                <label>Название узла</label>
+                <input type="text" id="new_node_title" placeholder="Например: Корзинки" value="">
+                <div class="hint">Появится в списке узлов.</div>
+
+                <label>Тип узла</label>
+                <select id="new_node_type">
+                    <option value="MESSAGE">MESSAGE</option>
+                    <option value="CONDITION">CONDITION</option>
+                    <option value="INPUT">INPUT</option>
+                    <option value="ACTION">ACTION</option>
                 </select>
-                <div class="hint">Выберите раздел/категорию из списка. Не нужно писать код.</div>
+                <div class="hint">Оставьте MESSAGE, если нужна простая страница.</div>
+
+                <label>Текст узла</label>
+                <textarea id="new_node_message">Выберите пункт:</textarea>
+                <div class="hint">Что покажет бот в этом узле.</div>
+
+                <label>Код узла (генерируется автоматически)</label>
+                <input type="text" id="new_node_code" disabled value="" placeholder="Будет сгенерирован">
+                <div class="hint">Можно не трогать — код проставится сам.</div>
+
+                <div class="inline-actions" style="margin-top:10px;">
+                    <button type="button" class="button" id="create_node_btn">Создать и выбрать</button>
+                    <button type="button" class="button" style="background:#6b7280;" id="cancel_create_node">Отмена</button>
+                    <span class="muted" id="create_node_status"></span>
+                </div>
             </div>
         </div>
-        <div class="inline-actions">
-            <button type="button" class="button" id="toggle_create_node">+ Создать новый раздел</button>
-            <span class="muted">Пример структуры: MAIN_MENU → Товары → Категории.</span>
-        </div>
-        <div id="create_node_modal" class="modal">
-            <h4>Создать новый раздел</h4>
-            <label>Название раздела</label>
-            <input type="text" id="new_node_title" placeholder="Например: Корзинки" value="">
-            <div class="hint">Название появится в списке узлов.</div>
 
-            <label>Тип узла</label>
-            <select id="new_node_type">
-                <option value="MESSAGE">MESSAGE</option>
-                <option value="CONDITION">CONDITION</option>
-                <option value="INPUT">INPUT</option>
-                <option value="ACTION">ACTION</option>
-            </select>
-            <div class="hint">Оставьте MESSAGE, если нужна простая страница.</div>
-
-            <label>Текст раздела</label>
-            <textarea id="new_node_message">Выберите пункт:</textarea>
-            <div class="hint">Что покажет бот в этом разделе.</div>
-
-            <label>Код узла (генерируется автоматически)</label>
-            <input type="text" id="new_node_code" disabled value="" placeholder="Будет сгенерирован">
-            <div class="hint">Можно не трогать — код проставится сам.</div>
-
-            <div class="inline-actions" style="margin-top:10px;">
-                <button type="button" class="button" id="create_node_btn">Создать и выбрать</button>
-                <button type="button" class="button" style="background:#6b7280;" id="cancel_create_node">Отмена</button>
-                <span class="muted" id="create_node_status"></span>
-            </div>
+        <div id="raw_block" style="display:none;">
+            <label>Payload</label>
+            <input type="text" name="raw_payload" value="{{ form_state.raw_payload or '' }}" placeholder="Например: OPEN_NODE_MASTERCLASSES">
+            <div class="hint">Для продвинутых сценариев. Введите payload вручную.</div>
         </div>
     </div>
 
@@ -116,21 +130,16 @@
         <div class="hint">Откроется внутри Telegram как WebApp.</div>
     </div>
 
-    {% if form_state.legacy_payload %}
-        <input type="hidden" name="legacy_payload" value="{{ form_state.legacy_payload }}">
-        <div class="hint">Старый payload будет сохранён: {{ form_state.legacy_payload }}</div>
-    {% endif %}
-
     <div class="field-row">
         <div>
-            <label>Строка</label>
+            <label>Ряд</label>
             <input type="number" name="row" value="{{ button.row if button else 0 }}">
-            <div class="hint">0 — первая строка.</div>
+            <div class="hint">0 = первая строка кнопок.</div>
         </div>
         <div>
             <label>Позиция</label>
             <input type="number" name="pos" value="{{ button.pos if button else 0 }}">
-            <div class="hint">0 — первая позиция в строке.</div>
+            <div class="hint">0 = первая кнопка в ряду.</div>
         </div>
     </div>
 
@@ -144,10 +153,13 @@
 </form>
 
 <script>
-    const actionSelect = document.getElementById('action_type');
+    const typeSelect = document.getElementById('button_type');
+    const actionSelect = document.getElementById('callback_action');
     const nodeBlock = document.getElementById('node_block');
     const urlBlock = document.getElementById('url_block');
     const webappBlock = document.getElementById('webapp_block');
+    const callbackBlock = document.getElementById('callback_block');
+    const rawBlock = document.getElementById('raw_block');
     const nodeSearch = document.getElementById('node_search');
     const nodeSelect = document.getElementById('target_node_code');
     const toggleCreateNode = document.getElementById('toggle_create_node');
@@ -161,10 +173,14 @@
     const createNodeStatus = document.getElementById('create_node_status');
 
     function syncVisibility() {
-        const value = actionSelect.value;
-        nodeBlock.style.display = value === 'NODE' ? 'block' : 'none';
-        urlBlock.style.display = value === 'URL' ? 'block' : 'none';
-        webappBlock.style.display = value === 'WEBAPP' ? 'block' : 'none';
+        const typeValue = typeSelect.value;
+        const actionValue = actionSelect.value;
+
+        callbackBlock.style.display = typeValue === 'callback' ? 'block' : 'none';
+        nodeBlock.style.display = typeValue === 'callback' && actionValue === 'OPEN_NODE' ? 'block' : 'none';
+        rawBlock.style.display = typeValue === 'callback' && actionValue === 'RAW' ? 'block' : 'none';
+        urlBlock.style.display = typeValue === 'url' ? 'block' : 'none';
+        webappBlock.style.display = typeValue === 'webapp' ? 'block' : 'none';
     }
 
     function filterNodes() {
@@ -213,6 +229,7 @@
         }
     }
 
+    typeSelect.addEventListener('change', syncVisibility);
     actionSelect.addEventListener('change', syncVisibility);
     nodeSearch.addEventListener('input', filterNodes);
     toggleCreateNode.addEventListener('click', () => {

--- a/admin_panel/templates/adminbot_buttons_list.html
+++ b/admin_panel/templates/adminbot_buttons_list.html
@@ -11,6 +11,11 @@
         th { background: #e2e8f0; }
         a.button { padding: 6px 10px; background: #2563eb; color: #fff; text-decoration: none; border-radius: 4px; }
         .muted { color: #475569; font-size: 14px; }
+        .inline { display:flex; gap:12px; align-items:center; flex-wrap: wrap; }
+        .modal { border:1px solid #cbd5e1; border-radius:8px; background:#fff; padding:12px; margin-top:12px; display:none; max-width:420px; }
+        .error { color:#dc2626; margin-top:8px; }
+        input[type="text"], input[type="checkbox"], label, textarea { font-size:14px; }
+        input[type="text"], textarea { width:100%; padding:8px; box-sizing:border-box; border:1px solid #cbd5e1; border-radius:6px; }
     </style>
 </head>
 <body>
@@ -24,16 +29,39 @@
 </header>
 <h2>Кнопки: {{ node.title }} ({{ node.code }})</h2>
 <div class="muted">Выберите действие для каждой кнопки: переход в узел, ссылка или WebApp. Старые кнопки продолжают работать.</div>
-<div style="margin:12px 0; display:flex; gap:12px; align-items:center; flex-wrap: wrap;">
+<div style="margin:12px 0;" class="inline">
     <a href="/adminbot/nodes/{{ node.id }}/buttons/new" class="button">Создать кнопку</a>
+    <button id="open_submenu" class="button" style="border:none;">Создать подменю</button>
     <span class="muted">Совет: начинайте с MAIN_MENU → Товары → Категории.</span>
+</div>
+<div id="submenu_modal" class="modal">
+    <h4>Быстрое подменю</h4>
+    <label>Название подменю</label>
+    <input type="text" id="submenu_title" placeholder="Например: Товары">
+    <div class="muted">Название кнопки и нового узла.</div>
+
+    <label style="margin-top:8px;">Код узла (опционально)</label>
+    <input type="text" id="submenu_code" placeholder="Оставьте пустым, сгенерируем">
+    <div class="muted">Если пусто — код появится автоматически.</div>
+
+    <label style="margin-top:8px;">
+        <input type="checkbox" id="add_back_button" checked> Добавить кнопку «Назад»
+    </label>
+    <div class="muted">Вернёт пользователя в исходный узел.</div>
+
+    <div class="inline" style="margin-top:10px;">
+        <button id="create_submenu" class="button">Создать</button>
+        <button id="cancel_submenu" class="button" style="background:#6b7280; border:none;">Отмена</button>
+        <span class="muted" id="submenu_status"></span>
+    </div>
+    <div class="error" id="submenu_error" style="display:none;"></div>
 </div>
 <table>
     <thead>
     <tr>
         <th>Текст кнопки</th>
-        <th>Действие</th>
-        <th>Значение</th>
+        <th>Тип</th>
+        <th>Цель / payload</th>
         <th>Строка</th>
         <th>Позиция</th>
         <th>Включена</th>
@@ -60,5 +88,58 @@
     {% endfor %}
     </tbody>
 </table>
+<script>
+    const openSubmenuBtn = document.getElementById('open_submenu');
+    const submenuModal = document.getElementById('submenu_modal');
+    const createSubmenuBtn = document.getElementById('create_submenu');
+    const cancelSubmenuBtn = document.getElementById('cancel_submenu');
+    const statusEl = document.getElementById('submenu_status');
+    const errorEl = document.getElementById('submenu_error');
+    const titleInput = document.getElementById('submenu_title');
+    const codeInput = document.getElementById('submenu_code');
+    const backInput = document.getElementById('add_back_button');
+
+    function toggleModal(show) {
+        submenuModal.style.display = show ? 'block' : 'none';
+        if (show) {
+            statusEl.textContent = '';
+            errorEl.style.display = 'none';
+            errorEl.textContent = '';
+        }
+    }
+
+    async function createSubmenu() {
+        statusEl.textContent = 'Создаём подменю...';
+        errorEl.style.display = 'none';
+        const payload = new FormData();
+        payload.append('submenu_title', titleInput.value || 'Новое подменю');
+        payload.append('submenu_code', codeInput.value || '');
+        payload.append('add_back_button', backInput.checked ? 'true' : '');
+
+        try {
+            const response = await fetch('/adminbot/nodes/{{ node.id }}/submenu', {
+                method: 'POST',
+                body: payload,
+            });
+            const data = await response.json();
+            if (!data.ok) {
+                errorEl.textContent = data.error || 'Не удалось создать подменю';
+                errorEl.style.display = 'block';
+                statusEl.textContent = '';
+                return;
+            }
+            statusEl.textContent = 'Готово, перенаправляем...';
+            window.location.href = data.redirect || `/adminbot/nodes/${data.node.id}/buttons`;
+        } catch (e) {
+            errorEl.textContent = 'Ошибка сети при создании подменю';
+            errorEl.style.display = 'block';
+            statusEl.textContent = '';
+        }
+    }
+
+    openSubmenuBtn.addEventListener('click', () => toggleModal(true));
+    cancelSubmenuBtn.addEventListener('click', (e) => { e.preventDefault(); toggleModal(false); });
+    createSubmenuBtn.addEventListener('click', (e) => { e.preventDefault(); createSubmenu(); });
+</script>
 </body>
 </html>

--- a/services/bot_config.py
+++ b/services/bot_config.py
@@ -120,6 +120,13 @@ def _resolve_button_action(button: BotButton) -> InlineKeyboardButton | None:
             return None
         return InlineKeyboardButton(text=button.title, web_app=WebAppInfo(url=webapp_url))
 
+    if action_type in {"BACK", "RAW"}:
+        payload = button.payload
+        if not payload:
+            logger.warning("Не указан payload для callback-кнопки %s", button.id)
+            return None
+        return InlineKeyboardButton(text=button.title, callback_data=payload)
+
     # Совместимость со старыми кнопками
     if button.type == "callback":
         return InlineKeyboardButton(text=button.title, callback_data=button.payload)


### PR DESCRIPTION
## Summary
- обновил форму кнопок: выбор типа (callback/url/webapp), готовые действия callback и выпадающий список узлов
- добавил быстрый мастер «Создать подменю» с автоматическим созданием узла и кнопок
- улучшил отображение целей кнопок и поддержку новых callback payload в рантайме

## Testing
- python -m compileall admin_panel services

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694929cfe7108326979dae9b70ad1f2b)