### PR TITLE
Refactor adminsite API into router/service modules

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -183,6 +183,48 @@ Production деплой одной командой
 - Добавлен раздел «Брендинг»: из админки можно задать название сайта, загрузить логотип и favicon. Пути хранятся в таблице `site_branding`, файлы складываются в `/media/branding/`.
 - Поддерживаемые форматы: логотип — PNG/JPG/JPEG/WEBP/SVG (до 5 МБ), favicon — ICO/PNG/SVG (до 2 МБ). При отсутствии файлов используется дефолтный `/favicon.ico` и текстовый логотип MiniDeN.
 - После замены логотипа или favicon автоматически увеличивается `assets_version`, а ссылки на ресурсы приходят с суффиксом `?v=...`, чтобы сбрасывать кеш в браузерах.
+- Данные брендинга отдаются через публичный endpoint `/api/branding` для WebApp.
+
+AdminSite API (категории, товары/курсы, настройки WebApp)
+----------------------------------------------------------
+
+Все методы под префиксом `/api/adminsite/*`, требуют авторизации администратора (`superadmin` или `admin_site`). Схемы полностью совместимы с Pydantic v2.
+
+- Health-check: `GET /api/adminsite/health` → `{ "ok": true }`.
+- Категории:
+  - `GET /api/adminsite/categories?type=product|course`
+  - `POST /api/adminsite/categories`
+  - `PUT /api/adminsite/categories/{id}`
+  - `DELETE /api/adminsite/categories/{id}` (удаление запрещено, если есть товары/курсы в категории)
+- Элементы (товары/мастер-классы):
+  - `GET /api/adminsite/items?type=product|course&category_id=<id>`
+  - `POST /api/adminsite/items`
+  - `PUT /api/adminsite/items/{id}`
+  - `DELETE /api/adminsite/items/{id}`
+- Настройки WebApp (красная кнопка):
+  - `GET /api/adminsite/webapp-settings?type=product|course&category_id=<id>` — отдаёт настройки для категории или глобальные, если категория не настроена.
+  - `PUT /api/adminsite/webapp-settings` — upsert по `scope+type+category_id`.
+
+Примеры curl (замените `<cookie>` на значение `admin_session`):
+
+```bash
+curl -H "Cookie: admin_session=<cookie>" "http://127.0.0.1:8000/api/adminsite/categories?type=product"
+
+curl -H "Cookie: admin_session=<cookie>" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"product","title":"Керамика","slug":null,"sort":10}' \
+  http://127.0.0.1:8000/api/adminsite/categories
+
+curl -H "Cookie: admin_session=<cookie>" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"product","category_id":1,"title":"Бокал","price":990}' \
+  http://127.0.0.1:8000/api/adminsite/items
+
+curl -H "Cookie: admin_session=<cookie>" \
+  -H "Content-Type: application/json" \
+  -d '{"scope":"global","type":"product","action_label":"Купить","min_selected":1}' \
+  http://127.0.0.1:8000/api/adminsite/webapp-settings
+```
 
 ### Система отзывов
 

--- a/admin_panel/adminsite/__init__.py
+++ b/admin_panel/adminsite/__init__.py
@@ -1,5 +1,5 @@
 """API and utilities for AdminSite constructor."""
 
-from admin_panel.adminsite.api import router
+from admin_panel.adminsite.router import router
 
 __all__ = ["router"]

--- a/admin_panel/adminsite/router.py
+++ b/admin_panel/adminsite/router.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy.orm import Session
+
+from admin_panel.dependencies import get_db_session
+from . import service
+from .schemas import (
+    CategoryPayload,
+    CategoryResponse,
+    CategoryUpdatePayload,
+    ItemPayload,
+    ItemResponse,
+    ItemUpdatePayload,
+    WebAppSettingsPayload,
+    WebAppSettingsResponse,
+)
+
+TypeQuery = Annotated[str, Query(pattern="^(product|course)$")]
+
+router = APIRouter(prefix="/api/adminsite", tags=["AdminSite"])
+
+
+@router.get("/health")
+def healthcheck() -> dict[str, bool]:
+    return {"ok": True}
+
+
+@router.get("/categories", response_model=list[CategoryResponse])
+def list_categories(
+    request: Request,
+    type: TypeQuery,
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    categories = service.list_categories(db, type)
+    return categories
+
+
+@router.post("/categories", response_model=CategoryResponse)
+def create_category(
+    payload: CategoryPayload,
+    request: Request,
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    category = service.create_category(db, payload)
+    return category
+
+
+@router.put("/categories/{category_id}", response_model=CategoryResponse)
+def update_category(
+    category_id: int,
+    payload: CategoryUpdatePayload,
+    request: Request,
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    category = service.update_category(db, category_id, payload)
+    return category
+
+
+@router.delete("/categories/{category_id}")
+def delete_category(
+    category_id: int,
+    request: Request,
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    return service.delete_category(db, category_id)
+
+
+@router.get("/items", response_model=list[ItemResponse])
+def list_items(
+    request: Request,
+    type: TypeQuery,
+    category_id: int | None = Query(None),
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    items = service.list_items(db, type, category_id)
+    return items
+
+
+@router.post("/items", response_model=ItemResponse)
+def create_item(
+    payload: ItemPayload,
+    request: Request,
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    item = service.create_item(db, payload)
+    return item
+
+
+@router.put("/items/{item_id}", response_model=ItemResponse)
+def update_item(
+    item_id: int,
+    payload: ItemUpdatePayload,
+    request: Request,
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    item = service.update_item(db, item_id, payload)
+    return item
+
+
+@router.delete("/items/{item_id}")
+def delete_item(
+    item_id: int,
+    request: Request,
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    return service.delete_item(db, item_id)
+
+
+@router.get("/webapp-settings", response_model=WebAppSettingsResponse)
+def get_webapp_settings(
+    request: Request,
+    type: TypeQuery,
+    category_id: int | None = Query(None),
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    settings = service.get_webapp_settings(db, type, category_id)
+    return settings
+
+
+@router.put("/webapp-settings", response_model=WebAppSettingsResponse)
+def upsert_webapp_settings(
+    payload: WebAppSettingsPayload,
+    request: Request,
+    db: Session = Depends(get_db_session),
+):
+    service.ensure_admin(request, db)
+    settings = service.upsert_webapp_settings(db, payload)
+    return settings

--- a/admin_panel/adminsite/schemas.py
+++ b/admin_panel/adminsite/schemas.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+
+TypeLiteral = Literal["product", "course"]
+ScopeLiteral = Literal["global", "category"]
+SlugPattern = r"^[a-z0-9]+(?:-[a-z0-9]+)*$"
+
+
+class CategoryPayload(BaseModel):
+    type: TypeLiteral
+    title: str
+    slug: str | None = Field(default=None, pattern=SlugPattern)
+    parent_id: int | None = None
+    is_active: bool = True
+    sort: int = 0
+
+
+class CategoryUpdatePayload(BaseModel):
+    type: TypeLiteral | None = None
+    title: str | None = None
+    slug: str | None = Field(default=None, pattern=SlugPattern)
+    parent_id: int | None = None
+    is_active: bool | None = None
+    sort: int | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class CategoryResponse(BaseModel):
+    id: int
+    type: TypeLiteral
+    title: str
+    slug: str
+    parent_id: int | None
+    is_active: bool
+    sort: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ItemPayload(BaseModel):
+    type: TypeLiteral
+    category_id: int
+    title: str
+    slug: str | None = Field(default=None, pattern=SlugPattern)
+    price: Decimal = Field(ge=0)
+    image_url: str | None = None
+    short_text: str | None = None
+    description: str | None = None
+    is_active: bool = True
+    sort: int = 0
+
+    @field_validator("price", mode="before")
+    def _coerce_price(cls, value: Decimal | str | int) -> Decimal:
+        return Decimal(value)
+
+
+class ItemUpdatePayload(BaseModel):
+    type: TypeLiteral | None = None
+    category_id: int | None = None
+    title: str | None = None
+    slug: str | None = Field(default=None, pattern=SlugPattern)
+    price: Decimal | None = Field(default=None, ge=0)
+    image_url: str | None = None
+    short_text: str | None = None
+    description: str | None = None
+    is_active: bool | None = None
+    sort: int | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+    @field_validator("price", mode="before")
+    def _coerce_price(cls, value: Decimal | str | int | None) -> Decimal | None:
+        if value is None:
+            return None
+        return Decimal(value)
+
+
+class ItemResponse(BaseModel):
+    id: int
+    type: TypeLiteral
+    category_id: int
+    title: str
+    slug: str
+    price: Decimal
+    image_url: str | None
+    short_text: str | None
+    description: str | None
+    is_active: bool
+    sort: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class WebAppSettingsPayload(BaseModel):
+    scope: ScopeLiteral
+    type: TypeLiteral
+    category_id: int | None = None
+    action_enabled: bool = True
+    action_label: str | None = "Оформить"
+    min_selected: int = Field(1, ge=0)
+
+    @field_validator("category_id")
+    def _validate_category_scope(
+        cls, value: int | None, info: ValidationInfo
+    ) -> int | None:
+        scope = (info.data or {}).get("scope")
+        if scope == "category" and value is None:
+            raise ValueError("category_id is required when scope=category")
+        if scope == "global" and value is not None:
+            raise ValueError("category_id must be null when scope=global")
+        return value
+
+
+class WebAppSettingsResponse(BaseModel):
+    id: int
+    scope: ScopeLiteral
+    type: TypeLiteral
+    category_id: int | None
+    action_enabled: bool
+    action_label: str | None
+    min_selected: int
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- restructured AdminSite API into dedicated router, schemas, and service layers under /api/adminsite
- kept slug generation and admin validation logic with Pydantic v2 schemas and defaults
- documented AdminSite API endpoints and curl examples in README

## Testing
- python -m compileall admin_panel/adminsite


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694992adf67883269f55864dce266099)