### PR TITLE
Add AdminSite diagnostics and version reporting

### DIFF
--- a/admin_panel/adminsite/static/adminsite/apiClient.js
+++ b/admin_panel/adminsite/static/adminsite/apiClient.js
@@ -28,6 +28,10 @@ function parseErrorDetail(detail) {
     if (!detail) return 'Ошибка запроса';
     if (typeof detail === 'string') return detail;
 
+    if (detail.error_id) {
+        return `${detail.detail || detail.message || 'Internal Error'} (error_id: ${detail.error_id})`;
+    }
+
     if (detail.detail) {
         const validation = parseValidationErrors(detail.detail);
         return validation || parseErrorDetail(detail.detail);
@@ -64,6 +68,9 @@ export async function apiRequest(url, options = {}) {
         const error = new Error(message);
         error.status = response.status;
         error.body = responseText;
+        if (payload?.error_id) {
+            error.errorId = payload.error_id;
+        }
         throw error;
     }
 

--- a/services/adminsite_pages.py
+++ b/services/adminsite_pages.py
@@ -59,15 +59,19 @@ def _serialize(page: AdminSitePage | None, slug: str = DEFAULT_SLUG) -> dict[str
         payload["updatedAt"] = payload["version"]
         payload["slug"] = slug
 
+    payload["key"] = slug
+
     return payload
 
 
-def get_page(slug: str = DEFAULT_SLUG) -> dict[str, Any]:
+def get_page(slug: str = DEFAULT_SLUG, *, raise_on_error: bool = False) -> dict[str, Any]:
     try:
         with get_session() as session:
             return _get_page(session, slug)
     except Exception:
         safe_slug = slug or DEFAULT_SLUG
+        if raise_on_error:
+            raise
         logger.exception("Failed to load AdminSite page %s, returning minimal state", safe_slug)
         return _serialize(None, safe_slug)
 


### PR DESCRIPTION
## Summary
- add a public /api/version endpoint and attach build metadata headers to responses
- wrap AdminSite page fetches with error_id logging, default home recovery, and a new debug diagnostics endpoint
- surface backend error identifiers in the AdminSite constructor UI for easier troubleshooting

## Testing
- python -m compileall admin_panel services webapi.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951725a6c9c8326955ba3d9c961a5be)