### PR TITLE
Add Telegram WebApp shop pages for products and courses

### DIFF
--- a/webapp/css/telegram_shop.css
+++ b/webapp/css/telegram_shop.css
@@ -1,0 +1,195 @@
+body.telegram-shop {
+  background: #f5f7fb;
+  color: #0f172a;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+}
+
+.telegram-shop__main {
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 20px 16px 96px;
+}
+
+.telegram-shop__header {
+  margin-bottom: 16px;
+}
+
+.telegram-shop__breadcrumbs {
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.telegram-shop__title {
+  margin: 4px 0 8px;
+  font-size: 24px;
+}
+
+.telegram-shop__description {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.4;
+}
+
+.telegram-shop__loading,
+.telegram-shop__empty,
+.telegram-shop__error {
+  padding: 24px;
+  border-radius: 16px;
+  background: #fff;
+  text-align: center;
+  color: #374151;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+}
+
+.telegram-shop__error {
+  border: 1px solid #fca5a5;
+  background: #fff1f2;
+  color: #b91c1c;
+}
+
+.telegram-shop__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.telegram-shop__card {
+  background: #fff;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  min-height: 320px;
+}
+
+.telegram-shop__card-image {
+  position: relative;
+  padding-top: 66%;
+  background: linear-gradient(120deg, #eef2ff, #f8fafc);
+}
+
+.telegram-shop__card-image img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.telegram-shop__card-body {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.telegram-shop__card-title {
+  font-size: 16px;
+  margin: 0;
+  color: #111827;
+}
+
+.telegram-shop__card-text {
+  font-size: 14px;
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.4;
+  flex: 1;
+}
+
+.telegram-shop__card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.telegram-shop__price {
+  font-weight: 700;
+  color: #111827;
+}
+
+.telegram-shop__qty-btn {
+  background: #ef4444;
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.telegram-shop__qty-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(239, 68, 68, 0.35);
+}
+
+.telegram-shop__qty-btn:active {
+  transform: translateY(0);
+}
+
+.telegram-shop__qty-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: #f3f4f6;
+  color: #111827;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.telegram-shop__action-bar {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  background: #fff;
+  box-shadow: 0 -6px 24px rgba(15, 23, 42, 0.12);
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  z-index: 10;
+}
+
+.telegram-shop__selected {
+  font-weight: 700;
+  color: #111827;
+}
+
+.telegram-shop__action-button {
+  flex: 1;
+  border: none;
+  border-radius: 12px;
+  padding: 14px 18px;
+  font-weight: 800;
+  background: linear-gradient(120deg, #ef4444, #b91c1c);
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.15s ease, transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.telegram-shop__action-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(239, 68, 68, 0.35);
+}
+
+.telegram-shop__action-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+@media (max-width: 640px) {
+  .telegram-shop__card {
+    min-height: 0;
+  }
+}

--- a/webapp/js/telegram_shop_page.js
+++ b/webapp/js/telegram_shop_page.js
@@ -1,0 +1,235 @@
+(function () {
+  const page = document.querySelector('[data-shop-page]');
+  if (!page) return;
+
+  const type = page.dataset.shopType === 'course' ? 'course' : 'product';
+  const isCourse = type === 'course';
+
+  const titleEl = document.getElementById('category-title');
+  const descriptionEl = document.getElementById('category-description');
+  const gridEl = document.getElementById('items-grid');
+  const loadingEl = document.getElementById('page-loading');
+  const emptyEl = document.getElementById('empty-state');
+  const errorEl = document.getElementById('error-state');
+  const actionBarEl = document.getElementById('action-bar');
+  const actionBtn = document.getElementById('action-button');
+  const selectedCountEl = document.getElementById('selected-count');
+
+  const quantities = new Map();
+  let settings = { action_enabled: true, action_label: null, min_selected: 0 };
+  let category = null;
+
+  function getCategorySlug() {
+    const url = new URL(window.location.href);
+    const byQuery = url.searchParams.get('category') || url.searchParams.get('slug');
+    if (byQuery) return byQuery;
+
+    const parts = window.location.pathname.split('/').filter(Boolean);
+    const anchor = isCourse ? 'courses' : 'products';
+    const anchorIndex = parts.lastIndexOf(anchor);
+    if (anchorIndex !== -1 && parts.length > anchorIndex + 1) {
+      const slugParts = parts.slice(anchorIndex + 1);
+      return slugParts.join('/').replace(/\.html?$/i, '');
+    }
+
+    return null;
+  }
+
+  function formatPrice(value) {
+    const num = Number(value) || 0;
+    if (num === 0) return 'Бесплатно';
+    return `${num.toLocaleString('ru-RU')} ₽`;
+  }
+
+  function updateSelectedCount() {
+    const total = Array.from(quantities.values()).reduce((acc, value) => acc + value, 0);
+    selectedCountEl.textContent = total;
+
+    const minRequired = settings?.min_selected ?? 0;
+    const enabledByAdmin = settings?.action_enabled !== false;
+    const meetsMin = total >= minRequired;
+
+    actionBtn.disabled = !enabledByAdmin || !meetsMin;
+  }
+
+  function buildCard(item) {
+    const card = document.createElement('article');
+    card.className = 'telegram-shop__card';
+
+    const imageWrapper = document.createElement('div');
+    imageWrapper.className = 'telegram-shop__card-image';
+    if (item.image_url) {
+      const img = document.createElement('img');
+      img.src = item.image_url;
+      img.alt = item.title || 'Изображение';
+      imageWrapper.appendChild(img);
+    }
+
+    const body = document.createElement('div');
+    body.className = 'telegram-shop__card-body';
+
+    const title = document.createElement('h3');
+    title.className = 'telegram-shop__card-title';
+    title.textContent = item.title || 'Без названия';
+
+    const text = document.createElement('p');
+    text.className = 'telegram-shop__card-text';
+    text.textContent = item.short_text || '';
+
+    const footer = document.createElement('div');
+    footer.className = 'telegram-shop__card-footer';
+
+    const price = document.createElement('div');
+    price.className = 'telegram-shop__price';
+    price.textContent = formatPrice(item.price);
+
+    const qtyBadge = document.createElement('div');
+    qtyBadge.className = 'telegram-shop__qty-badge';
+    qtyBadge.dataset.itemId = String(item.id);
+    qtyBadge.textContent = '0';
+
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.className = 'telegram-shop__qty-btn';
+    addBtn.textContent = '+';
+    addBtn.addEventListener('click', () => {
+      const current = quantities.get(item.id) || 0;
+      const next = current + 1;
+      quantities.set(item.id, next);
+      qtyBadge.textContent = String(next);
+      updateSelectedCount();
+    });
+
+    const controls = document.createElement('div');
+    controls.style.display = 'flex';
+    controls.style.alignItems = 'center';
+    controls.style.gap = '10px';
+    controls.append(qtyBadge, addBtn);
+
+    footer.append(price, controls);
+    body.append(title, text, footer);
+    card.append(imageWrapper, body);
+    return card;
+  }
+
+  function renderItems(items) {
+    loadingEl?.setAttribute('hidden', '');
+    errorEl?.setAttribute('hidden', '');
+    gridEl.innerHTML = '';
+
+    if (!items || !items.length) {
+      gridEl.setAttribute('hidden', '');
+      emptyEl?.removeAttribute('hidden');
+      actionBarEl?.setAttribute('hidden', '');
+      return;
+    }
+
+    emptyEl?.setAttribute('hidden', '');
+    gridEl.removeAttribute('hidden');
+    actionBarEl?.removeAttribute('hidden');
+
+    items.forEach((item) => {
+      quantities.set(item.id, 0);
+      gridEl.appendChild(buildCard(item));
+    });
+
+    updateSelectedCount();
+  }
+
+  function showError(message) {
+    loadingEl?.setAttribute('hidden', '');
+    emptyEl?.setAttribute('hidden', '');
+    gridEl?.setAttribute('hidden', '');
+    if (errorEl) {
+      errorEl.textContent = message || 'Не удалось загрузить данные';
+      errorEl.removeAttribute('hidden');
+    }
+  }
+
+  function applySettings(nextSettings) {
+    settings = {
+      action_enabled: nextSettings?.action_enabled !== false,
+      action_label: nextSettings?.action_label || null,
+      min_selected: Number.isFinite(nextSettings?.min_selected)
+        ? nextSettings.min_selected
+        : 0,
+    };
+
+    actionBtn.textContent = settings.action_label || 'Продолжить';
+    updateSelectedCount();
+  }
+
+  async function loadSettings(categoryId) {
+    try {
+      const data = await apiGet('/adminsite/webapp-settings', {
+        type,
+        category_id: categoryId,
+      });
+      applySettings(data);
+    } catch (error) {
+      console.warn('Failed to load webapp settings, using defaults', error);
+      applySettings(settings);
+    }
+  }
+
+  async function loadCategory(slug) {
+    const categories = await apiGet('/adminsite/categories', { type });
+    const found = (categories || []).find((item) => item.slug === slug);
+    if (!found) {
+      const err = new Error('Категория не найдена');
+      err.status = 404;
+      throw err;
+    }
+    return found;
+  }
+
+  async function loadItems(categoryId) {
+    return apiGet('/adminsite/items', { type, category_id: categoryId });
+  }
+
+  async function loadPage() {
+    const slug = getCategorySlug();
+    if (!slug) {
+      showError('Не удалось определить категорию из адреса страницы.');
+      return;
+    }
+
+    try {
+      loadingEl?.removeAttribute('hidden');
+      category = await loadCategory(slug);
+      titleEl.textContent = category.title || 'Категория';
+      descriptionEl.textContent = category.description || 'Выберите понравившиеся позиции';
+
+      await loadSettings(category.id);
+      const items = await loadItems(category.id);
+      renderItems(items || []);
+    } catch (error) {
+      console.error('Failed to load webapp catalog page', error);
+      showError(error?.message || 'Произошла ошибка при загрузке каталога');
+    }
+  }
+
+  actionBtn?.addEventListener('click', () => {
+    const total = Array.from(quantities.values()).reduce((sum, qty) => sum + qty, 0);
+    const minRequired = settings?.min_selected ?? 0;
+    if (total < minRequired) return;
+
+    const payload = {
+      source: 'adminsite',
+      type,
+      categorySlug: getCategorySlug(),
+      items: Array.from(quantities.entries())
+        .filter(([, qty]) => qty > 0)
+        .map(([id, qty]) => ({ id, qty })),
+    };
+
+    if (window.Telegram?.WebApp) {
+      window.Telegram.WebApp.sendData(JSON.stringify(payload));
+      window.Telegram.WebApp.close();
+    } else {
+      showToast('Откройте страницу через Telegram');
+    }
+  });
+
+  loadPage();
+})();

--- a/webapp/shop/courses/index.html
+++ b/webapp/shop/courses/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Каталог курсов | MiniDeN</title>
+  <link rel="stylesheet" href="/css/theme.css?v=20251218" />
+  <link rel="stylesheet" href="/css/telegram_shop.css?v=1" />
+</head>
+<body class="telegram-shop">
+  <main class="telegram-shop__main" data-shop-page data-shop-type="course">
+    <header class="telegram-shop__header">
+      <div class="telegram-shop__breadcrumbs">Каталог / Курсы</div>
+      <h1 class="telegram-shop__title" id="category-title">Категория</h1>
+      <p class="telegram-shop__description" id="category-description">Подбираем курсы...</p>
+    </header>
+
+    <section class="telegram-shop__content">
+      <div class="telegram-shop__loading" id="page-loading">Загружаем курсы...</div>
+      <div class="telegram-shop__grid" id="items-grid" hidden></div>
+      <div class="telegram-shop__empty" id="empty-state" hidden>В этой категории пока нет курсов.</div>
+      <div class="telegram-shop__error" id="error-state" hidden></div>
+    </section>
+  </main>
+
+  <div class="telegram-shop__action-bar" id="action-bar" hidden>
+    <div class="telegram-shop__selected">Выбрано: <span id="selected-count">0</span></div>
+    <button class="telegram-shop__action-button" id="action-button" type="button" disabled>Продолжить</button>
+  </div>
+
+  <div id="toast-container"></div>
+
+  <script src="/js/api.js?v=20250610"></script>
+  <script src="/js/telegram_shop_page.js?v=1"></script>
+</body>
+</html>

--- a/webapp/shop/products/index.html
+++ b/webapp/shop/products/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Каталог товаров | MiniDeN</title>
+  <link rel="stylesheet" href="/css/theme.css?v=20251218" />
+  <link rel="stylesheet" href="/css/telegram_shop.css?v=1" />
+</head>
+<body class="telegram-shop">
+  <main class="telegram-shop__main" data-shop-page data-shop-type="product">
+    <header class="telegram-shop__header">
+      <div class="telegram-shop__breadcrumbs">Каталог / Товары</div>
+      <h1 class="telegram-shop__title" id="category-title">Категория</h1>
+      <p class="telegram-shop__description" id="category-description">Подбираем товары...</p>
+    </header>
+
+    <section class="telegram-shop__content">
+      <div class="telegram-shop__loading" id="page-loading">Загружаем товары...</div>
+      <div class="telegram-shop__grid" id="items-grid" hidden></div>
+      <div class="telegram-shop__empty" id="empty-state" hidden>В этой категории пока нет товаров.</div>
+      <div class="telegram-shop__error" id="error-state" hidden></div>
+    </section>
+  </main>
+
+  <div class="telegram-shop__action-bar" id="action-bar" hidden>
+    <div class="telegram-shop__selected">Выбрано: <span id="selected-count">0</span></div>
+    <button class="telegram-shop__action-button" id="action-button" type="button" disabled>Продолжить</button>
+  </div>
+
+  <div id="toast-container"></div>
+
+  <script src="/js/api.js?v=20250610"></script>
+  <script src="/js/telegram_shop_page.js?v=1"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated Telegram WebApp catalog pages for product and course categories
- load categories, items, and webapp settings from the AdminSite API and render selectable cards
- send selected items back to Telegram WebApp with the configured action button and new styles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69498a347e3c8326a66b2a135f1f4a86)