### PR TITLE
Harden nginx deployment config and static mounting

### DIFF
--- a/deploy/nginx/miniden.conf
+++ b/deploy/nginx/miniden.conf
@@ -2,60 +2,86 @@ server {
     listen 80;
     server_name miniden.ru www.miniden.ru;
 
+    # certbot ACME challenge
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    # redirect http -> https
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name miniden.ru www.miniden.ru;
+
+    ssl_certificate     /etc/letsencrypt/live/miniden.ru/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/miniden.ru/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    client_max_body_size 32m;
+
+    # common proxy headers
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # (optional) websocket headers
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    # SPA root
     root /opt/miniden/webapp;
     index index.html;
 
-    access_log /var/log/nginx/miniden.access.log;
-    error_log /var/log/nginx/miniden.error.log;
-
-    client_max_body_size 25m;
-
-    location /.well-known/acme-challenge/ {
-        alias /var/www/letsencrypt/.well-known/acme-challenge/;
-        try_files $uri =404;
-    }
-
-    location /media/ {
-        alias /opt/miniden/media/;
-        add_header Cache-Control "public, max-age=86400";
-        autoindex off;
-    }
-
-    location /api/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_redirect off;
-    }
-
+    # IMPORTANT: static must be defined BEFORE SPA try_files if you ever change to regex
+    # Static from backend (FastAPI mount /static)
     location ^~ /static/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:8000/static/;
         proxy_redirect off;
     }
 
-    location /adminbot {
-        root /opt/miniden/webapp;
-        try_files $uri $uri/ /admin.html;
+    # media served by nginx
+    location ^~ /media/ {
+        alias /opt/miniden/media/;
+        try_files $uri $uri/ =404;
     }
 
+    # Auth endpoints
+    location = /login {
+        proxy_pass http://127.0.0.1:8000/login;
+        proxy_redirect off;
+    }
+
+    location = /logout {
+        proxy_pass http://127.0.0.1:8000/logout;
+        proxy_redirect off;
+    }
+
+    # AdminBot
+    location ^~ /adminbot/ {
+        proxy_pass http://127.0.0.1:8000/adminbot/;
+        proxy_redirect off;
+    }
+
+    # AdminSite
     location ^~ /adminsite/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:8000/adminsite/;
         proxy_redirect off;
     }
 
+    # API
+    location ^~ /api/ {
+        proxy_pass http://127.0.0.1:8000/api/;
+        proxy_redirect off;
+    }
+
+    # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary
- replace nginx template with the enforced https configuration and static/media locations
- harden deploy.sh with backups, https guard, config testing, and idempotent symlinking
- ensure FastAPI mounts the /static assets path even when the directory is absent initially

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aedfc2fb48326a581894a2f92e09a)