### PR TITLE
Harden deployment configuration

### DIFF
--- a/deploy/DEPLOY_CONTRACT.md
+++ b/deploy/DEPLOY_CONTRACT.md
@@ -6,22 +6,26 @@
 - код Telegram-бота
 - webapp (HTML/JS/CSS) для раздачи nginx
 - эталонные server-конфиги (deploy/nginx/miniden.conf и deploy/systemd)
+- единый deploy.sh, который **не** порождает альтернативных конфигов
 
 ## Одна команда деплоя на сервере
 sudo /opt/miniden/deploy.sh
 
 ## Что деплой ОБЯЗАН обновлять
-- git pull в /opt/miniden
+-- git reset --hard origin/<branch> в /opt/miniden
 - зависимости Python (если менялся requirements.txt)
 - webapp -> /opt/miniden/webapp
 - nginx config -> /etc/nginx/sites-available/miniden.conf (+ symlink sites-enabled)
 - systemd units -> /etc/systemd/system/
 - restart: miniden-api, miniden-bot
 - reload: nginx
+- проверка прав: пользователь/группа miniden, права на /opt/miniden/logs, /opt/miniden/media, /opt/miniden/uploads
 - post-checks (деплой падает, если любая проверка не прошла):
+  - curl http://127.0.0.1:8000/api/health
   - curl http://127.0.0.1:8000/adminsite/
   - curl http://127.0.0.1:8000/static/adminsite/base.css
   - curl http://127.0.0.1:8000/static/adminsite/constructor.js
+  - curl -I https://miniden.ru/
   - curl -I https://miniden.ru/adminsite/
   - curl -I https://miniden.ru/static/adminsite/constructor.js (Content-Type не text/html)
 
@@ -29,3 +33,4 @@ sudo /opt/miniden/deploy.sh
 - /opt/miniden/.env
 - /opt/miniden/media/
 - /opt/miniden/data/
+- действующий SSL-сертификат (Let’s Encrypt) и /etc/letsencrypt/*.pem

--- a/deploy/miniden-api.service
+++ b/deploy/miniden-api.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=MiniDeN FastAPI backend
+Description=MiniDeN FastAPI backend (legacy location)
 After=network.target
 
 [Service]
@@ -8,9 +8,10 @@ WorkingDirectory=/opt/miniden
 EnvironmentFile=/opt/miniden/.env
 Environment=PYTHONUNBUFFERED=1
 ExecStart=/opt/miniden/venv/bin/uvicorn webapi:app --host 127.0.0.1 --port 8000
-Restart=always
-RestartSec=2
-User=root
+User=miniden
+Group=miniden
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/nginx/miniden.conf
+++ b/deploy/nginx/miniden.conf
@@ -1,20 +1,20 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name miniden.ru www.miniden.ru;
 
-    # certbot ACME challenge
     location /.well-known/acme-challenge/ {
         root /var/www/html;
     }
 
-    # redirect http -> https
     location / {
         return 301 https://$host$request_uri;
     }
 }
 
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name miniden.ru www.miniden.ru;
 
     ssl_certificate     /etc/letsencrypt/live/miniden.ru/fullchain.pem;
@@ -22,37 +22,31 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+    access_log /var/log/nginx/miniden.access.log;
+    error_log /var/log/nginx/miniden.error.log;
     client_max_body_size 32m;
 
-    # common proxy headers
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-
-    # (optional) websocket headers
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
 
-    # SPA root
     root /opt/miniden/webapp;
     index index.html;
 
-    # IMPORTANT: static must be defined BEFORE SPA try_files if you ever change to regex
-    # Static from backend (FastAPI mount /static)
     location ^~ /static/ {
-        proxy_pass http://127.0.0.1:8000/static/;
-        proxy_redirect off;
+        alias /opt/miniden/admin_panel/adminsite/static/;
+        try_files $uri $uri/ =404;
     }
 
-    # media served by nginx
     location ^~ /media/ {
         alias /opt/miniden/media/;
         try_files $uri $uri/ =404;
     }
 
-    # Auth endpoints
     location = /login {
         proxy_pass http://127.0.0.1:8000/login;
         proxy_redirect off;
@@ -63,25 +57,21 @@ server {
         proxy_redirect off;
     }
 
-    # AdminBot
     location ^~ /adminbot/ {
         proxy_pass http://127.0.0.1:8000/adminbot/;
         proxy_redirect off;
     }
 
-    # AdminSite
     location ^~ /adminsite/ {
         proxy_pass http://127.0.0.1:8000/adminsite/;
         proxy_redirect off;
     }
 
-    # API
     location ^~ /api/ {
         proxy_pass http://127.0.0.1:8000/api/;
         proxy_redirect off;
     }
 
-    # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/deploy/systemd/miniden-api.service
+++ b/deploy/systemd/miniden-api.service
@@ -6,11 +6,12 @@ After=network.target
 Type=simple
 WorkingDirectory=/opt/miniden
 EnvironmentFile=/opt/miniden/.env
+Environment=PYTHONUNBUFFERED=1
 ExecStart=/opt/miniden/venv/bin/uvicorn webapi:app --host 127.0.0.1 --port 8000
-Restart=on-failure
-RestartSec=5s
 User=miniden
 Group=miniden
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/systemd/miniden-bot.service
+++ b/deploy/systemd/miniden-bot.service
@@ -6,11 +6,12 @@ After=network.target
 Type=simple
 WorkingDirectory=/opt/miniden
 EnvironmentFile=/opt/miniden/.env
+Environment=PYTHONUNBUFFERED=1
 ExecStart=/opt/miniden/venv/bin/python bot.py
-Restart=on-failure
-RestartSec=5s
 User=miniden
 Group=miniden
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- finalize nginx production config for HTTPS redirect, SPA fallback, and direct admin static/media handling
- standardize systemd units to run under the miniden user with unbuffered output
- harden deploy.sh with idempotent config installs, permission fixes, health checks, and refreshed deploy contract
- add startup validation logging for the AdminSite static route

## Testing
- python -m compileall webapi.py admin_panel

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d79e8f96483268e16d01c3d61239f)