### PR TITLE
Add AdminSite constructor UI with modular assets

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -198,12 +198,24 @@ AdminSite API (категории, товары/курсы, настройки W
   - `DELETE /api/adminsite/categories/{id}` (удаление запрещено, если есть товары/курсы в категории)
 - Элементы (товары/мастер-классы):
   - `GET /api/adminsite/items?type=product|course&category_id=<id>`
-  - `POST /api/adminsite/items`
-  - `PUT /api/adminsite/items/{id}`
-  - `DELETE /api/adminsite/items/{id}`
-- Настройки WebApp (красная кнопка):
-  - `GET /api/adminsite/webapp-settings?type=product|course&category_id=<id>` — отдаёт настройки для категории или глобальные, если категория не настроена.
-  - `PUT /api/adminsite/webapp-settings` — upsert по `scope+type+category_id`.
+
+    - `POST /api/adminsite/items`
+    - `PUT /api/adminsite/items/{id}`
+    - `DELETE /api/adminsite/items/{id}`
+  - Настройки WebApp (красная кнопка):
+    - `GET /api/adminsite/webapp-settings?type=product|course&category_id=<id>` — отдаёт настройки для категории или глобальные, если категория не настроена.
+    - `PUT /api/adminsite/webapp-settings` — upsert по `scope+type+category_id`.
+
+AdminPanel/adminsite: страницы конструктора
+-------------------------------------------
+- Маршрут `/adminsite/constructor` открывает новый раздел "AdminSite Конструктор" с вкладками для CRUD категорий и элементов, а также настройки красной WebApp-кнопки.
+- Шаблон: `admin_panel/templates/adminsite/constructor.html` (вкладки, таблицы, форма WebApp).
+- Статические модули:
+  - `admin_panel/static/js/adminsite/apiClient.js` — обёртка над fetch с разбором ошибок.
+  - `admin_panel/static/js/adminsite/modals.js` — компоненты CategoryModal и ItemModal с блокировкой кнопок на время сохранения.
+  - `admin_panel/static/js/adminsite/constructor.js` — логика страниц: загрузка данных, фильтры, поиск по названию, CRUD и настройка WebApp.
+  - `admin_panel/static/css/adminsite/constructor.css` — стили карточек, таблиц, модалок и тостов.
+- Новые кнопки навигации на страницах админки ведут в раздел "AdminSite Конструктор".
 
 Примеры curl (замените `<cookie>` на значение `admin_session`):
 

--- a/admin_panel/static/css/adminsite/constructor.css
+++ b/admin_panel/static/css/adminsite/constructor.css
@@ -1,0 +1,325 @@
+:root {
+    --bg: #0b1220;
+    --card: #0f172a;
+    --border: #1e293b;
+    --primary: #a855f7;
+    --primary-dark: #7c3aed;
+    --text: #e5e7eb;
+    --muted: #9ca3af;
+    --danger: #f87171;
+    --success: #34d399;
+    --accent: #38bdf8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    font-family: Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    margin: 0;
+}
+
+header {
+    background: var(--primary);
+    color: #0b1220;
+    padding: 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+header .nav {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+header a {
+    color: #0b1220;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+main {
+    padding: 24px;
+}
+
+h1 {
+    margin: 0 0 12px;
+}
+
+.tabs {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+}
+
+.tab {
+    padding: 10px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: var(--card);
+    color: var(--text);
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.tab.active {
+    background: var(--primary);
+    color: #0b1220;
+    border-color: var(--primary);
+}
+
+.panel {
+    display: none;
+}
+
+.panel.active {
+    display: block;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: 360px 1fr;
+    gap: 16px;
+    align-items: start;
+}
+
+.card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 16px;
+}
+
+label {
+    display: block;
+    margin-top: 10px;
+    font-size: 14px;
+    color: var(--muted);
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: #0b1220;
+    color: var(--text);
+    margin-top: 6px;
+}
+
+textarea {
+    min-height: 100px;
+    resize: vertical;
+}
+
+.actions {
+    margin-top: 14px;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+button {
+    border: none;
+    border-radius: 10px;
+    cursor: pointer;
+    padding: 10px 14px;
+    font-weight: bold;
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: #0b1220;
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled,
+.btn-danger:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.btn-secondary {
+    background: var(--border);
+    color: var(--text);
+}
+
+.btn-danger {
+    background: var(--danger);
+    color: #0b1220;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 8px;
+}
+
+th,
+td {
+    border: 1px solid var(--border);
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background: #111827;
+    color: var(--muted);
+}
+
+tr:nth-child(even) {
+    background: #0b1220;
+}
+
+.badge {
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-size: 12px;
+    background: #1e293b;
+    color: var(--muted);
+}
+
+.muted {
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.flex {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.status {
+    margin: 0 0 12px;
+    min-height: 20px;
+}
+
+.status.error {
+    color: var(--danger);
+}
+
+.status.success {
+    color: var(--success);
+}
+
+.table-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.pill {
+    background: #111827;
+    padding: 4px 6px;
+    border-radius: 8px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.stack {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.table-top {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.search-input {
+    max-width: 220px;
+}
+
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 30;
+}
+
+.modal {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 18px;
+    width: min(620px, 92vw);
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+.modal header {
+    position: static;
+    background: none;
+    color: var(--text);
+    padding: 0 0 12px;
+}
+
+.modal h3 {
+    margin: 0;
+}
+
+.modal .actions {
+    justify-content: flex-end;
+}
+
+.toast-container {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 40;
+}
+
+.toast {
+    background: #0f172a;
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 10px 12px;
+    border-radius: 10px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    min-width: 220px;
+}
+
+.toast.error {
+    border-color: var(--danger);
+    color: #fecdd3;
+}
+
+.toast.success {
+    border-color: var(--success);
+    color: #bbf7d0;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 12px;
+}
+
+@media (max-width: 1024px) {
+    .grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/admin_panel/static/js/adminsite/apiClient.js
+++ b/admin_panel/static/js/adminsite/apiClient.js
@@ -1,0 +1,33 @@
+const defaultHeaders = { 'Content-Type': 'application/json' };
+
+function parseErrorDetail(detail) {
+    if (!detail) return 'Ошибка запроса';
+    if (typeof detail === 'string') return detail;
+    if (detail.detail) return parseErrorDetail(detail.detail);
+    return JSON.stringify(detail);
+}
+
+export async function apiRequest(url, options = {}) {
+    const opts = { credentials: 'same-origin', ...options };
+    if (opts.body && !(opts.body instanceof FormData)) {
+        opts.headers = { ...defaultHeaders, ...(opts.headers || {}) };
+        opts.body = JSON.stringify(opts.body);
+    }
+
+    const response = await fetch(url, opts);
+    let payload = null;
+    try {
+        if (response.status !== 204) {
+            payload = await response.json();
+        }
+    } catch (_) {
+        /* ignore parse errors */
+    }
+
+    if (!response.ok) {
+        const message = payload ? parseErrorDetail(payload) : `HTTP ${response.status}`;
+        throw new Error(message);
+    }
+
+    return payload;
+}

--- a/admin_panel/static/js/adminsite/constructor.js
+++ b/admin_panel/static/js/adminsite/constructor.js
@@ -1,0 +1,392 @@
+import { apiRequest } from './apiClient.js';
+import { CategoryModal, ItemModal } from './modals.js';
+
+const state = {
+    categories: { product: [], course: [] },
+    items: { product: [], course: [] },
+    filters: {
+        product: { categoryId: '', search: '' },
+        course: { categoryId: '', search: '' },
+    },
+};
+
+const toastContainer = document.createElement('div');
+toastContainer.className = 'toast-container';
+document.body.appendChild(toastContainer);
+
+function showToast(message, type = 'info') {
+    const toast = document.createElement('div');
+    toast.className = `toast ${type === 'error' ? 'error' : type === 'success' ? 'success' : ''}`;
+    toast.textContent = message;
+    toastContainer.appendChild(toast);
+    setTimeout(() => toast.remove(), 4000);
+}
+
+const translitMap = {
+    'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd', 'е': 'e', 'ё': 'e', 'ж': 'zh', 'з': 'z', 'и': 'i',
+    'й': 'i', 'к': 'k', 'л': 'l', 'м': 'm', 'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't',
+    'у': 'u', 'ф': 'f', 'х': 'h', 'ц': 'c', 'ч': 'ch', 'ш': 'sh', 'щ': 'sch', 'ы': 'y', 'э': 'e', 'ю': 'yu', 'я': 'ya',
+    'ъ': '', 'ь': ''
+};
+
+function transliterate(value) {
+    return value
+        .split('')
+        .map((ch) => {
+            const lower = ch.toLowerCase();
+            const mapped = translitMap[lower];
+            if (mapped === undefined) return ch;
+            return ch === lower ? mapped : mapped.toUpperCase();
+        })
+        .join('');
+}
+
+function slugify(value) {
+    const transliterated = transliterate(value);
+    const normalized = transliterated.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+    return normalized
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '')
+        .replace(/-{2,}/g, '-');
+}
+
+function setStatus(targetId, message, isError = false) {
+    const el = document.getElementById(targetId);
+    if (!el) return;
+    el.textContent = message || '';
+    el.classList.remove('error', 'success');
+    if (message) {
+        el.classList.add(isError ? 'error' : 'success');
+    }
+}
+
+function categoryOptions(type) {
+    return state.categories[type] || [];
+}
+
+async function loadCategories(type) {
+    const target = `status-categories-${type}`;
+    setStatus(target, 'Загрузка...');
+    try {
+        const data = await apiRequest(`/api/adminsite/categories?type=${type}`);
+        state.categories[type] = data;
+        renderCategoryTable(type);
+        renderCategorySelects(type);
+        setStatus(target, `Загружено: ${data.length}`);
+    } catch (error) {
+        setStatus(target, error.message, true);
+        showToast(error.message, 'error');
+    }
+}
+
+function renderCategoryTable(type) {
+    const tbody = document.getElementById(`categories-list-${type}`);
+    tbody.innerHTML = '';
+    state.categories[type].forEach((category) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${category.id}</td>
+            <td>${category.title}</td>
+            <td>${category.slug || ''}</td>
+            <td>${category.is_active ? 'Да' : 'Нет'}</td>
+            <td>${category.sort ?? ''}</td>
+            <td>${category.created_at ? new Date(category.created_at).toLocaleString() : ''}</td>
+            <td>
+                <div class="table-actions">
+                    <button class="btn-secondary" data-action="edit">Редактировать</button>
+                    <button class="btn-danger" data-action="delete">Удалить</button>
+                </div>
+            </td>
+        `;
+        tr.querySelector('[data-action="edit"]').addEventListener('click', () => openCategoryModal(type, category));
+        tr.querySelector('[data-action="delete"]').addEventListener('click', () => deleteCategory(type, category.id));
+        tbody.appendChild(tr);
+    });
+}
+
+function renderCategorySelects(type) {
+    const filter = document.getElementById(`items-filter-${type}`);
+    const selects = [filter];
+    const webappSelect = document.getElementById('webapp-category');
+    const webappType = document.getElementById('webapp-type');
+    if (webappSelect && webappType.value === type) {
+        selects.push(webappSelect);
+    }
+
+    selects.forEach((select) => {
+        if (!select) return;
+        select.innerHTML = '';
+        if (select === filter) {
+            const allOption = document.createElement('option');
+            allOption.value = '';
+            allOption.textContent = 'Все категории';
+            select.appendChild(allOption);
+        }
+        state.categories[type].forEach((cat) => {
+            const option = document.createElement('option');
+            option.value = cat.id;
+            option.textContent = cat.title;
+            select.appendChild(option);
+        });
+    });
+}
+
+async function deleteCategory(type, id) {
+    if (!confirm('Удалить категорию?')) return;
+    try {
+        await apiRequest(`/api/adminsite/categories/${id}`, { method: 'DELETE' });
+        showToast('Категория удалена', 'success');
+        await loadCategories(type);
+    } catch (error) {
+        setStatus(`status-categories-${type}`, error.message, true);
+        showToast(error.message, 'error');
+    }
+}
+
+async function upsertCategory(type, payload) {
+    const body = {
+        type,
+        title: payload.title,
+        slug: payload.slug || slugify(payload.title),
+        is_active: payload.is_active,
+        sort: payload.sort ?? 0,
+    };
+    const method = payload.id ? 'PUT' : 'POST';
+    const url = payload.id ? `/api/adminsite/categories/${payload.id}` : '/api/adminsite/categories';
+    await apiRequest(url, { method, body });
+    await loadCategories(type);
+    showToast('Категория сохранена', 'success');
+}
+
+async function loadItems(type) {
+    const filter = state.filters[type];
+    const params = new URLSearchParams({ type });
+    if (filter.categoryId) {
+        params.append('category_id', filter.categoryId);
+    }
+    const target = `status-items-${type}`;
+    setStatus(target, 'Загрузка...');
+    try {
+        const data = await apiRequest(`/api/adminsite/items?${params.toString()}`);
+        state.items[type] = data;
+        renderItemsTable(type);
+        setStatus(target, `Загружено: ${data.length}`);
+    } catch (error) {
+        state.items[type] = [];
+        renderItemsTable(type);
+        setStatus(target, error.message, true);
+        showToast(error.message, 'error');
+    }
+}
+
+function renderItemsTable(type) {
+    const tbody = document.getElementById(`items-list-${type}`);
+    tbody.innerHTML = '';
+    const filter = state.filters[type];
+    const search = filter.search.toLowerCase();
+    const rows = state.items[type].filter((item) => {
+        const title = item.title || '';
+        return !search || title.toLowerCase().includes(search);
+    });
+    rows.forEach((item) => {
+        const categoryTitle = state.categories[type].find((c) => c.id === item.category_id)?.title || '';
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${item.id}</td>
+            <td>${item.title}</td>
+            <td>${categoryTitle}</td>
+            <td>${item.price ?? ''}</td>
+            <td>${item.is_active ? 'Да' : 'Нет'}</td>
+            <td>${item.sort ?? ''}</td>
+            <td>
+                <div class="table-actions">
+                    <button class="btn-secondary" data-action="edit">Редактировать</button>
+                    <button class="btn-danger" data-action="delete">Удалить</button>
+                </div>
+            </td>
+        `;
+        tr.querySelector('[data-action="edit"]').addEventListener('click', () => openItemModal(type, item));
+        tr.querySelector('[data-action="delete"]').addEventListener('click', () => deleteItem(type, item.id));
+        tbody.appendChild(tr);
+    });
+}
+
+async function deleteItem(type, id) {
+    if (!confirm('Удалить элемент?')) return;
+    try {
+        await apiRequest(`/api/adminsite/items/${id}`, { method: 'DELETE' });
+        await loadItems(type);
+        showToast('Элемент удалён', 'success');
+    } catch (error) {
+        setStatus(`status-items-${type}`, error.message, true);
+        showToast(error.message, 'error');
+    }
+}
+
+async function upsertItem(type, payload) {
+    const body = {
+        type,
+        category_id: payload.category_id,
+        title: payload.title,
+        slug: payload.slug || slugify(payload.title),
+        price: payload.price ?? 0,
+        image_url: payload.image_url,
+        short_text: payload.short_text,
+        description: payload.description,
+        is_active: payload.is_active,
+        sort: payload.sort ?? 0,
+    };
+    const method = payload.id ? 'PUT' : 'POST';
+    const url = payload.id ? `/api/adminsite/items/${payload.id}` : '/api/adminsite/items';
+    await apiRequest(url, { method, body });
+    await loadItems(type);
+    showToast('Элемент сохранён', 'success');
+}
+
+async function loadWebappSettings() {
+    const type = document.getElementById('webapp-type').value;
+    const scope = document.getElementById('webapp-scope').value;
+    const categorySelect = document.getElementById('webapp-category');
+    const params = new URLSearchParams({ type });
+    if (scope === 'category' && categorySelect.value) {
+        params.append('category_id', categorySelect.value);
+    }
+    try {
+        const data = await apiRequest(`/api/adminsite/webapp-settings?${params.toString()}`);
+        document.getElementById('webapp-enabled').checked = data.action_enabled;
+        document.getElementById('webapp-label').value = data.action_label || '';
+        document.getElementById('webapp-min-selected').value = data.min_selected ?? 0;
+        setStatus('status-webapp', 'Настройки загружены');
+    } catch (error) {
+        document.getElementById('webapp-enabled').checked = false;
+        document.getElementById('webapp-label').value = '';
+        document.getElementById('webapp-min-selected').value = 0;
+        setStatus('status-webapp', error.message, true);
+        showToast(error.message, 'error');
+    }
+}
+
+async function saveWebappSettings(event) {
+    event.preventDefault();
+    const button = event.submitter || event.target.querySelector('button[type="submit"]');
+    if (button) button.disabled = true;
+    const type = document.getElementById('webapp-type').value;
+    const scope = document.getElementById('webapp-scope').value;
+    const categorySelect = document.getElementById('webapp-category');
+    const payload = {
+        scope,
+        type,
+        category_id: scope === 'category' ? Number(categorySelect.value) : null,
+        action_enabled: document.getElementById('webapp-enabled').checked,
+        action_label: document.getElementById('webapp-label').value || null,
+        min_selected: Number(document.getElementById('webapp-min-selected').value) || 0,
+    };
+    try {
+        await apiRequest('/api/adminsite/webapp-settings', { method: 'PUT', body: payload });
+        setStatus('status-webapp', 'Настройки сохранены');
+        showToast('Настройки сохранены', 'success');
+        await loadWebappSettings();
+    } catch (error) {
+        setStatus('status-webapp', error.message, true);
+        showToast(error.message, 'error');
+    } finally {
+        if (button) button.disabled = false;
+    }
+}
+
+function toggleWebappCategory() {
+    const scope = document.getElementById('webapp-scope').value;
+    document.getElementById('webapp-category-wrapper').style.display = scope === 'category' ? 'block' : 'none';
+}
+
+function setupTabs() {
+    document.querySelectorAll('.tab').forEach((tab) => {
+        tab.addEventListener('click', () => {
+            const target = tab.dataset.tab;
+            document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
+            document.querySelectorAll('.panel').forEach((panel) => {
+                panel.classList.toggle('active', panel.id === `panel-${target}`);
+            });
+            tab.classList.add('active');
+        });
+    });
+}
+
+const categoryModals = {
+    product: new CategoryModal({ title: 'Категория товара', onSubmit: (payload) => upsertCategory('product', payload) }),
+    course: new CategoryModal({ title: 'Категория мастер-классов', onSubmit: (payload) => upsertCategory('course', payload) }),
+};
+
+const itemModals = {
+    product: new ItemModal({
+        title: 'Товар',
+        categoriesProvider: (type) => categoryOptions(type),
+        onSubmit: (payload) => upsertItem('product', payload),
+    }),
+    course: new ItemModal({
+        title: 'Мастер-класс',
+        categoriesProvider: (type) => categoryOptions(type),
+        onSubmit: (payload) => upsertItem('course', payload),
+    }),
+};
+
+function openCategoryModal(type, category = null) {
+    categoryModals[type].setData(category);
+    categoryModals[type].open();
+}
+
+function openItemModal(type, item = null) {
+    itemModals[type].setData(item, type);
+    itemModals[type].open();
+}
+
+function setupButtons() {
+    ['product', 'course'].forEach((type) => {
+        document.getElementById(`category-create-${type}`).addEventListener('click', () => openCategoryModal(type));
+        document.getElementById(`item-create-${type}`).addEventListener('click', () => openItemModal(type));
+        document.getElementById(`items-filter-${type}`).addEventListener('change', (event) => {
+            state.filters[type].categoryId = event.target.value;
+            loadItems(type);
+        });
+        document.getElementById(`items-search-${type}`).addEventListener('input', (event) => {
+            state.filters[type].search = event.target.value;
+            renderItemsTable(type);
+        });
+    });
+
+    document.getElementById('webapp-type').addEventListener('change', async () => {
+        renderCategorySelects(document.getElementById('webapp-type').value);
+        toggleWebappCategory();
+        await loadWebappSettings();
+    });
+    document.getElementById('webapp-scope').addEventListener('change', async () => {
+        toggleWebappCategory();
+        await loadWebappSettings();
+    });
+    document.getElementById('webapp-category').addEventListener('change', loadWebappSettings);
+    document.getElementById('webapp-form').addEventListener('submit', saveWebappSettings);
+    document.getElementById('webapp-reload').addEventListener('click', (e) => {
+        e.preventDefault();
+        loadWebappSettings();
+    });
+}
+
+async function bootstrap() {
+    setupTabs();
+    setupButtons();
+    toggleWebappCategory();
+    try {
+        await loadCategories('product');
+        await loadCategories('course');
+        await loadItems('product');
+        await loadItems('course');
+        await loadWebappSettings();
+        setStatus('global-status', 'Данные загружены');
+    } catch (error) {
+        setStatus('global-status', error.message, true);
+        showToast(error.message, 'error');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', bootstrap);

--- a/admin_panel/static/js/adminsite/modals.js
+++ b/admin_panel/static/js/adminsite/modals.js
@@ -1,0 +1,197 @@
+function createElement(html) {
+    const tpl = document.createElement('template');
+    tpl.innerHTML = html.trim();
+    return tpl.content.firstElementChild;
+}
+
+class BaseModal {
+    constructor(title) {
+        this.backdrop = createElement('<div class="modal-backdrop" hidden></div>');
+        this.modal = createElement('<div class="modal"></div>');
+        this.title = title;
+        this.status = createElement('<div class="status"></div>');
+        const header = createElement('<header><h3></h3></header>');
+        header.querySelector('h3').textContent = title;
+        this.modal.appendChild(header);
+        this.modal.appendChild(this.status);
+        this.backdrop.appendChild(this.modal);
+        document.body.appendChild(this.backdrop);
+    }
+
+    showMessage(text, isError = false) {
+        this.status.textContent = text || '';
+        this.status.classList.toggle('error', Boolean(text && isError));
+        this.status.classList.toggle('success', Boolean(text && !isError));
+    }
+
+    open() {
+        this.backdrop.hidden = false;
+    }
+
+    close() {
+        this.backdrop.hidden = true;
+        this.showMessage('');
+    }
+}
+
+export class CategoryModal extends BaseModal {
+    constructor({ title, onSubmit }) {
+        super(title);
+        this.onSubmit = onSubmit;
+        this.saveButton = createElement('<button class="btn-primary" type="button">Сохранить</button>');
+        this.cancelButton = createElement('<button class="btn-secondary" type="button">Отмена</button>');
+        this.form = createElement(`
+            <form class="stack">
+                <input type="hidden" name="id" />
+                <label>Название
+                    <input type="text" name="title" required />
+                </label>
+                <label>Slug
+                    <input type="text" name="slug" placeholder="optional" />
+                </label>
+                <label>Порядок
+                    <input type="number" name="sort" value="0" />
+                </label>
+                <label class="flex" style="margin-top:6px;">
+                    <input type="checkbox" name="is_active" checked /> Активна
+                </label>
+            </form>
+        `);
+        const actions = createElement('<div class="actions"></div>');
+        actions.append(this.saveButton, this.cancelButton);
+        this.modal.appendChild(this.form);
+        this.modal.appendChild(actions);
+        this.saveButton.addEventListener('click', () => this.submit());
+        this.cancelButton.addEventListener('click', () => this.close());
+    }
+
+    setData(category) {
+        this.form.querySelector('input[name="id"]').value = category?.id || '';
+        this.form.querySelector('input[name="title"]').value = category?.title || '';
+        this.form.querySelector('input[name="slug"]').value = category?.slug || '';
+        this.form.querySelector('input[name="sort"]').value = category?.sort ?? 0;
+        this.form.querySelector('input[name="is_active"]').checked = category?.is_active ?? true;
+    }
+
+    async submit() {
+        if (this.saveButton.disabled) return;
+        this.showMessage('');
+        this.saveButton.disabled = true;
+        try {
+            await this.onSubmit({
+                id: this.form.querySelector('input[name="id"]').value,
+                title: this.form.querySelector('input[name="title"]').value.trim(),
+                slug: this.form.querySelector('input[name="slug"]').value.trim(),
+                sort: Number(this.form.querySelector('input[name="sort"]').value) || 0,
+                is_active: this.form.querySelector('input[name="is_active"]').checked,
+            });
+            this.close();
+        } catch (error) {
+            this.showMessage(error.message, true);
+        } finally {
+            this.saveButton.disabled = false;
+        }
+    }
+}
+
+export class ItemModal extends BaseModal {
+    constructor({ title, categoriesProvider, onSubmit }) {
+        super(title);
+        this.onSubmit = onSubmit;
+        this.categoriesProvider = categoriesProvider;
+        this.saveButton = createElement('<button class="btn-primary" type="button">Сохранить</button>');
+        this.cancelButton = createElement('<button class="btn-secondary" type="button">Отмена</button>');
+        this.form = createElement(`
+            <form class="stack">
+                <input type="hidden" name="id" />
+                <label>Категория
+                    <select name="category_id" required></select>
+                </label>
+                <label>Название
+                    <input type="text" name="title" required />
+                </label>
+                <label>Slug
+                    <input type="text" name="slug" placeholder="optional" />
+                </label>
+                <div class="form-row">
+                    <label>Цена
+                        <input type="number" name="price" step="0.01" value="0" />
+                    </label>
+                    <label>Порядок
+                        <input type="number" name="sort" value="0" />
+                    </label>
+                </div>
+                <label>Картинка (URL)
+                    <input type="url" name="image_url" placeholder="https://..." />
+                </label>
+                <label>Короткий текст
+                    <textarea name="short_text" placeholder="Краткое описание"></textarea>
+                </label>
+                <label>Описание
+                    <textarea name="description" placeholder="Полное описание"></textarea>
+                </label>
+                <label class="flex" style="margin-top:6px;">
+                    <input type="checkbox" name="is_active" checked /> Активен
+                </label>
+            </form>
+        `);
+        const actions = createElement('<div class="actions"></div>');
+        actions.append(this.saveButton, this.cancelButton);
+        this.modal.append(this.form, actions);
+        this.saveButton.addEventListener('click', () => this.submit());
+        this.cancelButton.addEventListener('click', () => this.close());
+    }
+
+    refreshCategories(type) {
+        const select = this.form.querySelector('select[name="category_id"]');
+        select.innerHTML = '';
+        this.categoriesProvider(type).forEach((cat) => {
+            const option = document.createElement('option');
+            option.value = cat.id;
+            option.textContent = cat.title;
+            select.appendChild(option);
+        });
+    }
+
+    setData(item, type) {
+        this.refreshCategories(type);
+        this.form.dataset.type = type;
+        this.form.querySelector('input[name="id"]').value = item?.id || '';
+        this.form.querySelector('select[name="category_id"]').value = item?.category_id || '';
+        this.form.querySelector('input[name="title"]').value = item?.title || '';
+        this.form.querySelector('input[name="slug"]').value = item?.slug || '';
+        this.form.querySelector('input[name="price"]').value = item?.price ?? 0;
+        this.form.querySelector('input[name="sort"]').value = item?.sort ?? 0;
+        this.form.querySelector('input[name="image_url"]').value = item?.image_url || '';
+        this.form.querySelector('textarea[name="short_text"]').value = item?.short_text || '';
+        this.form.querySelector('textarea[name="description"]').value = item?.description || '';
+        this.form.querySelector('input[name="is_active"]').checked = item?.is_active ?? true;
+    }
+
+    async submit() {
+        if (this.saveButton.disabled) return;
+        this.showMessage('');
+        this.saveButton.disabled = true;
+        try {
+            const formType = this.form.dataset.type;
+            await this.onSubmit({
+                id: this.form.querySelector('input[name="id"]').value,
+                type: formType,
+                category_id: Number(this.form.querySelector('select[name="category_id"]').value),
+                title: this.form.querySelector('input[name="title"]').value.trim(),
+                slug: this.form.querySelector('input[name="slug"]').value.trim(),
+                price: this.form.querySelector('input[name="price"]').value || 0,
+                image_url: this.form.querySelector('input[name="image_url"]').value || null,
+                short_text: this.form.querySelector('textarea[name="short_text"]').value || null,
+                description: this.form.querySelector('textarea[name="description"]').value || null,
+                is_active: this.form.querySelector('input[name="is_active"]').checked,
+                sort: Number(this.form.querySelector('input[name="sort"]').value) || 0,
+            });
+            this.close();
+        } catch (error) {
+            this.showMessage(error.message, true);
+        } finally {
+            this.saveButton.disabled = false;
+        }
+    }
+}

--- a/admin_panel/templates/admin_profile.html
+++ b/admin_panel/templates/admin_profile.html
@@ -20,7 +20,7 @@
     <div>Профиль</div>
     <div style="display:flex; gap:12px; align-items:center;">
         <a href="/adminbot" style="color:#0b1220; font-weight:bold;">AdminBot</a>
-        <a href="/adminsite/constructor" style="color:#0b1220; font-weight:bold;">Конструктор (AdminSite)</a>
+        <a href="/adminsite/constructor" style="color:#0b1220; font-weight:bold;">AdminSite Конструктор</a>
         <a href="/admin/users" style="color:#0b1220; font-weight:bold;">Админы</a>
         <form method="post" action="/logout" style="margin:0;">
             <button type="submit">Выйти</button>

--- a/admin_panel/templates/admin_users.html
+++ b/admin_panel/templates/admin_users.html
@@ -27,7 +27,7 @@
     <div>Админы</div>
     <div style="display:flex; gap:12px; align-items:center;">
         <a href="/adminbot" style="color:#0b1220; font-weight:bold;">AdminBot</a>
-        <a href="/adminsite/constructor" style="color:#0b1220; font-weight:bold;">Конструктор (AdminSite)</a>
+        <a href="/adminsite/constructor" style="color:#0b1220; font-weight:bold;">AdminSite Конструктор</a>
         <a href="/admin/profile" style="color:#0b1220; font-weight:bold;">Профиль</a>
         <form method="post" action="/logout" style="margin:0;">
             <button class="btn btn-secondary" type="submit">Выйти</button>

--- a/admin_panel/templates/adminsite/constructor.html
+++ b/admin_panel/templates/adminsite/constructor.html
@@ -2,62 +2,13 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <title>Конструктор AdminSite</title>
-    <style>
-        :root {
-            --bg: #0b1220;
-            --card: #0f172a;
-            --border: #1e293b;
-            --primary: #a855f7;
-            --primary-dark: #7c3aed;
-            --text: #e5e7eb;
-            --muted: #9ca3af;
-            --danger: #f87171;
-            --success: #34d399;
-            --accent: #38bdf8;
-        }
-        * { box-sizing: border-box; }
-        body { font-family: Arial, sans-serif; background: var(--bg); color: var(--text); margin:0; }
-        header { background: var(--primary); color:#0b1220; padding:16px; display:flex; justify-content:space-between; align-items:center; position:sticky; top:0; z-index:10; }
-        header .nav { display:flex; gap:12px; align-items:center; }
-        header a { color:#0b1220; font-weight:bold; text-decoration:none; }
-        main { padding:24px; }
-        h1 { margin:0 0 12px; }
-        .tabs { display:flex; gap:10px; margin-bottom:16px; flex-wrap:wrap; }
-        .tab { padding:10px 14px; border-radius:10px; border:1px solid var(--border); background: var(--card); color: var(--text); cursor:pointer; transition: all 0.2s; }
-        .tab.active { background: var(--primary); color:#0b1220; border-color: var(--primary); }
-        .panel { display:none; }
-        .panel.active { display:block; }
-        .grid { display:grid; grid-template-columns: 320px 1fr; gap:16px; align-items:start; }
-        .card { background: var(--card); border:1px solid var(--border); border-radius:12px; padding:16px; }
-        label { display:block; margin-top:10px; font-size:14px; color:var(--muted); }
-        input, select, textarea { width:100%; padding:10px; border-radius:10px; border:1px solid var(--border); background:#0b1220; color:var(--text); margin-top:6px; }
-        textarea { min-height:100px; resize:vertical; }
-        .actions { margin-top:14px; display:flex; gap:8px; }
-        button { border:none; border-radius:10px; cursor:pointer; padding:10px 14px; font-weight:bold; }
-        .btn-primary { background: var(--primary); color:#0b1220; }
-        .btn-secondary { background: var(--border); color: var(--text); }
-        .btn-danger { background: var(--danger); color:#0b1220; }
-        table { width:100%; border-collapse: collapse; margin-top:8px; }
-        th, td { border:1px solid var(--border); padding:8px; text-align:left; }
-        th { background:#111827; color:var(--muted); }
-        tr:nth-child(even) { background:#0b1220; }
-        .badge { padding:4px 8px; border-radius:999px; font-size:12px; background:#1e293b; color:var(--muted); }
-        .muted { color: var(--muted); font-size:13px; }
-        .flex { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
-        .status { margin:0 0 12px; min-height:20px; }
-        .status.error { color: var(--danger); }
-        .status.success { color: var(--success); }
-        .table-actions { display:flex; gap:8px; flex-wrap:wrap; }
-        .pill { background:#111827; padding:4px 6px; border-radius:8px; font-size:12px; color:var(--muted); }
-        .stack { display:flex; flex-direction:column; gap:6px; }
-        @media (max-width: 1024px) { .grid { grid-template-columns: 1fr; } }
-    </style>
+    <title>AdminSite Конструктор</title>
+    <link rel="stylesheet" href="/admin/static/css/adminsite/constructor.css">
 </head>
 <body>
 <header>
     <div class="flex" style="gap:14px;">
-        <div style="font-size:20px; font-weight:bold;">Конструктор AdminSite</div>
+        <div style="font-size:20px; font-weight:bold;">AdminSite Конструктор</div>
         <span class="pill">{{ user.username }}</span>
     </div>
     <div class="nav">
@@ -71,8 +22,8 @@
     </div>
 </header>
 <main>
-    <h1>Категории, товары и настройки WebApp кнопки</h1>
-    <p class="muted">Управляйте категориями и элементами витрины. Используйте вкладку «WebApp кнопка», чтобы настроить действие красной кнопки в клиенте.</p>
+    <h1>Категории, элементы и WebApp кнопка</h1>
+    <p class="muted">Управляйте категориями и элементами витрины. Используйте вкладку «WebApp кнопка», чтобы настроить действие красной кнопки.</p>
 
     <div id="global-status" class="status"></div>
 
@@ -85,281 +36,146 @@
     </div>
 
     <section class="panel active" id="panel-categories-product">
-        <div class="grid">
-            <div class="card">
-                <h3>Категория товара</h3>
-                <div class="muted">Slug можно оставить пустым — он сгенерируется из названия.</div>
-                <form id="category-form-product" data-type="product">
-                    <input type="hidden" name="id">
-                    <label>Название
-                        <input type="text" name="title" required placeholder="Например: Свитеры">
-                    </label>
-                    <label>Slug
-                        <div class="flex">
-                            <input type="text" name="slug" placeholder="svitery">
-                            <button type="button" class="btn-secondary generate-slug">Сгенерировать</button>
-                        </div>
-                    </label>
-                    <label>Порядок
-                        <input type="number" name="sort" value="0">
-                    </label>
-                    <label class="flex" style="margin-top:12px;">
-                        <input type="checkbox" name="is_active" checked> Активна
-                    </label>
-                    <div class="actions">
-                        <button type="submit" class="btn-primary">Сохранить</button>
-                        <button type="button" class="btn-secondary reset-form">Сбросить</button>
-                    </div>
-                </form>
-            </div>
-            <div class="card">
-                <div class="flex" style="justify-content:space-between; align-items:center;">
-                    <h3>Категории (product)</h3>
-                    <div class="flex">
-                        <span class="muted">Создайте несколько категорий для фильтрации товаров.</span>
-                        <button type="button" class="btn-primary" onclick="resetCategoryForm('product'); document.getElementById('category-form-product').scrollIntoView({behavior:'smooth'});">Создать</button>
-                    </div>
+        <div class="card">
+            <div class="table-top">
+                <div>
+                    <h3 style="margin:0;">Категории товаров</h3>
+                    <p class="muted">Slug можно оставить пустым — сервер сгенерирует его.</p>
                 </div>
-                <div class="status" id="status-categories-product"></div>
-                <table>
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Название</th>
-                        <th>Slug</th>
-                        <th>Активна</th>
-                        <th>Порядок</th>
-                        <th>Создана</th>
-                        <th>Действия</th>
-                    </tr>
-                    </thead>
-                    <tbody id="categories-list-product"></tbody>
-                </table>
+                <button id="category-create-product" class="btn-primary" type="button">Создать</button>
             </div>
+            <div class="status" id="status-categories-product"></div>
+            <table>
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Slug</th>
+                    <th>Active</th>
+                    <th>Sort</th>
+                    <th>Created</th>
+                    <th>Действия</th>
+                </tr>
+                </thead>
+                <tbody id="categories-list-product"></tbody>
+            </table>
         </div>
     </section>
 
     <section class="panel" id="panel-categories-course">
-        <div class="grid">
-            <div class="card">
-                <h3>Категория мастер-классов</h3>
-                <div class="muted">Slug можно оставить пустым — он сгенерируется из названия.</div>
-                <form id="category-form-course" data-type="course">
-                    <input type="hidden" name="id">
-                    <label>Название
-                        <input type="text" name="title" required placeholder="Например: Вязание">
-                    </label>
-                    <label>Slug
-                        <div class="flex">
-                            <input type="text" name="slug" placeholder="vyazanie">
-                            <button type="button" class="btn-secondary generate-slug">Сгенерировать</button>
-                        </div>
-                    </label>
-                    <label>Порядок
-                        <input type="number" name="sort" value="0">
-                    </label>
-                    <label class="flex" style="margin-top:12px;">
-                        <input type="checkbox" name="is_active" checked> Активна
-                    </label>
-                    <div class="actions">
-                        <button type="submit" class="btn-primary">Сохранить</button>
-                        <button type="button" class="btn-secondary reset-form">Сбросить</button>
-                    </div>
-                </form>
-            </div>
-            <div class="card">
-                <div class="flex" style="justify-content:space-between; align-items:center;">
-                    <h3>Категории (course)</h3>
-                    <div class="flex">
-                        <span class="muted">Создайте категории для мастер-классов.</span>
-                        <button type="button" class="btn-primary" onclick="resetCategoryForm('course'); document.getElementById('category-form-course').scrollIntoView({behavior:'smooth'});">Создать</button>
-                    </div>
+        <div class="card">
+            <div class="table-top">
+                <div>
+                    <h3 style="margin:0;">Категории мастер-классов</h3>
+                    <p class="muted">Для типа course: slug можно оставить пустым.</p>
                 </div>
-                <div class="status" id="status-categories-course"></div>
-                <table>
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Название</th>
-                        <th>Slug</th>
-                        <th>Активна</th>
-                        <th>Порядок</th>
-                        <th>Создана</th>
-                        <th>Действия</th>
-                    </tr>
-                    </thead>
-                    <tbody id="categories-list-course"></tbody>
-                </table>
+                <button id="category-create-course" class="btn-primary" type="button">Создать</button>
             </div>
+            <div class="status" id="status-categories-course"></div>
+            <table>
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Slug</th>
+                    <th>Active</th>
+                    <th>Sort</th>
+                    <th>Created</th>
+                    <th>Действия</th>
+                </tr>
+                </thead>
+                <tbody id="categories-list-course"></tbody>
+            </table>
         </div>
     </section>
 
     <section class="panel" id="panel-items-product">
-        <div class="grid">
-            <div class="card">
-                <h3>Товар</h3>
-                <div class="muted">Все поля сохраняются сразу через API /api/adminsite/items.</div>
-                <form id="item-form-product" data-type="product">
-                    <input type="hidden" name="id">
-                    <label>Категория
-                        <select name="category_id" id="item-category-product" required></select>
-                    </label>
-                    <label>Название
-                        <input type="text" name="title" required placeholder="Например: Плед">
-                    </label>
-                    <label>Slug
-                        <div class="flex">
-                            <input type="text" name="slug" placeholder="pled">
-                            <button type="button" class="btn-secondary generate-slug">Сгенерировать</button>
-                        </div>
-                    </label>
-                    <label>Цена
-                        <input type="number" name="price" step="0.01" value="0">
-                    </label>
-                    <label>Картинка (URL)
-                        <input type="url" name="image_url" placeholder="https://...">
-                    </label>
-                    <label>Короткий текст
-                        <textarea name="short_text" placeholder="Краткое описание"></textarea>
-                    </label>
-                    <label>Описание
-                        <textarea name="description" placeholder="Полное описание"></textarea>
-                    </label>
-                    <label>Порядок
-                        <input type="number" name="sort" value="0">
-                    </label>
-                    <label class="flex" style="margin-top:12px;">
-                        <input type="checkbox" name="is_active" checked> Активен
-                    </label>
-                    <div class="actions">
-                        <button type="submit" class="btn-primary">Сохранить</button>
-                        <button type="button" class="btn-secondary reset-form">Сбросить</button>
-                    </div>
-                </form>
-            </div>
-            <div class="card">
-                <div class="flex" style="justify-content:space-between; align-items:center;">
-                    <h3>Товары</h3>
-                    <div class="flex">
-                        <button type="button" class="btn-primary" onclick="resetItemForm('product'); document.getElementById('item-form-product').scrollIntoView({behavior:'smooth'});">Создать</button>
-                        <label class="muted">Фильтр:
-                            <select id="items-filter-product"></select>
-                        </label>
-                    </div>
+        <div class="card">
+            <div class="table-top">
+                <div>
+                    <h3 style="margin:0;">Товары</h3>
+                    <p class="muted">CRUD для элементов типа product.</p>
                 </div>
-                <div class="status" id="status-items-product"></div>
-                <table>
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Название</th>
-                        <th>Категория</th>
-                        <th>Цена</th>
-                        <th>Slug</th>
-                        <th>Активен</th>
-                        <th>Порядок</th>
-                        <th>Действия</th>
-                    </tr>
-                    </thead>
-                    <tbody id="items-list-product"></tbody>
-                </table>
+                <div class="flex">
+                    <input type="search" id="items-search-product" class="search-input" placeholder="Поиск по названию">
+                    <select id="items-filter-product"></select>
+                    <button id="item-create-product" class="btn-primary" type="button">Создать</button>
+                </div>
             </div>
+            <div class="status" id="status-items-product"></div>
+            <table>
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Category</th>
+                    <th>Price</th>
+                    <th>Active</th>
+                    <th>Sort</th>
+                    <th>Действия</th>
+                </tr>
+                </thead>
+                <tbody id="items-list-product"></tbody>
+            </table>
         </div>
     </section>
 
     <section class="panel" id="panel-items-course">
-        <div class="grid">
-            <div class="card">
-                <h3>Мастер-класс</h3>
-                <div class="muted">Выберите категорию типа course и заполните карточку.</div>
-                <form id="item-form-course" data-type="course">
-                    <input type="hidden" name="id">
-                    <label>Категория
-                        <select name="category_id" id="item-category-course" required></select>
-                    </label>
-                    <label>Название
-                        <input type="text" name="title" required placeholder="Например: Базовый курс">
-                    </label>
-                    <label>Slug
-                        <div class="flex">
-                            <input type="text" name="slug" placeholder="bazovyj-kurs">
-                            <button type="button" class="btn-secondary generate-slug">Сгенерировать</button>
-                        </div>
-                    </label>
-                    <label>Цена
-                        <input type="number" name="price" step="0.01" value="0">
-                    </label>
-                    <label>Картинка (URL)
-                        <input type="url" name="image_url" placeholder="https://...">
-                    </label>
-                    <label>Короткий текст
-                        <textarea name="short_text" placeholder="Краткое описание"></textarea>
-                    </label>
-                    <label>Описание
-                        <textarea name="description" placeholder="Полное описание"></textarea>
-                    </label>
-                    <label>Порядок
-                        <input type="number" name="sort" value="0">
-                    </label>
-                    <label class="flex" style="margin-top:12px;">
-                        <input type="checkbox" name="is_active" checked> Активен
-                    </label>
-                    <div class="actions">
-                        <button type="submit" class="btn-primary">Сохранить</button>
-                        <button type="button" class="btn-secondary reset-form">Сбросить</button>
-                    </div>
-                </form>
-            </div>
-            <div class="card">
-                <div class="flex" style="justify-content:space-between; align-items:center;">
-                    <h3>Мастер-классы</h3>
-                    <div class="flex">
-                        <button type="button" class="btn-primary" onclick="resetItemForm('course'); document.getElementById('item-form-course').scrollIntoView({behavior:'smooth'});">Создать</button>
-                        <label class="muted">Фильтр:
-                            <select id="items-filter-course"></select>
-                        </label>
-                    </div>
+        <div class="card">
+            <div class="table-top">
+                <div>
+                    <h3 style="margin:0;">Мастер-классы</h3>
+                    <p class="muted">CRUD для элементов типа course.</p>
                 </div>
-                <div class="status" id="status-items-course"></div>
-                <table>
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Название</th>
-                        <th>Категория</th>
-                        <th>Цена</th>
-                        <th>Slug</th>
-                        <th>Активен</th>
-                        <th>Порядок</th>
-                        <th>Действия</th>
-                    </tr>
-                    </thead>
-                    <tbody id="items-list-course"></tbody>
-                </table>
+                <div class="flex">
+                    <input type="search" id="items-search-course" class="search-input" placeholder="Поиск по названию">
+                    <select id="items-filter-course"></select>
+                    <button id="item-create-course" class="btn-primary" type="button">Создать</button>
+                </div>
             </div>
+            <div class="status" id="status-items-course"></div>
+            <table>
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Category</th>
+                    <th>Price</th>
+                    <th>Active</th>
+                    <th>Sort</th>
+                    <th>Действия</th>
+                </tr>
+                </thead>
+                <tbody id="items-list-course"></tbody>
+            </table>
         </div>
     </section>
 
     <section class="panel" id="panel-webapp">
-        <div class="card" style="max-width:840px;">
-            <h3>WebApp кнопка</h3>
-            <p class="muted">Настройки красной кнопки: выберите тип, область действия и при необходимости категорию.</p>
+        <div class="card" style="max-width:880px;">
+            <div class="table-top">
+                <div>
+                    <h3 style="margin:0;">WebApp кнопка</h3>
+                    <p class="muted">Переключатели type/scope и действие красной кнопки.</p>
+                </div>
+                <button id="webapp-reload" class="btn-secondary" type="button">Обновить</button>
+            </div>
             <div class="status" id="status-webapp"></div>
             <form id="webapp-form">
-                <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));">
+                <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));">
                     <div>
                         <label>Тип
                             <select name="type" id="webapp-type">
-                                <option value="product">Товары (product)</option>
-                                <option value="course">Мастер-классы (course)</option>
+                                <option value="product">product</option>
+                                <option value="course">course</option>
                             </select>
                         </label>
                     </div>
                     <div>
                         <label>Scope
                             <select name="scope" id="webapp-scope">
-                                <option value="global">Global</option>
-                                <option value="category">Category</option>
+                                <option value="global">global</option>
+                                <option value="category">category</option>
                             </select>
                         </label>
                     </div>
@@ -370,512 +186,26 @@
                     </div>
                     <div>
                         <label>Label
-                            <input type="text" name="action_label" id="webapp-label" placeholder="Например: Купить">
+                            <input type="text" name="action_label" id="webapp-label" placeholder="Оформить" />
                         </label>
                     </div>
                     <div>
                         <label>Минимум выбранных
-                            <input type="number" name="min_selected" id="webapp-min-selected" min="0" value="1">
+                            <input type="number" name="min_selected" id="webapp-min-selected" min="0" value="1" />
                         </label>
                     </div>
                     <div style="display:flex; align-items:center; gap:8px; margin-top:26px;">
-                        <input type="checkbox" id="webapp-enabled" checked>
-                        <label for="webapp-enabled" class="muted">Действие включено</label>
+                        <input type="checkbox" id="webapp-enabled" />
+                        <label for="webapp-enabled" class="muted">action_enabled</label>
                     </div>
                 </div>
                 <div class="actions" style="margin-top:18px;">
-                    <button type="submit" class="btn-primary">Сохранить</button>
-                    <button type="button" class="btn-secondary" id="webapp-reload">Обновить</button>
+                    <button class="btn-primary" type="submit">Сохранить</button>
                 </div>
             </form>
         </div>
     </section>
 </main>
-<script>
-const state = {
-    categories: { product: [], course: [] },
-    items: { product: [], course: [] },
-    categoryEditing: { product: null, course: null },
-    itemEditing: { product: null, course: null },
-};
-
-const statusGlobal = document.getElementById('global-status');
-
-function showMessage(target, message, isError = false) {
-    if (!target) return;
-    target.textContent = message || '';
-    target.classList.remove('error', 'success');
-    if (message) {
-        target.classList.add(isError ? 'error' : 'success');
-    }
-}
-
-const translitMap = {
-    'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd', 'е': 'e', 'ё': 'e', 'ж': 'zh', 'з': 'z', 'и': 'i',
-    'й': 'i', 'к': 'k', 'л': 'l', 'м': 'm', 'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't',
-    'у': 'u', 'ф': 'f', 'х': 'h', 'ц': 'c', 'ч': 'ch', 'ш': 'sh', 'щ': 'sch', 'ы': 'y', 'э': 'e', 'ю': 'yu', 'я': 'ya',
-    'ъ': '', 'ь': ''
-};
-
-function transliterate(value) {
-    return value
-        .split('')
-        .map((ch) => {
-            const lower = ch.toLowerCase();
-            const mapped = translitMap[lower];
-            if (mapped === undefined) return ch;
-            return ch === lower ? mapped : mapped.toUpperCase();
-        })
-        .join('');
-}
-
-function slugify(value) {
-    const transliterated = transliterate(value);
-    const normalized = transliterated.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
-    return normalized
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/(^-|-$)/g, '')
-        .replace(/-{2,}/g, '-');
-}
-
-async function fetchJson(url, options = {}) {
-    const opts = { credentials: 'same-origin', ...options };
-    if (opts.body && !(opts.body instanceof FormData)) {
-        opts.headers = { 'Content-Type': 'application/json', ...(opts.headers || {}) };
-        opts.body = JSON.stringify(opts.body);
-    }
-    const response = await fetch(url, opts);
-    if (!response.ok) {
-        let detail = `HTTP ${response.status}`;
-        try {
-            const data = await response.json();
-            detail = data.detail || detail;
-        } catch (e) { /* ignore */ }
-        throw new Error(detail);
-    }
-    if (response.status === 204) return null;
-    return response.json();
-}
-
-function resetCategoryForm(type) {
-    const form = document.getElementById(`category-form-${type}`);
-    form.reset();
-    form.querySelector('input[name="id"]').value = '';
-    form.querySelector('input[name="sort"]').value = 0;
-    form.querySelector('input[name="is_active"]').checked = true;
-    state.categoryEditing[type] = null;
-    showMessage(document.getElementById(`status-categories-${type}`), '');
-}
-
-function resetItemForm(type) {
-    const form = document.getElementById(`item-form-${type}`);
-    form.reset();
-    form.querySelector('input[name="id"]').value = '';
-    form.querySelector('input[name="price"]').value = 0;
-    form.querySelector('input[name="sort"]').value = 0;
-    form.querySelector('input[name="is_active"]').checked = true;
-    state.itemEditing[type] = null;
-    showMessage(document.getElementById(`status-items-${type}`), '');
-    populateCategoryOptions(type);
-}
-
-function populateCategoryOptions(type) {
-    const categories = state.categories[type];
-    const select = document.getElementById(`item-category-${type}`);
-    const filter = document.getElementById(`items-filter-${type}`);
-    if (select) {
-        select.innerHTML = '';
-        categories.forEach((cat) => {
-            const option = document.createElement('option');
-            option.value = cat.id;
-            option.textContent = `${cat.title} (${cat.slug})`;
-            select.appendChild(option);
-        });
-    }
-    if (filter) {
-        filter.innerHTML = '';
-        const any = document.createElement('option');
-        any.value = '';
-        any.textContent = 'Все категории';
-        filter.appendChild(any);
-        categories.forEach((cat) => {
-            const option = document.createElement('option');
-            option.value = cat.id;
-            option.textContent = cat.title;
-            filter.appendChild(option);
-        });
-    }
-    const webappType = document.getElementById('webapp-type').value;
-    if (type === webappType) {
-        const webappSelect = document.getElementById('webapp-category');
-        if (webappSelect) {
-            webappSelect.innerHTML = '';
-            categories.forEach((cat) => {
-                const option = document.createElement('option');
-                option.value = cat.id;
-                option.textContent = cat.title;
-                webappSelect.appendChild(option);
-            });
-        }
-    }
-}
-
-function renderCategories(type) {
-    const tbody = document.getElementById(`categories-list-${type}`);
-    tbody.innerHTML = '';
-    const list = state.categories[type];
-    if (!list.length) {
-        const row = document.createElement('tr');
-        const cell = document.createElement('td');
-        cell.colSpan = 7;
-        cell.textContent = 'Нет категорий';
-        row.appendChild(cell);
-        tbody.appendChild(row);
-        return;
-    }
-    list.forEach((cat) => {
-        const row = document.createElement('tr');
-        row.innerHTML = `
-            <td>${cat.id}</td>
-            <td>${cat.title}</td>
-            <td><span class="badge">${cat.slug}</span></td>
-            <td>${cat.is_active ? '✅' : '⛔'}</td>
-            <td>${cat.sort}</td>
-            <td class="muted">${cat.created_at}</td>
-            <td>
-                <div class="table-actions">
-                    <button class="btn-secondary" data-action="edit" data-id="${cat.id}" data-type="${type}">Редактировать</button>
-                    <button class="btn-danger" data-action="delete" data-id="${cat.id}" data-type="${type}">Удалить</button>
-                </div>
-            </td>
-        `;
-        tbody.appendChild(row);
-    });
-    tbody.querySelectorAll('button').forEach((btn) => {
-        const action = btn.dataset.action;
-        const id = Number(btn.dataset.id);
-        const catType = btn.dataset.type;
-        if (action === 'edit') {
-            btn.addEventListener('click', () => fillCategoryForm(catType, id));
-        } else {
-            btn.addEventListener('click', () => deleteCategory(catType, id));
-        }
-    });
-}
-
-function renderItems(type) {
-    const tbody = document.getElementById(`items-list-${type}`);
-    tbody.innerHTML = '';
-    const items = state.items[type];
-    const categories = Object.fromEntries(state.categories[type].map((c) => [c.id, c]));
-    if (!items.length) {
-        const row = document.createElement('tr');
-        const cell = document.createElement('td');
-        cell.colSpan = 8;
-        cell.textContent = 'Нет элементов';
-        row.appendChild(cell);
-        tbody.appendChild(row);
-        return;
-    }
-    items.forEach((item) => {
-        const category = categories[item.category_id];
-        const row = document.createElement('tr');
-        row.innerHTML = `
-            <td>${item.id}</td>
-            <td>${item.title}</td>
-            <td>${category ? category.title : '—'}</td>
-            <td>${item.price}</td>
-            <td><span class="badge">${item.slug}</span></td>
-            <td>${item.is_active ? '✅' : '⛔'}</td>
-            <td>${item.sort}</td>
-            <td>
-                <div class="table-actions">
-                    <button class="btn-secondary" data-action="edit" data-id="${item.id}" data-type="${type}">Редактировать</button>
-                    <button class="btn-danger" data-action="delete" data-id="${item.id}" data-type="${type}">Удалить</button>
-                </div>
-            </td>
-        `;
-        tbody.appendChild(row);
-    });
-    tbody.querySelectorAll('button').forEach((btn) => {
-        const action = btn.dataset.action;
-        const id = Number(btn.dataset.id);
-        const itemType = btn.dataset.type;
-        if (action === 'edit') {
-            btn.addEventListener('click', () => fillItemForm(itemType, id));
-        } else {
-            btn.addEventListener('click', () => deleteItem(itemType, id));
-        }
-    });
-}
-
-async function loadCategories(type) {
-    try {
-        const data = await fetchJson(`/api/adminsite/categories?type=${type}`);
-        state.categories[type] = data;
-        renderCategories(type);
-        populateCategoryOptions(type);
-        showMessage(document.getElementById(`status-categories-${type}`), '');
-    } catch (error) {
-        showMessage(document.getElementById(`status-categories-${type}`), error.message, true);
-    }
-}
-
-async function loadItems(type) {
-    const filter = document.getElementById(`items-filter-${type}`);
-    const categoryId = filter && filter.value ? Number(filter.value) : null;
-    const query = new URLSearchParams({ type });
-    if (categoryId) query.append('category_id', String(categoryId));
-    try {
-        const data = await fetchJson(`/api/adminsite/items?${query.toString()}`);
-        state.items[type] = data;
-        renderItems(type);
-        showMessage(document.getElementById(`status-items-${type}`), '');
-    } catch (error) {
-        showMessage(document.getElementById(`status-items-${type}`), error.message, true);
-    }
-}
-
-function fillCategoryForm(type, id) {
-    const category = state.categories[type].find((c) => c.id === id);
-    if (!category) return;
-    const form = document.getElementById(`category-form-${type}`);
-    form.querySelector('input[name="id"]').value = category.id;
-    form.querySelector('input[name="title"]').value = category.title;
-    form.querySelector('input[name="slug"]').value = category.slug;
-    form.querySelector('input[name="sort"]').value = category.sort;
-    form.querySelector('input[name="is_active"]').checked = category.is_active;
-    state.categoryEditing[type] = category.id;
-}
-
-function fillItemForm(type, id) {
-    const item = state.items[type].find((c) => c.id === id);
-    if (!item) return;
-    const form = document.getElementById(`item-form-${type}`);
-    form.querySelector('input[name="id"]').value = item.id;
-    form.querySelector('select[name="category_id"]').value = item.category_id;
-    form.querySelector('input[name="title"]').value = item.title;
-    form.querySelector('input[name="slug"]').value = item.slug;
-    form.querySelector('input[name="price"]').value = item.price;
-    form.querySelector('input[name="image_url"]').value = item.image_url || '';
-    form.querySelector('textarea[name="short_text"]').value = item.short_text || '';
-    form.querySelector('textarea[name="description"]').value = item.description || '';
-    form.querySelector('input[name="sort"]').value = item.sort;
-    form.querySelector('input[name="is_active"]').checked = item.is_active;
-    state.itemEditing[type] = item.id;
-}
-
-async function deleteCategory(type, id) {
-    if (!confirm('Удалить категорию?')) return;
-    try {
-        await fetchJson(`/api/adminsite/categories/${id}`, { method: 'DELETE' });
-        showMessage(document.getElementById(`status-categories-${type}`), 'Категория удалена');
-        await loadCategories(type);
-        await loadItems(type);
-    } catch (error) {
-        showMessage(document.getElementById(`status-categories-${type}`), error.message, true);
-    }
-}
-
-async function deleteItem(type, id) {
-    if (!confirm('Удалить элемент?')) return;
-    try {
-        await fetchJson(`/api/adminsite/items/${id}`, { method: 'DELETE' });
-        showMessage(document.getElementById(`status-items-${type}`), 'Элемент удалён');
-        await loadItems(type);
-    } catch (error) {
-        showMessage(document.getElementById(`status-items-${type}`), error.message, true);
-    }
-}
-
-async function saveCategory(event) {
-    event.preventDefault();
-    const form = event.target;
-    const type = form.dataset.type;
-    const id = form.querySelector('input[name="id"]').value;
-    const title = form.querySelector('input[name="title"]').value.trim();
-    const slugInput = form.querySelector('input[name="slug"]').value.trim();
-    const payload = {
-        type,
-        title,
-        slug: slugInput || slugify(title),
-        is_active: form.querySelector('input[name="is_active"]').checked,
-        sort: Number(form.querySelector('input[name="sort"]').value) || 0,
-    };
-    const method = id ? 'PUT' : 'POST';
-    const url = id ? `/api/adminsite/categories/${id}` : '/api/adminsite/categories';
-    try {
-        await fetchJson(url, { method, body: payload });
-        showMessage(document.getElementById(`status-categories-${type}`), 'Сохранено');
-        resetCategoryForm(type);
-        await loadCategories(type);
-    } catch (error) {
-        showMessage(document.getElementById(`status-categories-${type}`), error.message, true);
-    }
-}
-
-async function saveItem(event) {
-    event.preventDefault();
-    const form = event.target;
-    const type = form.dataset.type;
-    const id = form.querySelector('input[name="id"]').value;
-    const title = form.querySelector('input[name="title"]').value.trim();
-    const slugInput = form.querySelector('input[name="slug"]').value.trim();
-    const payload = {
-        type,
-        category_id: Number(form.querySelector('select[name="category_id"]').value),
-        title,
-        slug: slugInput || slugify(title),
-        price: form.querySelector('input[name="price"]').value || 0,
-        image_url: form.querySelector('input[name="image_url"]').value || null,
-        short_text: form.querySelector('textarea[name="short_text"]').value || null,
-        description: form.querySelector('textarea[name="description"]').value || null,
-        is_active: form.querySelector('input[name="is_active"]').checked,
-        sort: Number(form.querySelector('input[name="sort"]').value) || 0,
-    };
-    const method = id ? 'PUT' : 'POST';
-    const url = id ? `/api/adminsite/items/${id}` : '/api/adminsite/items';
-    try {
-        await fetchJson(url, { method, body: payload });
-        showMessage(document.getElementById(`status-items-${type}`), 'Сохранено');
-        resetItemForm(type);
-        await loadItems(type);
-    } catch (error) {
-        showMessage(document.getElementById(`status-items-${type}`), error.message, true);
-    }
-}
-
-function setupSlugButtons() {
-    document.querySelectorAll('.generate-slug').forEach((btn) => {
-        btn.addEventListener('click', () => {
-            const wrapper = btn.closest('form');
-            const titleInput = wrapper.querySelector('input[name="title"]');
-            const slugInput = wrapper.querySelector('input[name="slug"]');
-            slugInput.value = slugify(titleInput.value || '');
-        });
-    });
-}
-
-function setupTabs() {
-    document.querySelectorAll('.tab').forEach((tab) => {
-        tab.addEventListener('click', () => {
-            const target = tab.dataset.tab;
-            document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
-            tab.classList.add('active');
-            document.querySelectorAll('.panel').forEach((panel) => {
-                panel.classList.toggle('active', panel.id === `panel-${target}`);
-            });
-        });
-    });
-}
-
-function setupForms() {
-    ['product', 'course'].forEach((type) => {
-        const categoryForm = document.getElementById(`category-form-${type}`);
-        const itemForm = document.getElementById(`item-form-${type}`);
-        categoryForm.addEventListener('submit', saveCategory);
-        itemForm.addEventListener('submit', saveItem);
-        categoryForm.querySelector('.reset-form').addEventListener('click', () => resetCategoryForm(type));
-        itemForm.querySelector('.reset-form').addEventListener('click', () => resetItemForm(type));
-    });
-}
-
-function setupFilters() {
-    ['product', 'course'].forEach((type) => {
-        const filter = document.getElementById(`items-filter-${type}`);
-        filter.addEventListener('change', () => loadItems(type));
-    });
-}
-
-function toggleWebappCategoryVisibility() {
-    const scope = document.getElementById('webapp-scope').value;
-    const wrapper = document.getElementById('webapp-category-wrapper');
-    wrapper.style.display = scope === 'category' ? 'block' : 'none';
-}
-
-async function loadWebappSettings() {
-    const type = document.getElementById('webapp-type').value;
-    const scope = document.getElementById('webapp-scope').value;
-    const categorySelect = document.getElementById('webapp-category');
-    const statusEl = document.getElementById('status-webapp');
-    const params = new URLSearchParams({ type });
-    if (scope === 'category' && categorySelect.value) {
-        params.append('category_id', categorySelect.value);
-    }
-    try {
-        const data = await fetchJson(`/api/adminsite/webapp-settings?${params.toString()}`);
-        document.getElementById('webapp-enabled').checked = data.action_enabled;
-        document.getElementById('webapp-label').value = data.action_label || '';
-        document.getElementById('webapp-min-selected').value = data.min_selected;
-        showMessage(statusEl, 'Настройки загружены');
-    } catch (error) {
-        document.getElementById('webapp-enabled').checked = true;
-        document.getElementById('webapp-label').value = '';
-        document.getElementById('webapp-min-selected').value = 1;
-        const message = error.message.toLowerCase().includes('not found') || error.message.includes('404')
-            ? 'Настройки не найдены, сохраните форму'
-            : error.message;
-        showMessage(statusEl, message, true);
-    }
-}
-
-async function saveWebappSettings(event) {
-    event.preventDefault();
-    const type = document.getElementById('webapp-type').value;
-    const scope = document.getElementById('webapp-scope').value;
-    const categorySelect = document.getElementById('webapp-category');
-    const payload = {
-        type,
-        scope,
-        category_id: scope === 'category' ? Number(categorySelect.value) : null,
-        action_enabled: document.getElementById('webapp-enabled').checked,
-        action_label: document.getElementById('webapp-label').value || null,
-        min_selected: Number(document.getElementById('webapp-min-selected').value) || 0,
-    };
-    try {
-        await fetchJson('/api/adminsite/webapp-settings', { method: 'PUT', body: payload });
-        showMessage(document.getElementById('status-webapp'), 'Настройки сохранены');
-        await loadWebappSettings();
-    } catch (error) {
-        showMessage(document.getElementById('status-webapp'), error.message, true);
-    }
-}
-
-function setupWebappForm() {
-    document.getElementById('webapp-form').addEventListener('submit', saveWebappSettings);
-    document.getElementById('webapp-reload').addEventListener('click', loadWebappSettings);
-    document.getElementById('webapp-type').addEventListener('change', async () => {
-        populateCategoryOptions(document.getElementById('webapp-type').value);
-        await loadWebappSettings();
-    });
-    document.getElementById('webapp-scope').addEventListener('change', async () => {
-        toggleWebappCategoryVisibility();
-        await loadWebappSettings();
-    });
-    document.getElementById('webapp-category').addEventListener('change', loadWebappSettings);
-    toggleWebappCategoryVisibility();
-}
-
-async function bootstrap() {
-    setupTabs();
-    setupForms();
-    setupFilters();
-    setupSlugButtons();
-    setupWebappForm();
-    try {
-        await loadCategories('product');
-        await loadCategories('course');
-        await loadItems('product');
-        await loadItems('course');
-        await loadWebappSettings();
-        showMessage(statusGlobal, 'Данные загружены');
-    } catch (error) {
-        showMessage(statusGlobal, error.message, true);
-    }
-}
-
-document.addEventListener('DOMContentLoaded', bootstrap);
-</script>
+<script type="module" src="/admin/static/js/adminsite/constructor.js"></script>
 </body>
 </html>

--- a/admin_panel/templates/adminsite/dashboard.html
+++ b/admin_panel/templates/adminsite/dashboard.html
@@ -15,7 +15,7 @@
 <header>
     <div>AdminSite Dashboard</div>
     <div style="display:flex; gap:12px; align-items:center;">
-        <a href="/adminsite/constructor" style="color:#0b1220;">Конструктор (AdminSite)</a>
+        <a href="/adminsite/constructor" style="color:#0b1220;">AdminSite Конструктор</a>
         <a href="/admin/profile" style="color:#0b1220;">Профиль</a>
         <form method="post" action="/logout" style="margin:0;">
             <button type="submit" style="background:#0b1220; color:#a855f7; border:none; padding:8px 12px; border-radius:8px; cursor:pointer;">Выйти</button>


### PR DESCRIPTION
## Summary
- add AdminSite Конструктор section with tabbed layout for categories, items, and WebApp button
- extract reusable adminsite API client and modal components with disabled-on-submit handling
- refresh navigation labels and documentation for the constructor pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949945a67ac83268da13ae5e6f00c07)