### PR TITLE
Handle adminsite webapp cart payload

### DIFF
--- a/handlers/webapp.py
+++ b/handlers/webapp.py
@@ -2,12 +2,90 @@ import json
 import logging
 
 from aiogram import F, Router
-from aiogram.types import Message
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message, WebAppInfo
 
+from config import get_settings
 from services.cart import add_to_cart
 from services.products import get_product_by_id
 
 router = Router()
+
+
+def _build_adminsite_menu() -> InlineKeyboardMarkup:
+    settings = get_settings()
+    cart_url = settings.webapp_cart_url or settings.webapp_index_url
+
+    inline_keyboard: list[list[InlineKeyboardButton]] = []
+    if cart_url:
+        inline_keyboard.append(
+            [
+                InlineKeyboardButton(
+                    text="Оплатить сейчас",
+                    web_app=WebAppInfo(url=cart_url),
+                )
+            ]
+        )
+    inline_keyboard.append(
+        [InlineKeyboardButton(text="Связаться в чат", callback_data="contact_manager")]
+    )
+    if cart_url:
+        inline_keyboard.append(
+            [
+                InlineKeyboardButton(
+                    text="Корзина",
+                    web_app=WebAppInfo(url=cart_url),
+                )
+            ]
+        )
+
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def _is_valid_adminsite_item(item: dict) -> bool:
+    return isinstance(item, dict) and item.get("id") is not None
+
+
+async def _handle_adminsite_payload(message: Message, payload: dict) -> None:
+    if payload.get("source") != "adminsite":
+        return
+
+    items = payload.get("items")
+    if not isinstance(items, list):
+        logging.warning("Некорректный items в adminsite payload: %s", items)
+        return
+
+    mapped_type = "course" if payload.get("type") == "course" else "basket"
+
+    added_count = 0
+    for item in items:
+        if not _is_valid_adminsite_item(item):
+            continue
+        try:
+            product_id = int(item.get("id"))
+            qty = int(item.get("qty") or 1)
+            qty = max(qty, 1)
+        except (TypeError, ValueError):
+            logging.warning("Некорректный item в adminsite payload: %s", item)
+            continue
+
+        try:
+            add_to_cart(
+                user_id=message.from_user.id,
+                product_id=product_id,
+                product_type=mapped_type,
+                qty=qty,
+            )
+        except Exception:
+            logging.exception(
+                "Ошибка при добавлении товара из adminsite web_app_data: %s", item
+            )
+            continue
+        added_count += 1
+
+    reply_markup = _build_adminsite_menu()
+    await message.answer(
+        f"Добавлено: {added_count} позиций", reply_markup=reply_markup, disable_notification=True
+    )
 
 
 @router.message(F.web_app_data)
@@ -20,11 +98,19 @@ async def handle_webapp_data(message: Message) -> None:
     if not message.web_app_data or not message.web_app_data.data:
         return
 
+    if not message.from_user:
+        logging.warning("web_app_data received without from_user")
+        return
+
     raw = message.web_app_data.data
     try:
         data = json.loads(raw)
     except Exception:
         logging.exception("Не удалось разобрать web_app_data: %s", raw)
+        return
+
+    if data.get("source") == "adminsite":
+        await _handle_adminsite_payload(message, data)
         return
 
     if data.get("action") != "add_to_cart":


### PR DESCRIPTION
## Summary
- parse adminsite web_app_data payloads and add selected items to the user cart
- reply with quick menu buttons for payment, chat contact, and cart access after WebApp closes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69498b8e4b488326bd29e5b416aef193)