### PR TITLE
Fix AdminSite static mount and update docs

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -117,6 +117,12 @@ AdminSite UI / шаблоны
   - `/adminsite/constructor` (конструктор витрины)
   - `/static/adminsite/constructor.js` (JS возвращается с корректным Content-Type)
 
+AdminSite Static
+----------------
+- FastAPI монтирует `/static` напрямую на `admin_panel/adminsite/static`, чтобы `url_for('static', filename='adminsite/...')` работал во всех шаблонах AdminSite.
+- Каталоги создаются при старте приложения; в `static/adminsite/` лежат `base.css` и `constructor.js`, доступные по URL `/static/adminsite/base.css` и `/static/adminsite/constructor.js`.
+- Если сервер отдаёт 500 на `/adminsite/`, проверьте, что маршрут `static` зарегистрирован (`GET /api/adminsite/debug/routes`) и что `admin_panel/adminsite/static` существует на диске.
+
 Логи AdminBot
 -------------
 - Каталог логов: `/opt/miniden/logs` (создаётся автоматически при старте приложений).

--- a/webapi.py
+++ b/webapi.py
@@ -84,6 +84,9 @@ from schemas.home import HomeBlockIn, HomePostIn, HomeSectionIn
 
 
 BASE_DIR = Path(__file__).resolve().parent
+ADMINSITE_STATIC_PATH = (
+    BASE_DIR / "admin_panel" / "adminsite" / "static"
+).resolve()
 WEBAPP_DIR = BASE_DIR / "webapp"
 STATIC_DIR_PUBLIC = BASE_DIR / "static"
 setup_logging(log_file=API_LOG_FILE)
@@ -219,7 +222,7 @@ app.mount("/media", StaticFiles(directory=MEDIA_ROOT), name="media")
 if ensure_adminsite_static_dir():
     app.mount(
         "/static",
-        StaticFiles(directory=str(ADMINSITE_STATIC_ROOT.resolve())),
+        StaticFiles(directory=ADMINSITE_STATIC_PATH),
         name="static",
     )
 else:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- ensure AdminSite static files are mounted at /static using an absolute path so url_for('static') works
- document the AdminSite static mount and checks in README

## Testing
- python -m compileall webapi.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adfae245c8326a081de4281a093a1)