### PR TITLE
Handle hero image fallbacks

### DIFF
--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -3339,6 +3339,17 @@ body.page-index .pill:nth-child(2) {
   box-shadow: 0 16px 38px rgba(0, 0, 0, 0.08);
 }
 
+.page-hero__placeholder {
+  width: 100%;
+  max-width: 420px;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--radius-card);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.08);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(0, 0, 0, 0.04)),
+    linear-gradient(90deg, var(--surface-secondary), var(--surface-primary));
+  border: 1px dashed var(--color-border-subtle);
+}
+
 .page-section {
   background: var(--surface-primary);
   border: 1px solid var(--color-border-subtle);

--- a/webapp/js/site_app.js
+++ b/webapp/js/site_app.js
@@ -331,10 +331,28 @@ function buildHeroSection(block) {
 
   const visual = document.createElement('div');
   visual.className = 'page-hero__visual';
-  const img = document.createElement('img');
-  img.alt = block?.title || 'Hero';
-  img.src = block?.imageUrl || '/static/img/home-placeholder.svg';
-  visual.appendChild(img);
+
+  const createPlaceholder = () => {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'page-hero__placeholder';
+    placeholder.setAttribute('aria-hidden', 'true');
+    return placeholder;
+  };
+
+  if (block?.imageUrl) {
+    const img = document.createElement('img');
+    img.alt = block?.title || 'Hero';
+    img.src = block.imageUrl;
+    img.onerror = () => {
+      img.remove();
+      if (!visual.querySelector('.page-hero__placeholder')) {
+        visual.appendChild(createPlaceholder());
+      }
+    };
+    visual.appendChild(img);
+  } else {
+    visual.appendChild(createPlaceholder());
+  }
 
   section.append(content, visual);
   return section;


### PR DESCRIPTION
## Summary
- render the hero block without relying on the missing `/static/img/home-placeholder.svg` asset
- add inline placeholder and image error handling so missing or broken hero images do not block rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69503fbcabd0832685cae230a1492855)