### PR TITLE
Fix storefront home config handling

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -24,7 +24,7 @@
   <div class="header-actions">
     <div class="template-switcher">
       <span class="muted">Шаблон</span>
-      <div class="template-name" id="template-name">Services</div>
+      <div class="template-name" id="template-name">—</div>
     </div>
     <button class="menu-toggle" aria-label="Открыть меню">☰</button>
   </div>


### PR DESCRIPTION
## Summary
- apply storefront template and blocks from the `/api/site/home` response instead of relying on hardcoded defaults
- expand the home debug overlay with applied template id and clearer block diagnostics, plus remove default template label
- keep rendering resilient with safe fallbacks when loading configuration fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695048b21e2c832696abdcc32b1269f8)