### PR TITLE
Persist theme selection and add categories navigation

### DIFF
--- a/admin_panel/adminsite/static/adminsite/constructor.js
+++ b/admin_panel/adminsite/static/adminsite/constructor.js
@@ -1216,7 +1216,7 @@ function setHomepageVersion(version) {
 function openHomepagePreview(event) {
     if (event) event.preventDefault();
     const cacheBust = Date.now().toString();
-    const previewUrl = `/?debug=1&t=${cacheBust}`;
+    const previewUrl = `/?debug=1&_=${cacheBust}`;
     if (homepagePreviewLink) homepagePreviewLink.href = previewUrl;
     window.open(previewUrl, '_blank', 'noopener');
 }
@@ -1890,6 +1890,7 @@ async function saveHomepageConfig() {
         setHomepageStatus('Сохранено и доступно');
         showToast('Страница обновлена');
         console.debug('[AdminSite constructor] Страница сохранена', homepageLoadedConfig);
+        openHomepagePreview();
     } catch (error) {
         console.error('[AdminSite constructor] Сохранение страницы не удалось', error);
         const message = formatErrorMessage(error, 'Не удалось сохранить страницу');

--- a/services/theme_service.py
+++ b/services/theme_service.py
@@ -115,6 +115,8 @@ def _persist_theme_state(template: ThemeTemplate, theme_state: dict[str, Any]) -
         }
         page.updated_at = datetime.utcnow()
         session.add(page)
+        session.commit()
+        session.refresh(page)
 
 
 def _build_theme_state(template: ThemeTemplate, *, existing: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -3331,6 +3331,81 @@ body.page-index .pill:nth-child(2) {
   gap: 22px;
 }
 
+.site-panel {
+  background: var(--surface-primary, var(--card-bg));
+  border: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.06));
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.05);
+  border-radius: var(--radius-card, 16px);
+  padding: 18px 16px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.panel-header h2 {
+  margin: 4px 0 0;
+}
+
+.categories-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.category-card {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  background: var(--surface-secondary, rgba(255, 255, 255, 0.7));
+  border: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.05));
+  border-radius: var(--radius-tile, 20px);
+  padding: 12px 14px;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.04);
+  text-decoration: none;
+  color: var(--color-text-main);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.category-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.08);
+}
+
+.category-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.28), rgba(0, 0, 0, 0.04));
+  border: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.06));
+  font-weight: 700;
+  color: var(--color-text-main);
+}
+
+.category-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.debug-strip {
+  margin: 12px 0;
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px dashed var(--color-border-subtle, rgba(0, 0, 0, 0.1));
+  border-radius: 10px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
 .page-hero {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -33,13 +33,25 @@
   </nav>
 </header>
 
-<div class="app-sidebar-overlay"></div>
-<div id="toast-container"></div>
+  <div class="app-sidebar-overlay"></div>
+  <div id="toast-container"></div>
 
-<main class="site-main">
-  <section id="view-home" class="site-view">
-    <div id="home-blocks" class="page-blocks"></div>
-  </section>
+  <main class="site-main">
+    <section id="view-home" class="site-view">
+      <section id="home-categories" class="site-panel" hidden>
+        <div class="panel-header">
+          <div>
+            <p class="muted">Категории</p>
+            <h2>Навигация по разделам</h2>
+          </div>
+          <button id="categories-refresh" class="btn secondary" type="button">Обновить</button>
+        </div>
+        <div id="categories-grid" class="categories-grid"></div>
+      </section>
+
+      <div id="debug-strip" class="debug-strip" hidden></div>
+      <div id="home-blocks" class="page-blocks"></div>
+    </section>
 
   <section id="view-category" class="site-view" hidden>
     <div class="breadcrumbs" id="category-breadcrumbs"></div>


### PR DESCRIPTION
## Summary
- persist applied theme to the stored home page so `/api/site/home` returns the selected template
- load and surface site theme and debug info from the home API with a categories grid for navigation
- update AdminSite preview button to open the showcase with a cache-busting parameter after saving

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951859ed62083269197be38e94acfc5)