### PR TITLE
Link product categories with constructor pages and admin shortcuts

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -806,6 +806,21 @@ session_id теперь передаётся как query-параметр, ка
 - Systemd units: `deploy/systemd/miniden-api.service` and `miniden-bot.service` are installed/reloaded by the script, then restarted sequentially.
 - Protected paths: deploy script keeps existing `.env`, `media/`, `data/`, and runtime `logs/` untouched while updating code.
 
+## AdminSite/Constructor: Категории → Страницы
+- При создании/обновлении категории товаров или мастер-классов автоматически создаётся страница конструктора (таблица `adminsite_categories`) и `page_id` сохраняется в `product_categories.page_id`.
+- Slug и название синхронизируются с категорией; при запросах к API категории заполняется связка `page_id/page_slug`, а существующие категории без связки получают страницу автоматически при загрузке списков.
+- Отдельный эндпоинт `/api/admin/product-categories/{id}/page` позволяет принудительно создать/привязать страницу, если она потерялась.
+
+## Быстрые переходы в админке
+- В списке категорий добавлены ссылки: «Страница» (открывает `/adminsite/constructor` с нужной категорией), «Товары» и «Мастер-классы» (открывают списки с фильтром `category_id`/`type`).
+- В формах категорий отображается read-only блок с `page_id/page_slug`, кнопки для открытия конструктора и списков, а также кнопка «Создать страницу», вызывающая `/api/admin/product-categories/{id}/page`.
+- Ссылки используют query-параметры `view`, `type`, `category_id`, поэтому переход из списка категорий сразу включает нужный фильтр в админке.
+
+## Проверка (smoke test)
+1. Создать категорию в админке (вкладка «Категории товаров/мастер-классов») — после сохранения у записи появляется `page_id`, а в конструкторе видна страница.
+2. Создать товар и указать созданную категорию.
+3. Открыть публичную страницу категории (`/category/<slug>` или кнопка «Страница») и убедиться, что новый товар отображается без ручного редактирования страницы; при необходимости из формы категории можно нажать «Создать страницу» для восстановления привязки.
+
 ## Maintenance log
 - Audited repository layout and deployment entrypoints (see `docs/audit_report.md`).
 - Fixed AdminSite constructor history sync so browser Back closes modals cleanly and does not trap navigation.

--- a/database.py
+++ b/database.py
@@ -78,6 +78,7 @@ def init_db() -> None:
             "ALTER TABLE products_courses ADD COLUMN IF NOT EXISTS masterclass_url TEXT",
             "ALTER TABLE product_reviews ADD COLUMN IF NOT EXISTS masterclass_id INTEGER",
             "ALTER TABLE product_reviews ALTER COLUMN product_id DROP NOT NULL",
+            "ALTER TABLE product_categories ADD COLUMN IF NOT EXISTS page_id INTEGER",
             "ALTER TABLE webchat_sessions ADD COLUMN IF NOT EXISTS session_key VARCHAR(64)",
             "ALTER TABLE webchat_sessions ADD COLUMN IF NOT EXISTS user_identifier TEXT",
             "ALTER TABLE webchat_sessions ADD COLUMN IF NOT EXISTS user_agent TEXT",

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -261,8 +261,11 @@ class ProductCategory(Base):
     sort_order = Column(Integer, nullable=False, default=0)
     is_active = Column(Boolean, default=True, nullable=False)
     type = Column(String, nullable=False, default="basket")
+    page_id = Column(Integer, ForeignKey("adminsite_categories.id"), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=func.now(), nullable=False)
+
+    page = relationship("AdminSiteCategory")
 
 
 class User(Base):

--- a/webapp/admin.html
+++ b/webapp/admin.html
@@ -178,6 +178,13 @@
               <div class="image-preview" id="product-category-image-preview" style="display:none;">
                 <img alt="Превью категории" />
               </div>
+              <div class="muted" id="product-category-page-info">Страница создаётся автоматически при сохранении категории.</div>
+              <div class="quick-actions" id="product-category-page-actions" style="display:flex; gap:6px; flex-wrap:wrap;">
+                <a class="btn secondary" id="product-category-open-page" target="_blank" href="/adminsite/constructor">Открыть страницу</a>
+                <a class="btn secondary" id="product-category-open-products" href="#">Товары</a>
+                <a class="btn secondary" id="product-category-open-courses" href="#">Мастер-классы</a>
+                <button class="btn secondary" type="button" id="product-category-create-page">Создать страницу</button>
+              </div>
               <label>Порядок сортировки</label>
               <input type="number" name="sort_order" min="0" value="0" />
               <label style="display:flex; gap:8px; align-items:center; margin-top:8px;">
@@ -239,6 +246,13 @@
               <input type="file" name="image_file" id="course-category-image-file" accept="image/*" />
               <div class="image-preview" id="course-category-image-preview" style="display:none;">
                 <img alt="Превью категории" />
+              </div>
+              <div class="muted" id="course-category-page-info">Страница создаётся автоматически при сохранении категории.</div>
+              <div class="quick-actions" id="course-category-page-actions" style="display:flex; gap:6px; flex-wrap:wrap;">
+                <a class="btn secondary" id="course-category-open-page" target="_blank" href="/adminsite/constructor">Открыть страницу</a>
+                <a class="btn secondary" id="course-category-open-products" href="#">Товары</a>
+                <a class="btn secondary" id="course-category-open-courses" href="#">Мастер-классы</a>
+                <button class="btn secondary" type="button" id="course-category-create-page">Создать страницу</button>
               </div>
               <label>Порядок сортировки</label>
               <input type="number" name="sort_order" min="0" value="0" />
@@ -1046,6 +1060,16 @@
     const courseCategoryImageFile = document.getElementById('course-category-image-file');
     const productCategoryImagePreview = document.getElementById('product-category-image-preview');
     const courseCategoryImagePreview = document.getElementById('course-category-image-preview');
+    const productCategoryPageInfo = document.getElementById('product-category-page-info');
+    const courseCategoryPageInfo = document.getElementById('course-category-page-info');
+    const productCategoryOpenPage = document.getElementById('product-category-open-page');
+    const courseCategoryOpenPage = document.getElementById('course-category-open-page');
+    const productCategoryOpenProducts = document.getElementById('product-category-open-products');
+    const courseCategoryOpenProducts = document.getElementById('course-category-open-products');
+    const productCategoryOpenCourses = document.getElementById('product-category-open-courses');
+    const courseCategoryOpenCourses = document.getElementById('course-category-open-courses');
+    const productCategoryCreatePage = document.getElementById('product-category-create-page');
+    const courseCategoryCreatePage = document.getElementById('course-category-create-page');
 
     const brandingSiteTitleInput = document.getElementById('branding-site-title');
     const brandingAssetsVersion = document.getElementById('branding-assets-version');
@@ -1068,6 +1092,10 @@
       basket: new Map(),
       course: new Map(),
     };
+    const initialParams = new URLSearchParams(window.location.search);
+    const initialViewParam = initialParams.get('view') || 'orders';
+    const initialCategoryParam = initialParams.get('category_id');
+    const initialTypeParam = initialParams.get('type');
 
     if (statusFilter) {
       statusFilter.value = DEFAULT_ORDER_STATUS;
@@ -1386,6 +1414,45 @@
         img.removeAttribute('src');
         img.style.display = 'none';
         previewEl.style.display = 'none';
+      }
+    }
+
+    function updateCategoryPageSection(scope = 'basket', category = null) {
+      const isBasket = scope === 'basket';
+      const pageInfoEl = isBasket ? productCategoryPageInfo : courseCategoryPageInfo;
+      const openPageLink = isBasket ? productCategoryOpenPage : courseCategoryOpenPage;
+      const openProductsLink = isBasket ? productCategoryOpenProducts : courseCategoryOpenProducts;
+      const openCoursesLink = isBasket ? productCategoryOpenCourses : courseCategoryOpenCourses;
+      const createPageBtn = isBasket ? productCategoryCreatePage : courseCategoryCreatePage;
+
+      const pageId = category?.page_id;
+      const pageSlug = category?.page_slug || category?.slug || '';
+      const pageType = category?.type === 'course' ? 'course' : 'product';
+      const categoryId = category?.id;
+
+      if (pageInfoEl) {
+        pageInfoEl.textContent = pageId
+          ? `Страница #${pageId}${pageSlug ? ` (${pageSlug})` : ''}`
+          : 'Страница появится автоматически. Создайте её вручную, если связка потерялась.';
+      }
+
+      if (openPageLink) {
+        openPageLink.href = pageId ? `/adminsite/constructor?type=${pageType}&category_id=${pageId}` : '/adminsite/constructor';
+        openPageLink.style.opacity = pageId ? '' : '0.6';
+        openPageLink.tabIndex = pageId ? 0 : -1;
+      }
+
+      if (openProductsLink) {
+        const typeParam = pageType === 'course' ? 'course' : 'basket';
+        openProductsLink.href = `/admin.html?view=product-list&type=${typeParam}${categoryId ? `&category_id=${categoryId}` : ''}`;
+      }
+
+      if (openCoursesLink) {
+        openCoursesLink.href = `/admin.html?view=course-list&type=course${categoryId ? `&category_id=${categoryId}` : ''}`;
+      }
+
+      if (createPageBtn) {
+        createPageBtn.disabled = !categoryId;
       }
     }
 
@@ -2536,6 +2603,10 @@
         row.dataset.id = cat.id;
         row.classList.toggle('selected', String(cat.id) === String(selectedId));
         const updated = formatDate(cat.updated_at);
+        const pageType = cat.type === 'course' ? 'course' : 'product';
+        const pageLink = cat.page_id ? `/adminsite/constructor?type=${pageType}&category_id=${cat.page_id}` : '/adminsite/constructor';
+        const productsLink = `/admin.html?view=product-list&category_id=${cat.id}&type=${pageType === 'course' ? 'course' : 'basket'}`;
+        const masterclassesLink = `/admin.html?view=course-list&category_id=${cat.id}&type=course`;
         row.innerHTML = `
           <td>#${cat.id}</td>
           <td>${cat.name}</td>
@@ -2546,13 +2617,16 @@
           <td>${updated}</td>
           <td>
             <div style="display:flex; gap:6px; flex-wrap:wrap;">
+              <a class="btn secondary" href="${pageLink}" target="_blank" ${cat.page_id ? '' : 'aria-disabled="true" style="opacity:0.6;"'}>Страница</a>
+              <a class="btn secondary" href="${productsLink}">Товары</a>
+              <a class="btn secondary" href="${masterclassesLink}">Мастер-классы</a>
               <button class="btn secondary" type="button" data-edit="${cat.id}">Редактировать</button>
               <button class="btn secondary danger" type="button" data-delete="${cat.id}">Удалить</button>
             </div>
           </td>
         `;
         row.addEventListener('click', (event) => {
-          if (event.target.closest('button')) return;
+          if (event.target.closest('button') || event.target.closest('a')) return;
           onEdit?.(cat);
         });
         const editBtn = row.querySelector('button[data-edit]');
@@ -2620,6 +2694,7 @@
       }
       setCategoryPreview(previewEl, category.image_url, category.image_version || category.updated_at);
       clearFileInput(form.elements.image_file);
+      updateCategoryPageSection(defaultType === 'basket' ? 'basket' : 'course', category);
     }
 
     function resetCategoryForm(form, titleEl, defaultTitle, defaultType = 'basket', previewEl = null, deleteBtn = null) {
@@ -2630,6 +2705,7 @@
       if (deleteBtn) deleteBtn.style.display = 'none';
       setCategoryPreview(previewEl, '', null);
       clearFileInput(form?.elements?.image_file);
+      updateCategoryPageSection(defaultType === 'basket' ? 'basket' : 'course', { id: null, type: defaultType });
     }
 
     async function renderProductTable(items, targetTable, type) {
@@ -2801,6 +2877,43 @@
         }
       } catch (e) {
         handleError(e, 'Не удалось удалить категорию');
+      }
+    }
+
+    async function ensureCategoryPage(scope = 'basket') {
+      if (!currentUser) return;
+      const isBasket = scope === 'basket';
+      const categoryId = isBasket ? editingProductCategoryId : editingCourseCategoryId;
+      if (!categoryId) {
+        showToast('Сначала сохраните категорию');
+        return;
+      }
+
+      try {
+        await apiPost(`/admin/product-categories/${categoryId}/page`, {
+          user_id: currentUser.telegram_id,
+          force: true,
+        });
+        setStatus('Страница категории обновлена');
+        if (isBasket) {
+          await Promise.all([
+            loadProductCategories(categoryId),
+            loadCategories(productCategorySelect, 'basket'),
+            loadCategories(productCategoryFilter, 'basket', { includeAllOption: true }),
+          ]);
+          const refreshed = productCategoryItems.find((cat) => String(cat.id) === String(categoryId));
+          if (refreshed) startCategoryEdit(refreshed, 'basket');
+        } else {
+          await Promise.all([
+            loadCourseCategories(categoryId),
+            loadCategories(courseCategorySelect, 'course'),
+            loadCategories(courseCategoryFilter, 'course', { includeAllOption: true }),
+          ]);
+          const refreshed = courseCategoryItems.find((cat) => String(cat.id) === String(categoryId));
+          if (refreshed) startCategoryEdit(refreshed, 'course');
+        }
+      } catch (e) {
+        handleError(e, 'Не удалось создать страницу категории');
       }
     }
 
@@ -3671,6 +3784,8 @@
       const category = courseCategoryItems.find((cat) => String(cat.id) === String(editingCourseCategoryId));
       handleCategoryDelete(category || { id: editingCourseCategoryId }, 'course');
     });
+    productCategoryCreatePage?.addEventListener('click', () => ensureCategoryPage('basket'));
+    courseCategoryCreatePage?.addEventListener('click', () => ensureCategoryPage('course'));
     homeBlockReset?.addEventListener('click', resetHomeBlockForm);
     homePostReset?.addEventListener('click', resetHomePostForm);
 
@@ -3769,6 +3884,14 @@
           loadCategories(courseCategorySelect, 'course'),
         ]);
 
+        if (initialCategoryParam) {
+          if (initialTypeParam === 'course') {
+            if (courseCategoryFilter) courseCategoryFilter.value = initialCategoryParam;
+          } else if (productCategoryFilter) {
+            productCategoryFilter.value = initialCategoryParam;
+          }
+        }
+
         await Promise.all([loadProductCategories(), loadCourseCategories()]);
 
         resetPromoCreateForm();
@@ -3780,7 +3903,7 @@
         await loadReviews();
         await Promise.all([loadHomeBlocks(), loadHomePosts()]);
         await loadBrandingSettings();
-        showSection('orders');
+        handleViewNavigation(initialViewParam || 'orders');
         console.log('[admin] initApp done');
       } catch (e) {
         handleError(e, 'Ошибка загрузки админки');

--- a/webapp/js/category_page.js
+++ b/webapp/js/category_page.js
@@ -217,6 +217,9 @@
   function renderCategory(category) {
     if (heroTitle) heroTitle.textContent = category.name || 'Категория';
     if (heroDescription) heroDescription.textContent = category.description || 'Описание появится позже.';
+    if (category?.name) {
+      document.title = `MiniDeN — ${category.name}`;
+    }
     if (heroImage) {
       const heroUrl = versionedImageUrl(category);
       if (heroUrl) {
@@ -257,6 +260,9 @@
       renderCategory(category);
       renderList(productsSection, products, 'Товары этой категории', buildProductCard);
       renderList(masterclassesSection, masterclasses, 'Мастер-классы', buildMasterclassCard);
+      if (noteEl) {
+        noteEl.textContent = products.length || masterclasses.length ? '' : 'Категория создана, товары появятся позже.';
+      }
     } catch (error) {
       console.error('Failed to load category', error);
       if (noteEl) noteEl.textContent = 'Категория не найдена или выключена.';


### PR DESCRIPTION
## Summary
- add a page_id link from product categories to AdminSite constructor categories and auto-create/sync pages when categories are saved
- expose category page metadata in APIs, adjust category page messaging, and provide an endpoint to recreate missing pages
- enhance admin UI with quick links to constructor pages, product/masterclass lists with query filters, and document the flow in README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed23977f88326be98710eafa6e7d8)