### PR TITLE
Ensure home page loads config with debug overlay

### DIFF
--- a/webapp/js/site_api.js
+++ b/webapp/js/site_api.js
@@ -30,10 +30,12 @@ export function fetchMenu(type = 'product') {
   return request('/api/site/menu', { type });
 }
 
-export function fetchHome(limit = 6, version = null) {
+export function fetchHome(limit = 6, version = null, extraParams = {}) {
   const params = {
     limit,
     v: version || Date.now().toString(),
+    t: Date.now().toString(),
+    ...extraParams,
   };
   return request('/api/site/home', params);
 }


### PR DESCRIPTION
## Summary
- force the storefront to fetch `/api/site/home` with cache-busting and resilient parsing of blocks
- add a debug overlay (enabled via `?debug=1`) to show fetch status, version, and block info with manual reload
- render blocks with fallbacks when the home configuration is missing or empty

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69503d01cce4832689054dfbea0326ca)