### PR TITLE
Fix AdminBot admin routes prefix

### DIFF
--- a/admin_panel/routes/adminbot_admins.py
+++ b/admin_panel/routes/adminbot_admins.py
@@ -14,7 +14,7 @@ from models.admin_user import AdminRole, AdminUser, AdminRoleModel
 from services import auth as auth_service
 from services.passwords import hash_password, verify_password
 
-router = APIRouter(prefix="/adminbot", tags=["AdminBotAdmins"])
+router = APIRouter(tags=["AdminBotAdmins"])
 
 ADMIN_ROLES = (
     AdminRole.superadmin,


### PR DESCRIPTION
## Summary
- remove the extra /adminbot prefix from admin routes so admins, profile, and related pages resolve correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949302de20c8326bfacdf118e3b1f44)