### PR TITLE
Fix adminsite constructor settings fallback

### DIFF
--- a/admin_panel/adminsite/service.py
+++ b/admin_panel/adminsite/service.py
@@ -329,7 +329,17 @@ def get_webapp_settings(
         )
 
     if settings is None:
-        raise HTTPException(status_code=404, detail="Settings not found")
+        settings = AdminSiteWebAppSettings(
+            scope="global",
+            type=type_value,
+            category_id=None,
+            action_enabled=True,
+            action_label="Оформить",
+            min_selected=1,
+        )
+        db.add(settings)
+        db.commit()
+        db.refresh(settings)
 
     return settings
 


### PR DESCRIPTION
## Summary
- ensure the adminsite webapp settings endpoint returns a default global record instead of 404
- handle missing webapp settings gracefully in the constructor frontend and reset UI status
- seed history state to keep back navigation working within the adminsite constructor

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d87c0dcf08326b9ce0789b4b306a6)