### PR TITLE
Fix AdminSite static handling and harden deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ location /api/ {
 }
 ```
 
+В продакшене эталонный конфиг лежит в `deploy/nginx/miniden.conf` и на деплое
+копируется в `/etc/nginx/sites-available/miniden.conf` (с symlink в
+`sites-enabled`). Редактировать следует только исходный файл в репозитории.
+
 Пример systemd unit для фонового запуска backend'а (`/etc/systemd/system/miniden-api.service`):
 
 ```

--- a/admin_panel/__init__.py
+++ b/admin_panel/__init__.py
@@ -11,4 +11,5 @@ from fastapi.templating import Jinja2Templates
 
 BASE_DIR = Path(__file__).resolve().parent
 TEMPLATES = Jinja2Templates(directory=str(BASE_DIR / "templates"))
-STATIC_DIR = BASE_DIR / "static"
+# Все статические ассеты AdminSite/constructor лежат в admin_panel/adminsite/static
+STATIC_DIR = BASE_DIR / "adminsite" / "static"

--- a/admin_panel/routes/adminsite.py
+++ b/admin_panel/routes/adminsite.py
@@ -13,7 +13,12 @@ from admin_panel.dependencies import (
     get_db_session,
     require_admin,
 )
-from admin_panel.adminsite import TEMPLATES
+from admin_panel.adminsite import (
+    ADMINSITE_CONSTRUCTOR_PATH,
+    ADMINSITE_STATIC_DIR,
+    ADMINSITE_STATIC_ROOT,
+    TEMPLATES,
+)
 from admin_panel.routes import auth as auth_routes
 from models.admin_user import AdminRole
 from services import auth as auth_service
@@ -27,6 +32,17 @@ ALLOWED_ROLES = (AdminRole.superadmin, AdminRole.admin_site)
 
 def _login_redirect() -> RedirectResponse:
     return RedirectResponse(url="/adminsite/login?next=/adminsite", status_code=303)
+
+
+@router.get("/_debug_static")
+async def debug_static_assets() -> dict[str, str | bool]:
+    base_css = ADMINSITE_STATIC_DIR / "base.css"
+    constructor_js = ADMINSITE_CONSTRUCTOR_PATH
+    return {
+        "static_root": str(ADMINSITE_STATIC_ROOT),
+        "base_css_exists": base_css.exists(),
+        "constructor_js_exists": constructor_js.exists(),
+    }
 
 
 @router.get("/login")

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV_BIN="$PROJECT_DIR/venv/bin"
 PIP_BIN="$VENV_BIN/pip"
-PYTHON_BIN="$VENV_BIN/python"
 NGINX_SRC="$PROJECT_DIR/deploy/nginx/miniden.conf"
 NGINX_DST="/etc/nginx/sites-available/miniden.conf"
+NGINX_ENABLED_DST="/etc/nginx/sites-enabled/miniden.conf"
 SYSTEMD_SRC_DIR="$PROJECT_DIR/deploy/systemd"
 
 log() {
@@ -15,6 +15,43 @@ log() {
 
 warn() {
   echo "[deploy][WARN] $*" >&2
+}
+
+fail_with_logs() {
+  warn "$1"
+  warn "---- journalctl -u miniden-api.service (last 120 lines) ----"
+  sudo journalctl -u miniden-api.service -n 120 --no-pager || true
+  if sudo test -f /var/log/nginx/miniden.error.log; then
+    warn "---- /var/log/nginx/miniden.error.log (last 120 lines) ----"
+    sudo tail -n 120 /var/log/nginx/miniden.error.log || true
+  fi
+  exit 1
+}
+
+check_http_ok() {
+  local url="$1"
+  if ! curl -fsS "$url" > /dev/null; then
+    fail_with_logs "Healthcheck failed: $url"
+  fi
+}
+
+check_head_ok() {
+  local url="$1"
+  if ! curl -fsSI "$url" > /dev/null; then
+    fail_with_logs "Healthcheck (HEAD) failed: $url"
+  fi
+}
+
+ensure_js_content_type() {
+  local url="$1"
+  local headers
+  headers=$(curl -fsSI "$url" | tr -d '\r') || fail_with_logs "Failed to read headers for $url"
+  if echo "$headers" | grep -qi "content-type: text/html"; then
+    fail_with_logs "Unexpected text/html Content-Type for $url"
+  fi
+  if ! echo "$headers" | grep -Eqi "content-type: .*javascript"; then
+    fail_with_logs "Content-Type for $url is not JavaScript: $(echo "$headers" | grep -i 'content-type')"
+  fi
 }
 
 log "-> Updating repository"
@@ -41,11 +78,14 @@ fi
 log "-> Install nginx config: $NGINX_SRC -> $NGINX_DST"
 if [ -f "$NGINX_SRC" ]; then
   sudo cp -f "$NGINX_SRC" "$NGINX_DST"
-  sudo ln -sf "$NGINX_DST" /etc/nginx/sites-enabled/miniden.conf
+  sudo ln -sf "$NGINX_DST" "$NGINX_ENABLED_DST"
+  log "-> nginx config test"
   sudo nginx -t
+  log "-> Reload nginx"
   sudo systemctl reload nginx
+  log "-> Active nginx config: $(sudo readlink -f "$NGINX_ENABLED_DST")"
 else
-  warn "nginx source config not found: $NGINX_SRC"
+  fail_with_logs "nginx source config not found: $NGINX_SRC"
 fi
 
 for service_name in miniden-api miniden-bot; do
@@ -57,10 +97,15 @@ for service_name in miniden-api miniden-bot; do
 
 done
 
-if [ -x "$PYTHON_BIN" ]; then
-  HEALTH_URL="http://127.0.0.1:8000/api/health"
-  log "-> Healthcheck $HEALTH_URL"
-  if ! curl -fsS "$HEALTH_URL" > /dev/null; then
-    warn "Healthcheck failed: $HEALTH_URL"
-  fi
-fi
+log "-> Post-deploy healthchecks (local)"
+check_http_ok "http://127.0.0.1:8000/adminsite/"
+check_http_ok "http://127.0.0.1:8000/static/adminsite/base.css"
+check_http_ok "http://127.0.0.1:8000/static/adminsite/constructor.js"
+ensure_js_content_type "http://127.0.0.1:8000/static/adminsite/constructor.js"
+
+log "-> Post-deploy healthchecks (public domain)"
+check_head_ok "https://miniden.ru/adminsite/"
+check_head_ok "https://miniden.ru/static/adminsite/constructor.js"
+ensure_js_content_type "https://miniden.ru/static/adminsite/constructor.js"
+
+log "-> Healthchecks succeeded"

--- a/deploy/DEPLOY_CONTRACT.md
+++ b/deploy/DEPLOY_CONTRACT.md
@@ -5,7 +5,7 @@
 - код API
 - код Telegram-бота
 - webapp (HTML/JS/CSS) для раздачи nginx
-- эталонные server-конфиги (deploy/nginx и deploy/systemd)
+- эталонные server-конфиги (deploy/nginx/miniden.conf и deploy/systemd)
 
 ## Одна команда деплоя на сервере
 sudo /opt/miniden/deploy.sh
@@ -18,7 +18,12 @@ sudo /opt/miniden/deploy.sh
 - systemd units -> /etc/systemd/system/
 - restart: miniden-api, miniden-bot
 - reload: nginx
-- post-check: curl http://127.0.0.1:8000/api/health
+- post-checks (деплой падает, если любая проверка не прошла):
+  - curl http://127.0.0.1:8000/adminsite/
+  - curl http://127.0.0.1:8000/static/adminsite/base.css
+  - curl http://127.0.0.1:8000/static/adminsite/constructor.js
+  - curl -I https://miniden.ru/adminsite/
+  - curl -I https://miniden.ru/static/adminsite/constructor.js (Content-Type не text/html)
 
 ## Что деплой НЕ ИМЕЕТ ПРАВА трогать
 - /opt/miniden/.env

--- a/webapi.py
+++ b/webapi.py
@@ -84,9 +84,7 @@ from schemas.home import HomeBlockIn, HomePostIn, HomeSectionIn
 
 
 BASE_DIR = Path(__file__).resolve().parent
-ADMINSITE_STATIC_PATH = (
-    BASE_DIR / "admin_panel" / "adminsite" / "static"
-).resolve()
+ADMINSITE_STATIC_PATH = ADMINSITE_STATIC_ROOT.resolve()
 WEBAPP_DIR = BASE_DIR / "webapp"
 STATIC_DIR_PUBLIC = BASE_DIR / "static"
 setup_logging(log_file=API_LOG_FILE)


### PR DESCRIPTION
## Summary
- point AdminSite STATIC_DIR to the constructor static assets and expose a debug endpoint for asset presence
- keep the FastAPI static mount at /static for AdminSite assets and align the static path constant
- enforce canonical nginx config usage in deploy.sh with strict nginx reload and post-deploy health checks
- document the single nginx config location and required deploy checks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aeb8501588326a8ca3167823fea74)