### PR TITLE
Fix style preset schema to allow boolean cardBorder

### DIFF
--- a/admin_panel/adminsite/schemas.py
+++ b/admin_panel/adminsite/schemas.py
@@ -161,11 +161,29 @@ class ThemeApplyPayload(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class StylePreset(BaseModel):
+    card_border: bool | str | None = Field(default=None, alias="cardBorder")
+    button_style: str | None = Field(default=None, alias="buttonStyle")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("card_border", mode="before")
+    @classmethod
+    def parse_card_border(cls, value: object) -> object:
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1"}:
+                return True
+            if normalized in {"false", "0"}:
+                return False
+        return value
+
+
 class ThemeApplyResponse(BaseModel):
     applied_template_id: str = Field(alias="appliedTemplateId")
     timestamp: int
     updated_at: str = Field(alias="updatedAt")
     css_vars: dict[str, str] = Field(default_factory=dict, alias="cssVars")
-    style_preset: dict[str, str] | None = Field(default=None, alias="stylePreset")
+    style_preset: StylePreset | None = Field(default=None, alias="stylePreset")
 
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
## Summary
- adjust admin site theme apply response schema to use a typed style preset that accepts boolean cardBorder values and normalizes string booleans
- align page theme configuration schema with the typed style preset model for consistent validation of style presets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518067a6248326bcb8c359dfdc6b37)