### PR TITLE
Ensure AdminSite save updates storefront home data

### DIFF
--- a/admin_panel/adminsite/static/adminsite/constructor.js
+++ b/admin_panel/adminsite/static/adminsite/constructor.js
@@ -1693,18 +1693,25 @@ async function saveHomepageConfig() {
             templateId: homepageConfig.templateId || 'services',
             blocks: homepageConfig.blocks || [],
         };
+        console.debug('[AdminSite constructor] Отправка страницы', payload);
         const data = await apiRequest(`${API_BASE}/pages/home`, {
             method: 'PUT',
             body: payload,
             credentials: 'include',
         });
+        if (!data || typeof data !== 'object') {
+            throw new Error('API вернул пустой ответ, страница не сохранена');
+        }
+
         homepageLoadedConfig = normalizeHomepageConfig(data || payload);
         renderHomepageForm(homepageLoadedConfig);
         setHomepageStatus('Сохранено');
         showToast('Страница обновлена');
+        console.debug('[AdminSite constructor] Страница сохранена', homepageLoadedConfig);
     } catch (error) {
-        console.error(error);
+        console.error('[AdminSite constructor] Сохранение страницы не удалось', error);
         setHomepageStatus(error.message || 'Не удалось сохранить страницу', true);
+        showToast(error.message || 'Не удалось сохранить страницу', 'error');
     }
 }
 

--- a/webapp/js/site_api.js
+++ b/webapp/js/site_api.js
@@ -1,5 +1,6 @@
 export async function request(path, params = null) {
   const url = new URL(path, window.location.origin);
+
   if (params) {
     Object.entries(params).forEach(([key, value]) => {
       if (value !== undefined && value !== null && value !== '') {
@@ -8,7 +9,9 @@ export async function request(path, params = null) {
     });
   }
 
-  const response = await fetch(url.toString());
+  url.searchParams.set('_', Date.now().toString());
+
+  const response = await fetch(url.toString(), { cache: 'no-store' });
   const text = await response.text();
   const isJson = text.trim().startsWith('{') || text.trim().startsWith('[');
   const payload = isJson ? JSON.parse(text || '{}') : text;


### PR DESCRIPTION
## Summary
- add cache-busting and no-store fetch options to the storefront API helper so home data refreshes after AdminSite changes
- improve AdminSite constructor save flow with debug logging, empty-response guard, and visible error toast

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69503019d6048326ac60919efac033c4)