### PR TITLE
Create portfolio-style home layout and preset

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,6 +3,7 @@ MiniDeN — Telegram-бот и веб-магазин
 
 Changelog / История изменений
 -----------------------------
+- 2026-02-10: Главная витрина перешла на портфолио-пресет: hero с CTA-кнопками, карточки разделов и соцсети по умолчанию. Блок категорий выводится только если добавить блок `categories` в конструкторе AdminSite.
 - 2026-02-06: Global audit витрины/AdminSite. /api/site/home теперь возвращает templateId/version/updatedAt + blocksCount/blockTypes для диагностики; витрина читает конфиг только из API с защитой рендера (try/catch по блокам) и debug-оверлеем (?debug=1) со статусом запроса; кнопка «Предпросмотр» в AdminSite открывает витрину с cache-bust параметром и debug-флагом; placeholder вынесен в data URI, каталог static/uploads создаётся при старте.
 - 2025-12-07: Исправлен SyntaxError в `services/products.py` (незакрытые скобки вокруг запроса категорий), из-за которого падал запуск `miniden-api`. Проверка: `python -m py_compile services/products.py`.
 - 2025-12-01: Fix AdminSite static + unify nginx deploy config. Исправлено монтирование `/static` в FastAPI (ошибка `url_for('static', ...)` больше не возникает), шаблоны AdminSite теперь ссылаются на конструктор через `url_for`, а единственным источником nginx-конфига остаётся `deploy/nginx/miniden.conf`, который копируется из `deploy.sh` в `/etc/nginx/sites-available/miniden.conf` и линкуется в `sites-enabled`. Проверка: `curl -I http://127.0.0.1:8000/static/adminsite/base.css`, `curl -I http://127.0.0.1:8000/static/adminsite/constructor.js`, открытие https://miniden.ru/adminsite/ и https://miniden.ru/adminsite/constructor/ (CSS/JS должны быть 200 и с корректным Content-Type).
@@ -29,6 +30,11 @@ Smoke test
 2. Создать товар «Корзинка вязаная», выбрать категорию «Корзинки», ввести цену (например, 750) и сохранить.
 3. Открыть `/c/korzinki` из колонки «Страница» в конструкторе.
 4. Убедиться, что товар отображается в списке категории (если категорий пусто — выводится «В этой категории пока нет товаров»).
+
+Главная витрина (home)
+----------------------
+- В конструкторе AdminSite добавлена кнопка «Портфолио-пресет» — она заполняет главную hero-блоком с CTA, карточками разделов и соцсетями. Все тексты и ссылки редактируются через блоки.
+- Категории на главной отображаются только через блок `categories`: добавьте этот блок в списке блоков, если нужна сетка разделов; без него рендерятся только сохранённые блоки.
 
 Правило: legacy `webapp/admin.html` не редактируем; для каталога/витрины используем AdminSite (constructor + /c/:slug).
 

--- a/admin_panel/adminsite/templates/constructor.html
+++ b/admin_panel/adminsite/templates/constructor.html
@@ -156,9 +156,10 @@
                 <h4 style="margin:0;">Блоки страницы</h4>
                 <div class="actions" style="margin:0;">
                     <button class="btn-secondary" type="button" id="homepage-add-block">+ Добавить блок</button>
-                        <button class="btn-ghost" type="button" id="homepage-reset">Сбросить</button>
-                    </div>
+                    <button class="btn-primary" type="button" id="homepage-preset">Портфолио-пресет</button>
+                    <button class="btn-ghost" type="button" id="homepage-reset">Сбросить</button>
                 </div>
+            </div>
                 <p class="muted" style="margin-top:4px;">Перетащите блоки вверх/вниз или редактируйте содержимое справа.</p>
                 <div id="homepage-blocks-list" class="block-list"></div>
                 <div class="developer-toggle">

--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -144,7 +144,14 @@ body {
   background: var(--color-bg);
   color: var(--color-text-main);
   min-height: 100vh;
-  padding: 0 18px 48px;
+  padding: 0 0 48px;
+}
+
+.layout-shell {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 18px;
 }
 
 a {
@@ -192,13 +199,15 @@ a:hover {
   z-index: 1100;
   background: var(--nav-surface);
   backdrop-filter: blur(14px);
-  border: 1px solid var(--nav-border);
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.06);
+  border-bottom: 1px solid var(--nav-border);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.06);
+  padding: 10px 0;
+}
+
+.top-nav__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 12px;
-  margin: 0 -18px;
   gap: 12px;
 }
 
@@ -320,16 +329,25 @@ a:hover {
 }
 
 .app-sidebar {
-  position: static;
-  width: auto;
-  height: auto;
-  padding: 0;
-  background: transparent;
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(360px, 100%);
+  height: 100vh;
+  padding: 20px 18px;
+  background: var(--surface-primary, #fff);
   display: flex;
   flex-direction: column;
   gap: 8px;
-  transform: none;
-  box-shadow: none;
+  transform: translateX(110%);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.2);
+  border-left: 1px solid var(--color-border-subtle);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  overflow-y: auto;
+}
+
+.app-sidebar.open {
+  transform: translateX(0);
 }
 
 .sidebar-brand {
@@ -363,6 +381,30 @@ a:hover {
   font-size: 13px;
 }
 
+.sidebar-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding-bottom: 8px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.brand--inline {
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
+.menu-close {
+  background: transparent;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-button);
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
 .app-sidebar a {
   color: var(--color-text-muted);
   text-decoration: none;
@@ -391,25 +433,35 @@ a:hover {
 }
 
 .app-sidebar-overlay {
-  display: none;
+  display: block;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.app-sidebar-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .menu-toggle {
   display: inline-flex;
-  background: transparent;
+  background: var(--surface-primary);
   border: 1px solid var(--color-border-subtle);
   color: var(--color-text-main);
-  border-radius: 14px;
-  padding: 10px 12px;
+  border-radius: var(--radius-button);
+  padding: 8px 14px;
   cursor: pointer;
-  background: var(--tile-gradient);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.06);
 }
 
 main {
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: 28px 18px 80px;
+  max-width: none;
+  margin: 0;
+  padding: 28px 0 80px;
 }
 
 .hero {
@@ -3358,6 +3410,19 @@ body.page-index .pill:nth-child(2) {
   gap: 12px;
 }
 
+.categories-grid--cards {
+  gap: 16px;
+}
+
+.categories-grid--cards .category-card {
+  padding: 14px 16px;
+}
+
+.categories-grid--cards .category-icon {
+  width: 42px;
+  height: 42px;
+}
+
 .category-card {
   display: flex;
   gap: 12px;
@@ -3410,8 +3475,9 @@ body.page-index .pill:nth-child(2) {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   align-items: center;
-  gap: 18px;
-  padding: 20px;
+  gap: 22px;
+  padding: 24px;
+  max-height: 520px;
   border-radius: calc(var(--radius-card) + 6px);
   border: 1px solid var(--color-border-subtle);
   background: var(--surface-primary);
@@ -3421,12 +3487,18 @@ body.page-index .pill:nth-child(2) {
 .page-hero__content {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 14px;
+}
+
+.page-hero__visual {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .page-hero__visual img {
   width: 100%;
   max-width: 420px;
+  max-height: 360px;
   border-radius: var(--radius-card);
   box-shadow: 0 16px 38px rgba(0, 0, 0, 0.08);
 }
@@ -3434,6 +3506,7 @@ body.page-index .pill:nth-child(2) {
 .page-hero__placeholder {
   width: 100%;
   max-width: 420px;
+  max-height: 360px;
   aspect-ratio: 4 / 3;
   border-radius: var(--radius-card);
   box-shadow: 0 16px 38px rgba(0, 0, 0, 0.08);
@@ -3442,18 +3515,31 @@ body.page-index .pill:nth-child(2) {
   border: 1px dashed var(--color-border-subtle);
 }
 
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.hero-actions .btn {
+  min-width: 140px;
+  justify-content: center;
+}
+
 .page-section {
   background: var(--surface-primary);
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-card);
-  padding: 18px;
+  padding: 20px;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.06);
 }
 
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(var(--columns, 2), minmax(0, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(var(--columns, 2), minmax(220px, 1fr));
+  gap: 18px;
+  align-items: stretch;
 }
 
 .page-card {
@@ -3464,11 +3550,13 @@ body.page-index .pill:nth-child(2) {
   display: flex;
   flex-direction: column;
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.05);
+  height: 100%;
 }
 
 .page-card__image {
   width: 100%;
-  height: 180px;
+  height: 160px;
+  background: var(--tile-gradient);
   object-fit: cover;
 }
 
@@ -3476,13 +3564,14 @@ body.page-index .pill:nth-child(2) {
   padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+  flex: 1;
 }
 
 .social-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 10px;
+  gap: 12px;
 }
 
 .social-chip {

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -12,31 +12,44 @@
 </head>
 <body class="site-app">
 <header class="top-nav">
-  <div class="brand">
-    <div class="brand__logo-wrapper brand__logo-placeholder" aria-hidden="true"></div>
-    <div class="brand__text">
-      <div class="brand__title">MiniDeN</div>
-      <span class="muted">конструктор витрины</span>
+  <div class="layout-shell top-nav__inner">
+    <div class="brand">
+      <div class="brand__logo-wrapper brand__logo-placeholder" aria-hidden="true"></div>
+      <div class="brand__text">
+        <div class="brand__title">MiniDeN</div>
+        <span class="muted">конструктор витрины</span>
+      </div>
+    </div>
+    <div class="header-actions">
+      <div class="template-switcher">
+        <span class="muted">Шаблон</span>
+        <div class="template-name" id="template-name">—</div>
+      </div>
+      <button class="menu-toggle" aria-label="Открыть меню">Меню</button>
     </div>
   </div>
-  <div class="header-actions">
-    <div class="template-switcher">
-      <span class="muted">Шаблон</span>
-      <div class="template-name" id="template-name">—</div>
-    </div>
-    <button class="menu-toggle" aria-label="Открыть меню">☰</button>
-  </div>
-  <nav class="nav-links app-sidebar" id="nav-links">
-    <a href="/" data-router-link class="active">Главная</a>
-    <div class="nav-divider"></div>
-    <div id="nav-menu"></div>
-  </nav>
 </header>
 
-  <div class="app-sidebar-overlay"></div>
-  <div id="toast-container"></div>
+<nav class="nav-links app-sidebar" id="nav-links">
+  <div class="sidebar-head">
+    <div class="brand brand--inline">
+      <div class="brand__logo-wrapper brand__logo-placeholder" aria-hidden="true"></div>
+      <div class="brand__text">
+        <div class="brand__title">MiniDeN</div>
+        <span class="muted">конструктор витрины</span>
+      </div>
+    </div>
+    <button class="menu-close" aria-label="Закрыть меню">✕</button>
+  </div>
+  <a href="/" data-router-link class="active">Главная</a>
+  <div class="nav-divider"></div>
+  <div id="nav-menu"></div>
+</nav>
 
-  <main class="site-main">
+<div class="app-sidebar-overlay"></div>
+<div id="toast-container"></div>
+
+  <main class="site-main layout-shell">
     <section id="view-home" class="site-view">
       <section id="home-categories" class="site-panel" hidden>
         <div class="panel-header">


### PR DESCRIPTION
## Summary
- redesign the home renderer to rely on configured blocks, rendering categories only when a `categories` block is present
- add a portfolio preset in AdminSite with hero CTA buttons, cards, socials, and support for editing hero buttons and category blocks
- compact the site header, containerize the layout, and polish hero/card/social styles for the portfolio look

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518a1c682483269db49a5ba0da4f7c)