### PR TITLE
Stop auto-rendering categories on home page

### DIFF
--- a/admin_panel/adminsite/templates/constructor.html
+++ b/admin_panel/adminsite/templates/constructor.html
@@ -156,7 +156,7 @@
                 <h4 style="margin:0;">Блоки страницы</h4>
                 <div class="actions" style="margin:0;">
                     <button class="btn-secondary" type="button" id="homepage-add-block">+ Добавить блок</button>
-                    <button class="btn-primary" type="button" id="homepage-preset">Портфолио-пресет</button>
+                    <button class="btn-primary" type="button" id="homepage-preset">Сделать главную портфолио</button>
                     <button class="btn-ghost" type="button" id="homepage-reset">Сбросить</button>
                 </div>
             </div>

--- a/webapp/css/theme.base.css
+++ b/webapp/css/theme.base.css
@@ -160,7 +160,7 @@ a:hover {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 12px;
+  padding: 10px 12px;
   margin: 0 -18px;
   gap: 12px;
 }
@@ -171,15 +171,15 @@ a:hover {
   gap: 10px;
   font-weight: 800;
   letter-spacing: -0.02em;
-  padding: 8px 12px;
+  padding: 6px 10px;
   border-radius: 14px;
   background: var(--tile-gradient);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
 }
 
 .brand__logo-wrapper {
-  width: 52px;
-  height: 52px;
+  width: 44px;
+  height: 44px;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.14);
   border: 1px solid var(--color-border-subtle);
@@ -280,6 +280,11 @@ a:hover {
   flex-direction: column;
   padding: 0 0 8px;
   margin: 0;
+}
+
+body[data-view='home'] #nav-menu,
+body[data-view='home'] .nav-divider {
+  display: none;
 }
 
 .app-sidebar {

--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -201,7 +201,7 @@ a:hover {
   backdrop-filter: blur(14px);
   border-bottom: 1px solid var(--nav-border);
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.06);
-  padding: 10px 0;
+  padding: 8px 0;
 }
 
 .top-nav__inner {
@@ -217,15 +217,15 @@ a:hover {
   gap: 10px;
   font-weight: 800;
   letter-spacing: -0.02em;
-  padding: 8px 12px;
+  padding: 6px 10px;
   border-radius: 14px;
   background: var(--tile-gradient);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
 }
 
 .brand__logo-wrapper {
-  width: 52px;
-  height: 52px;
+  width: 44px;
+  height: 44px;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.14);
   border: 1px solid var(--color-border-subtle);
@@ -326,6 +326,11 @@ a:hover {
   flex-direction: column;
   padding: 0 0 8px;
   margin: 0;
+}
+
+body[data-view='home'] #nav-menu,
+body[data-view='home'] .nav-divider {
+  display: none;
 }
 
 .app-sidebar {

--- a/webapp/js/site_app.js
+++ b/webapp/js/site_app.js
@@ -269,6 +269,7 @@ function showView(name) {
   hideAllViews();
   const target = views[name];
   if (target) target.removeAttribute('hidden');
+  document.body.dataset.view = name || '';
 }
 
 function formatPrice(value) {
@@ -545,32 +546,6 @@ function buildHeroSection(block) {
   return section;
 }
 
-function buildFallbackCards(data) {
-  const cards = [];
-  const categories = [...(data?.product_categories || []), ...(data?.course_categories || [])];
-  categories.slice(0, 3).forEach((category) => {
-    cards.push({
-      title: category?.title || 'Категория',
-      href: category?.url || `/c/${category?.slug || ''}`,
-      icon: 'folder',
-      imageUrl: category?.image_url,
-      description: category?.type === 'course' ? 'Мастер-классы' : 'Каталог',
-    });
-  });
-
-  const featured = [...(data?.featured_products || []), ...(data?.featured_masterclasses || [])];
-  featured.slice(0, 3).forEach((item) => {
-    cards.push({
-      title: item?.title || 'Элемент',
-      href: item?.url || '#',
-      imageUrl: item?.image_url,
-      description: item?.short_text,
-    });
-  });
-
-  return cards;
-}
-
 function buildCard(item) {
   const card = document.createElement('article');
   card.className = 'page-card hover-lift';
@@ -608,7 +583,7 @@ function buildCard(item) {
   return card;
 }
 
-function buildCardsSection(block, data) {
+function buildCardsSection(block) {
   const section = document.createElement('section');
   section.className = 'page-section reveal';
 
@@ -633,11 +608,12 @@ function buildCardsSection(block, data) {
   grid.className = 'cards-grid';
   grid.style.setProperty('--columns', block?.layout?.columns || 2);
 
-  const items = block?.items?.length ? block.items : buildFallbackCards(data);
+  // Cards render only explicitly configured items to avoid implicit category fallbacks.
+  const items = Array.isArray(block?.items) ? block.items : [];
   if (!items.length) {
     const empty = document.createElement('div');
     empty.className = 'muted';
-    empty.textContent = 'Карточки будут показаны после заполнения конфигурации.';
+    empty.textContent = 'Карточки появятся после добавления элементов в AdminSite.';
     section.appendChild(empty);
   } else {
     items.forEach((item) => grid.appendChild(buildCard(item)));
@@ -775,7 +751,7 @@ function renderHomeBlocks(blocks, data, { categories = [] } = {}) {
         return;
       }
       if (block?.type === 'cards') {
-        homeBlocksContainer.appendChild(buildCardsSection(block, data));
+        homeBlocksContainer.appendChild(buildCardsSection(block));
         return;
       }
       if (block?.type === 'text') {


### PR DESCRIPTION
## Summary
- remove automatic category/card fallbacks so the home page renders only configured blocks
- hide category navigation from the header on the home view and reduce the header height
- rename the AdminSite portfolio preset button for clarity

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695193efff408326b573981b02c2056f)