### PR TITLE
Add visual homepage editor and media library for AdminSite

### DIFF
--- a/admin_panel/adminsite/media.py
+++ b/admin_panel/adminsite/media.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException, UploadFile
+
+
+UPLOAD_DIR = Path(__file__).resolve().parents[2] / "static" / "uploads"
+ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
+ALLOWED_MIMES = {"image/jpeg", "image/png", "image/webp"}
+MAX_SIZE_BYTES = 5 * 1024 * 1024
+
+
+def _ensure_dir() -> None:
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _build_file_url(filename: str) -> str:
+    safe_name = filename.lstrip("/")
+    return f"/static/uploads/{safe_name}"
+
+
+def list_media(query: str | None = None) -> list[dict[str, Any]]:
+    _ensure_dir()
+    if not UPLOAD_DIR.exists():
+        return []
+
+    items: list[dict[str, Any]] = []
+    for file_path in UPLOAD_DIR.iterdir():
+        if not file_path.is_file():
+            continue
+
+        stat = file_path.stat()
+        items.append(
+            {
+                "name": file_path.name,
+                "size": stat.st_size,
+                "url": _build_file_url(file_path.name),
+                "modified": stat.st_mtime,
+            }
+        )
+
+    filtered = items
+    if query:
+        needle = query.lower().strip()
+        filtered = [item for item in items if needle in item["name"].lower()]
+
+    return sorted(filtered, key=lambda item: item["modified"], reverse=True)
+
+
+def _validate_upload(upload: UploadFile) -> str | None:
+    filename = upload.filename or ""
+    extension = Path(filename).suffix.lower()
+    if extension not in ALLOWED_EXTENSIONS:
+        return "Разрешены только изображения (jpg, jpeg, png, webp)."
+
+    content_type = (upload.content_type or "").split(";")[0].strip()
+    guessed, _ = mimetypes.guess_type(filename)
+    if content_type and content_type not in ALLOWED_MIMES:
+        return "Тип файла не похож на изображение."
+    if guessed and guessed not in ALLOWED_MIMES:
+        return "Файл не похож на изображение."
+    return None
+
+
+async def save_upload(upload: UploadFile) -> dict[str, str]:
+    from uuid import uuid4
+
+    _ensure_dir()
+    validation_error = _validate_upload(upload)
+    if validation_error:
+        raise HTTPException(status_code=400, detail=validation_error)
+
+    data = await upload.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="Файл пустой")
+
+    if len(data) > MAX_SIZE_BYTES:
+        raise HTTPException(status_code=400, detail="Файл слишком большой. Лимит 5 МБ.")
+
+    extension = Path(upload.filename or "").suffix.lower()
+    target_name = f"{uuid4().hex}{extension}"
+    target_path = (UPLOAD_DIR / target_name).resolve()
+
+    try:
+        target_path.write_bytes(data)
+    except Exception as exc:  # pragma: no cover - защита от проблем с диском
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    return {"url": _build_file_url(target_name), "filename": target_name}
+
+
+def delete_media(filename: str) -> dict[str, str]:
+    if not filename:
+        raise HTTPException(status_code=400, detail="Не указано имя файла")
+
+    target = (UPLOAD_DIR / filename).resolve()
+    if not str(target).startswith(str(UPLOAD_DIR.resolve())):
+        raise HTTPException(status_code=400, detail="Неверное имя файла")
+
+    if target.exists():
+        try:
+            target.unlink()
+        except Exception as exc:  # pragma: no cover - fail-safe
+            raise HTTPException(status_code=500, detail=str(exc))
+
+    return {"status": "deleted"}
+
+
+__all__ = ["list_media", "save_upload", "delete_media"]

--- a/admin_panel/adminsite/static/adminsite/constructor.css
+++ b/admin_panel/adminsite/static/adminsite/constructor.css
@@ -358,3 +358,289 @@ tr:nth-child(even) {
         grid-template-columns: 1fr;
     }
 }
+
+.homepage-top {
+    display: flex;
+    gap: 16px;
+    align-items: stretch;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.template-picker {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+    flex: 1;
+}
+
+.template-card {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 12px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: #0f172a;
+    cursor: pointer;
+    transition: border-color 0.2s, transform 0.2s;
+}
+
+.template-card:hover,
+.template-card.active {
+    border-color: var(--primary);
+    transform: translateY(-2px);
+}
+
+.template-preview {
+    height: 70px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: linear-gradient(120deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02));
+}
+
+.template-preview.baskets {
+    background: linear-gradient(135deg, #fef3c7, #fde68a);
+}
+
+.template-preview.electronics {
+    background: linear-gradient(135deg, #0ea5e9, #1e3a8a);
+}
+
+.template-preview.services {
+    background: linear-gradient(135deg, #cbd5e1, #f8fafc);
+}
+
+.template-title {
+    font-weight: 700;
+}
+
+.homepage-actions {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.homepage-layout {
+    margin-top: 16px;
+    display: grid;
+    grid-template-columns: 360px 1fr;
+    gap: 16px;
+}
+
+@media (max-width: 1024px) {
+    .homepage-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+.block-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.block-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 10px;
+    align-items: center;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: #0b1220;
+    cursor: pointer;
+}
+
+.block-row.active {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 1px var(--primary);
+}
+
+.block-row .meta {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.block-row .actions {
+    justify-content: flex-end;
+}
+
+.block-editor {
+    min-height: 280px;
+    background: #0b1220;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+}
+
+.block-editor label {
+    color: var(--muted);
+}
+
+.field-row {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.inline-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 6px;
+}
+
+.pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: #1f2937;
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.list-item {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 8px;
+    align-items: center;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: #0f172a;
+}
+
+.list-item h5 {
+    margin: 0;
+}
+
+.developer-toggle {
+    margin-top: 14px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    padding: 10px;
+    border-radius: 12px;
+    background: #0f172a;
+    border: 1px dashed var(--border);
+}
+
+.devtools {
+    margin-top: 10px;
+    padding: 12px;
+    border-radius: 12px;
+    background: #0b1220;
+    border: 1px solid var(--border);
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 46px;
+    height: 26px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #1f2937;
+    transition: .2s;
+    border-radius: 34px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: .2s;
+    border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+    background-color: var(--primary);
+}
+
+.switch input:checked + .slider:before {
+    transform: translateX(20px);
+}
+
+.media-grid {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    gap: 14px;
+}
+
+@media (max-width: 980px) {
+    .media-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.media-list {
+    display: grid;
+    gap: 12px;
+}
+
+.media-card {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    gap: 10px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 10px;
+    background: #0b1220;
+}
+
+.media-card img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+}
+
+.media-card .actions {
+    justify-content: flex-start;
+}
+
+.file-input {
+    display: block;
+    padding: 12px;
+    border: 1px dashed var(--border);
+    border-radius: 10px;
+    cursor: pointer;
+    background: #0b1220;
+}
+
+.file-input input {
+    margin-top: 6px;
+}

--- a/admin_panel/adminsite/static/adminsite/modals.js
+++ b/admin_panel/adminsite/static/adminsite/modals.js
@@ -4,7 +4,7 @@ function createElement(html) {
     return tpl.content.firstElementChild;
 }
 
-class BaseModal {
+export class BaseModal {
     constructor(title) {
         this.backdrop = createElement('<div class="modal-backdrop" hidden></div>');
         this.modal = createElement('<div class="modal"></div>');

--- a/admin_panel/adminsite/templates/constructor.html
+++ b/admin_panel/adminsite/templates/constructor.html
@@ -96,7 +96,7 @@
         <div class="table-top">
             <div>
                 <h3 style="margin:0;">Главная страница</h3>
-                <p class="muted">Шаблоны оформления и блоки для витрины AdminSite. Контент остаётся неизменным при смене шаблона.</p>
+                <p class="muted">Визуальный редактор блоков для витрины AdminSite. Контент остаётся неизменным при смене шаблона.</p>
             </div>
             <div class="badge-list">
                 <span class="tag">HeroBlock</span>
@@ -106,28 +106,114 @@
             </div>
         </div>
         <div class="status" id="status-homepage"></div>
-        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap:14px;">
-            <div class="card" style="padding:14px;">
-                <h4 style="margin-top:0;">Шаблон</h4>
-                <label>Выберите пресет оформления
-                    <select id="homepage-template">
-                        <option value="baskets">Baskets</option>
-                        <option value="electronics">Electronics</option>
-                        <option value="services">Services (дефолт)</option>
-                    </select>
-                </label>
-                <p class="muted" style="margin-top:6px;">Смена шаблона влияет только на цвета, радиусы и тени. Контент блоков не меняется.</p>
-                <div class="divider"></div>
-                <p class="muted">Шаблоны описаны в registry и применяются на фронте через CSS variables.</p>
-            </div>
-            <div class="card" style="padding:14px;">
-                <h4 style="margin-top:0;">Блоки</h4>
-                <p class="muted" style="margin-top:-4px;">Редактируйте конфигурацию блоков в формате JSON. Поддерживаются hero, cards, text, social.</p>
-                <textarea id="homepage-blocks" rows="18" style="width:100%; resize:vertical; font-family: monospace;"></textarea>
-                <div class="actions" style="margin-top:12px; gap:8px;">
-                    <button class="btn-secondary" type="button" id="homepage-reset">Сбросить</button>
-                    <button class="btn-primary" type="button" id="homepage-save">Сохранить</button>
+        <div class="homepage-top">
+            <div class="template-picker" id="homepage-template">
+                <div class="template-card" data-template="baskets">
+                    <div class="template-preview baskets"></div>
+                    <div>
+                        <div class="template-title">Baskets</div>
+                        <p class="muted">Тёплая палитра и плавные карточки.</p>
+                    </div>
                 </div>
+                <div class="template-card" data-template="electronics">
+                    <div class="template-preview electronics"></div>
+                    <div>
+                        <div class="template-title">Electronics</div>
+                        <p class="muted">Контрастная тема и чёткие края.</p>
+                    </div>
+                </div>
+                <div class="template-card" data-template="services">
+                    <div class="template-preview services"></div>
+                    <div>
+                        <div class="template-title">Services</div>
+                        <p class="muted">Нейтральная тема по умолчанию.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="homepage-actions">
+                <a class="btn-secondary" href="/" target="_blank" rel="noopener">Предпросмотр</a>
+                <button class="btn-primary" type="button" id="homepage-save">Сохранить</button>
+            </div>
+        </div>
+
+        <div class="homepage-layout">
+            <div class="card block-list-card">
+                <div class="card-header">
+                    <h4 style="margin:0;">Блоки страницы</h4>
+                    <div class="actions" style="margin:0;">
+                        <button class="btn-secondary" type="button" id="homepage-add-block">+ Добавить блок</button>
+                        <button class="btn-ghost" type="button" id="homepage-reset">Сбросить</button>
+                    </div>
+                </div>
+                <p class="muted" style="margin-top:4px;">Перетащите блоки вверх/вниз или редактируйте содержимое справа.</p>
+                <div id="homepage-blocks-list" class="block-list"></div>
+                <div class="developer-toggle">
+                    <label class="switch">
+                        <input type="checkbox" id="homepage-dev-toggle" />
+                        <span class="slider"></span>
+                    </label>
+                    <div>
+                        <div class="template-title">Режим разработчика</div>
+                        <p class="muted" style="margin:0;">Показать/скрыть JSON конфигурацию.</p>
+                    </div>
+                </div>
+                <div id="homepage-devtools" class="devtools" hidden>
+                    <p class="muted" style="margin:0 0 8px;">Измените JSON вручную или вставьте существующую конфигурацию. Сохранение поднимает валидные данные в визуальный редактор.</p>
+                    <textarea id="homepage-blocks" rows="14" style="width:100%; resize:vertical; font-family: monospace;"></textarea>
+                    <div class="actions" style="margin-top:12px; gap:8px;">
+                        <button class="btn-secondary" type="button" id="homepage-dev-apply">Применить JSON</button>
+                        <button class="btn-ghost" type="button" id="homepage-dev-hide">Скрыть</button>
+                    </div>
+                    <div class="status" id="homepage-dev-status"></div>
+                </div>
+            </div>
+            <div class="card block-editor-card">
+                <div class="card-header" style="align-items:center;">
+                    <div>
+                        <h4 style="margin:0;" id="homepage-editor-title">Редактор блока</h4>
+                        <p class="muted" id="homepage-editor-subtitle" style="margin:4px 0 0;">Выберите блок слева, чтобы отредактировать.</p>
+                    </div>
+                    <div class="badge-list" id="homepage-block-meta"></div>
+                </div>
+                <div id="homepage-block-editor" class="block-editor"></div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="panel" id="panel-media">
+    <div class="card">
+        <div class="table-top">
+            <div>
+                <h3 style="margin:0;">Медиа-библиотека</h3>
+                <p class="muted">Загружайте изображения и копируйте URL. Подключено к тем же файлам, что использует AdminBot.</p>
+            </div>
+            <div class="badge-list">
+                <span class="tag">upload</span>
+                <span class="tag">preview</span>
+                <span class="tag">copy URL</span>
+            </div>
+        </div>
+        <div class="status" id="status-media"></div>
+        <div class="media-grid">
+            <div class="card upload-card">
+                <h4 style="margin-top:0;">Загрузка файла</h4>
+                <p class="muted" style="margin-top:-4px;">jpg, png или webp до 5 МБ</p>
+                <label class="file-input">Выберите файл
+                    <input type="file" id="media-upload-input" accept="image/jpeg,image/png,image/webp" />
+                </label>
+                <div class="actions" style="margin-top:12px;">
+                    <button class="btn-primary" type="button" id="media-upload-btn">Загрузить</button>
+                    <button class="btn-ghost" type="button" id="media-refresh">Обновить</button>
+                </div>
+                <div class="status" id="media-upload-status"></div>
+            </div>
+            <div class="card list-card">
+                <div class="card-header" style="gap:12px;">
+                    <h4 style="margin:0;">Файлы</h4>
+                    <input type="search" id="media-search" placeholder="Поиск по имени" />
+                </div>
+                <div id="media-list" class="media-list"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the homepage JSON textarea with a visual block editor that manages hero, cards, text, and social blocks with template previews and defaults
- add a media library panel and picker powered by AdminSite API endpoints for listing, uploading, deleting, and selecting images
- ensure stored homepage configs are normalized with defaults so the public storefront renders saved content consistently

## Testing
- python -m compileall admin_panel


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694efea70b4c8326b838e3baebe4be80)