### PR TITLE
Fix SyntaxError in product categories loader

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,6 +3,7 @@ MiniDeN — Telegram-бот и веб-магазин
 
 Changelog / История изменений
 -----------------------------
+- 2025-12-07: Исправлен SyntaxError в `services/products.py` (незакрытые скобки вокруг запроса категорий), из-за которого падал запуск `miniden-api`. Проверка: `python -m py_compile services/products.py`.
 - 2025-12-01: Fix AdminSite static + unify nginx deploy config. Исправлено монтирование `/static` в FastAPI (ошибка `url_for('static', ...)` больше не возникает), шаблоны AdminSite теперь ссылаются на конструктор через `url_for`, а единственным источником nginx-конфига остаётся `deploy/nginx/miniden.conf`, который копируется из `deploy.sh` в `/etc/nginx/sites-available/miniden.conf` и линкуется в `sites-enabled`. Проверка: `curl -I http://127.0.0.1:8000/static/adminsite/base.css`, `curl -I http://127.0.0.1:8000/static/adminsite/constructor.js`, открытие https://miniden.ru/adminsite/ и https://miniden.ru/adminsite/constructor/ (CSS/JS должны быть 200 и с корректным Content-Type).
 - Hotfix: Pydantic v2 compatibility (pattern вместо regex и др.) — backend падал при старте (502 Bad Gateway) из-за использования синтаксиса Pydantic v1 в AdminSite моделях.
 

--- a/services/products.py
+++ b/services/products.py
@@ -341,10 +341,11 @@ def _load_category_maps(product_type: str, *, include_mixed: bool = False):
             )
             .scalars()
             .all()
+        )
+
         for row in rows:
             if getattr(row, "page_id", None) is None:
                 _ensure_category_page(session, row)
-        )
 
     for row in rows:
         meta = _category_meta(row)


### PR DESCRIPTION
## Summary
- fix the unclosed parentheses in services/products.py so category loading compiles again
- add maintenance log entry documenting the SyntaxError fix and verification command

## Testing
- python -m py_compile services/products.py
- python -c "import services.products"
- uvicorn webapi:app --host 0.0.0.0 --port 8000 *(fails: ValueError: Не найден BOT_TOKEN в .env)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed70a125483269183b2047a89a0ab)