### PR TITLE
Fix AdminSite static route registration

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -119,7 +119,7 @@ AdminSite UI / шаблоны
 
 AdminSite Static
 ----------------
-- FastAPI монтирует `/static` напрямую на `admin_panel/adminsite/static`, чтобы `url_for('static', filename='adminsite/...')` работал во всех шаблонах AdminSite.
+- FastAPI монтирует `/static` напрямую на `admin_panel/adminsite/static`, чтобы `url_for('static', path='adminsite/...')` работал во всех шаблонах AdminSite.
 - Каталоги создаются при старте приложения; в `static/adminsite/` лежат `base.css` и `constructor.js`, доступные по URL `/static/adminsite/base.css` и `/static/adminsite/constructor.js`.
 - Если сервер отдаёт 500 на `/adminsite/`, проверьте, что маршрут `static` зарегистрирован (`GET /api/adminsite/debug/routes`) и что `admin_panel/adminsite/static` существует на диске.
 

--- a/admin_panel/adminsite/templates/base_adminsite.html
+++ b/admin_panel/adminsite/templates/base_adminsite.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}AdminSite{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='adminsite/base.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='adminsite/base.css') }}">
     {% block head_extra %}{% endblock %}
 </head>
 <body class="{{ body_class | default('') }}">

--- a/admin_panel/adminsite/templates/constructor.html
+++ b/admin_panel/adminsite/templates/constructor.html
@@ -1,7 +1,7 @@
 {% extends "base_adminsite.html" %}
 {% block title %}AdminSite Конструктор{% endblock %}
 {% block head_extra %}
-    <link rel="stylesheet" href="{{ url_for('static', filename='adminsite/constructor.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='adminsite/constructor.css') }}">
 {% endblock %}
 {% block content %}
 <div id="constructor-status-bar"></div>

--- a/webapi.py
+++ b/webapi.py
@@ -222,7 +222,8 @@ app.mount("/media", StaticFiles(directory=MEDIA_ROOT), name="media")
 if ensure_adminsite_static_dir():
     app.mount(
         "/static",
-        StaticFiles(directory=ADMINSITE_STATIC_PATH),
+        # AdminSite templates rely on url_for('static', path='adminsite/...').
+        StaticFiles(directory=str(ADMINSITE_STATIC_PATH)),
         name="static",
     )
 else:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- clarify AdminSite static mounting in the main FastAPI app
- fix AdminSite templates to resolve static assets via url_for path parameter
- document static mount expectations in README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae2f675f48326a91204fa896ad7cf)