### PR TITLE
Fix AdminSite constructor webapp settings type

### DIFF
--- a/admin_panel/adminsite/templates/constructor.html
+++ b/admin_panel/adminsite/templates/constructor.html
@@ -184,8 +184,8 @@
                     <div class="form-row">
                         <label>Type
                             <select name="type" id="webapp-type">
-                                <option value="open_catalog">open_catalog</option>
-                                <option value="open_category">open_category</option>
+                                <option value="product">product — витрина товаров</option>
+                                <option value="course">course — витрина мастер-классов</option>
                             </select>
                         </label>
                         <label id="webapp-category-wrapper">Category


### PR DESCRIPTION
## Summary
- align the AdminSite constructor WebApp type selector with the API schema values
- validate WebApp form type/category before API calls and disable the category selector when scope is global

## Testing
- python -m compileall admin_panel/adminsite

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d80b9163c8326a436224b7ab931ac)