### PR TITLE
Fix AdminSite static proxy rules

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -131,6 +131,10 @@ Production деплой одной командой
 - JS конструктора подключается по пути `/static/adminsite/constructor.js`; при корректной настройке сервер отдаёт сам JS-код, а не HTML.
 - Быстрая проверка API: `GET /api/adminsite/health` (ожидается `{ "ok": true }`).
 - На странице `/adminsite/constructor` вверху отображается статусный блок: «JS: LOADED» появляется после выполнения `constructor.js`, «API: OK» — после успешного ответа health-checkа. Ошибки API (например, 401/403/500 или не-JSON ответы) показываются там же.
+- Nginx должен проксировать `/static/` в backend до fallback на `/index.html`. Эталонный блок (см. `deploy/nginx/miniden.conf`):
+  - `location ^~ /static/ { proxy_pass http://127.0.0.1:8000; ... }`
+  - после применения конфигурации `curl -I https://<host>/static/adminsite/constructor.js` должен отдавать `Content-Type: application/javascript`, а не HTML.
+  - контрольный эндпоинт: `GET /api/adminsite/debug/static` возвращает путь и факт наличия `constructor.js` на сервере.
 
 Фронтенд-оболочка
 ------------------

--- a/deploy/nginx/miniden.conf
+++ b/deploy/nginx/miniden.conf
@@ -31,9 +31,29 @@ server {
         proxy_redirect off;
     }
 
+    location ^~ /static/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+    }
+
     location /adminbot {
         root /opt/miniden/webapp;
         try_files $uri $uri/ /admin.html;
+    }
+
+    location ^~ /adminsite/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- proxy AdminSite static and routes through the backend before the SPA fallback in the nginx example config
- document how to verify constructor.js is served as JavaScript and reference the debug endpoint

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad6527e908326acd3b2f4b496375e)