### PR TITLE
Remove AdminSite webapp button support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -262,8 +262,8 @@ AdminSite Static
 - После замены логотипа или favicon автоматически увеличивается `assets_version`, а ссылки на ресурсы приходят с суффиксом `?v=...`, чтобы сбрасывать кеш в браузерах.
 - Данные брендинга отдаются через публичный endpoint `/api/branding` для WebApp.
 
-AdminSite API (категории, товары/курсы, настройки WebApp)
-----------------------------------------------------------
+AdminSite API (категории и товары/курсы)
+----------------------------------------
 
 Все методы под префиксом `/api/adminsite/*`, требуют авторизации администратора (`superadmin` или `admin_site`). Схемы полностью совместимы с Pydantic v2.
 
@@ -278,19 +278,18 @@ AdminSite API (категории, товары/курсы, настройки W
 
     - `POST /api/adminsite/items`
     - `PUT /api/adminsite/items/{id}`
-    - `DELETE /api/adminsite/items/{id}`
-  - Настройки WebApp (красная кнопка):
-    - `GET /api/adminsite/webapp-settings?type=product|course&category_id=<id>` — отдаёт настройки для категории или глобальные, если категория не настроена.
-    - `PUT /api/adminsite/webapp-settings` — upsert по `scope+type+category_id`.
+  - `DELETE /api/adminsite/items/{id}`
 
-AdminPanel/adminsite: страницы конструктора
+- Функционал WebApp-кнопки удалён: эндпоинты `/api/adminsite/webapp-settings` больше не доступны, связанные настройки больше не блокируют удаление категорий, таблица `adminsite_webapp_settings` удаляется при инициализации БД, вкладка WebApp в конструкторе скрыта.
+
+- AdminPanel/adminsite: страницы конструктора
 -------------------------------------------
-- Маршрут `/adminsite/constructor` открывает новый раздел "AdminSite Конструктор" с вкладками для CRUD категорий и элементов, а также настройки красной WebApp-кнопки.
-- Шаблон: `admin_panel/adminsite/templates/constructor.html` (вкладки, таблицы, форма WebApp).
+- Маршрут `/adminsite/constructor` открывает раздел "AdminSite Конструктор" с вкладками для CRUD категорий и элементов.
+- Шаблон: `admin_panel/adminsite/templates/constructor.html` (вкладки, таблицы и формы для категорий/элементов).
 - Статические модули:
   - `admin_panel/adminsite/static/adminsite/apiClient.js` — обёртка над fetch с разбором ошибок.
   - `admin_panel/adminsite/static/adminsite/modals.js` — компоненты CategoryModal и ItemModal с блокировкой кнопок на время сохранения.
-  - `admin_panel/adminsite/static/adminsite/constructor.js` — логика страниц: загрузка данных, фильтры, поиск по названию, CRUD и настройка WebApp.
+  - `admin_panel/adminsite/static/adminsite/constructor.js` — логика страниц: загрузка данных, фильтры, поиск по названию и CRUD.
   - `admin_panel/adminsite/static/adminsite/constructor.css` — стили карточек, таблиц, модалок и тостов.
   - URL для загрузки конструкторских статик-ресурсов: `/static/adminsite/constructor.js` и `/static/adminsite/constructor.css`.
 - Новые кнопки навигации на страницах админки ведут в раздел "AdminSite Конструктор".
@@ -309,11 +308,6 @@ curl -H "Cookie: admin_session=<cookie>" \
   -H "Content-Type: application/json" \
   -d '{"type":"product","category_id":1,"title":"Бокал","price":990}' \
   http://127.0.0.1:8000/api/adminsite/items
-
-curl -H "Cookie: admin_session=<cookie>" \
-  -H "Content-Type: application/json" \
-  -d '{"scope":"global","type":"product","action_label":"Купить","min_selected":1}' \
-  http://127.0.0.1:8000/api/adminsite/webapp-settings
 ```
 
 ### Система отзывов

--- a/admin_panel/adminsite/API_TESTS.md
+++ b/admin_panel/adminsite/API_TESTS.md
@@ -84,26 +84,3 @@ curl -X PUT -H "Content-Type: application/json" \
 curl -X DELETE -b "admin_session=<token>" http://localhost:8000/api/adminsite/items/1
 ```
 
-## Настройки WebApp
-
-Получить настройки (вернёт категорию, если есть, иначе global):
-
-```bash
-curl -b "admin_session=<token>" "http://localhost:8000/api/adminsite/webapp-settings?type=product&category_id=1"
-```
-
-Upsert настроек:
-
-```bash
-curl -X PUT -H "Content-Type: application/json" \
-  -b "admin_session=<token>" \
-  -d '{
-    "scope": "category",
-    "type": "product",
-    "category_id": 1,
-    "action_enabled": true,
-    "action_label": "Оформить",
-    "min_selected": 1
-  }' \
-  http://localhost:8000/api/adminsite/webapp-settings
-```

--- a/admin_panel/adminsite/router.py
+++ b/admin_panel/adminsite/router.py
@@ -30,8 +30,6 @@ from .schemas import (
     ItemUpdatePayload,
     ThemeApplyPayload,
     ThemeApplyResponse,
-    WebAppSettingsPayload,
-    WebAppSettingsResponse,
 )
 
 TypeQuery = Annotated[str, Query(min_length=1)]
@@ -339,24 +337,3 @@ def delete_item(
     return service.delete_item(db, item_id)
 
 
-@router.get("/webapp-settings", response_model=WebAppSettingsResponse)
-def get_webapp_settings(
-    request: Request,
-    type: TypeQuery,
-    category_id: int | None = Query(None),
-    db: Session = Depends(get_db_session),
-):
-    service.ensure_admin(request, db)
-    settings = service.get_webapp_settings(db, type, category_id)
-    return settings
-
-
-@router.put("/webapp-settings", response_model=WebAppSettingsResponse)
-def upsert_webapp_settings(
-    payload: WebAppSettingsPayload,
-    request: Request,
-    db: Session = Depends(get_db_session),
-):
-    service.ensure_admin(request, db)
-    settings = service.upsert_webapp_settings(db, payload)
-    return settings

--- a/admin_panel/adminsite/schemas.py
+++ b/admin_panel/adminsite/schemas.py
@@ -4,14 +4,9 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Literal
 
-from datetime import datetime
-from decimal import Decimal
-from typing import Literal
-
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 TypeLiteral = str
-ScopeLiteral = Literal["global", "category"]
 SlugPattern = r"^[a-z0-9]+(?:-[a-z0-9]+)*$"
 
 
@@ -130,38 +125,6 @@ class ItemResponse(BaseModel):
     is_active: bool
     sort: int
     created_at: datetime
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-class WebAppSettingsPayload(BaseModel):
-    scope: ScopeLiteral
-    type: TypeLiteral
-    category_id: int | None = None
-    action_enabled: bool = True
-    action_label: str | None = "Оформить"
-    min_selected: int = Field(1, ge=0)
-
-    @field_validator("category_id")
-    def _validate_category_scope(
-        cls, value: int | None, info: ValidationInfo
-    ) -> int | None:
-        scope = (info.data or {}).get("scope")
-        if scope == "category" and value is None:
-            raise ValueError("category_id is required when scope=category")
-        if scope == "global" and value is not None:
-            raise ValueError("category_id must be null when scope=global")
-        return value
-
-
-class WebAppSettingsResponse(BaseModel):
-    id: int
-    scope: ScopeLiteral
-    type: TypeLiteral
-    category_id: int | None
-    action_enabled: bool
-    action_label: str | None
-    min_selected: int
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/admin_panel/adminsite/templates/constructor.html
+++ b/admin_panel/adminsite/templates/constructor.html
@@ -7,15 +7,14 @@
 <div id="constructor-status-bar"></div>
 <div class="page-actions" style="justify-content: space-between; align-items:flex-start; gap:16px;">
     <div>
-        <h1>Категории, элементы и WebApp кнопка</h1>
-        <p class="muted">Управляйте категориями и элементами витрины. Используйте вкладку «WebApp кнопка», чтобы настроить действие красной кнопки.</p>
+        <h1>Категории и элементы</h1>
+        <p class="muted">Управляйте категориями и элементами витрины через единый конструктор.</p>
     </div>
     <div class="notice" style="max-width: 360px;">
         <div class="badge-list">
             <span class="tag">Категории</span>
             <span class="tag">Товары</span>
             <span class="tag">Мастер-классы</span>
-            <span class="tag">WebApp</span>
         </div>
         <p style="margin-top:10px;">Все изменения сохраняются через API AdminSite без перезагрузки страницы.</p>
     </div>
@@ -26,70 +25,6 @@
 <div class="tabs" id="constructor-tabs"></div>
 
 <div id="constructor-panels"></div>
-
-<section class="panel" id="panel-webapp">
-    <div class="card">
-        <div class="table-top">
-            <div>
-                <h3 style="margin:0;">WebApp кнопка</h3>
-                <p class="muted">Настройка действия красной кнопки WebApp.</p>
-            </div>
-            <div class="badge-list">
-                <span class="tag">action_label</span>
-                <span class="tag">scope</span>
-                <span class="tag">type</span>
-            </div>
-        </div>
-        <div class="status" id="status-webapp"></div>
-        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:14px;">
-            <div class="card" style="padding:14px;">
-                <form id="webapp-form">
-                    <label>Текст кнопки
-                        <input type="text" name="action_label" id="webapp-label" placeholder="Например, Открыть витрину" required />
-                    </label>
-                    <label>Scope
-                        <select name="scope" id="webapp-scope">
-                            <option value="global">global</option>
-                            <option value="category">category</option>
-                        </select>
-                    </label>
-                    <div class="form-row">
-                        <label>Type
-                            <select name="type" id="webapp-type">
-                                <option value="product">product — витрина товаров</option>
-                                <option value="course">course — витрина мастер-классов</option>
-                            </select>
-                        </label>
-                        <label id="webapp-category-wrapper">Category
-                            <select name="category_id" id="webapp-category"></select>
-                        </label>
-                    </div>
-                    <div class="form-row">
-                        <div>
-                            <label>Минимум выбранных
-                                <input type="number" name="min_selected" id="webapp-min-selected" min="0" value="1" />
-                            </label>
-                        </div>
-                        <div style="display:flex; align-items:center; gap:8px; margin-top:26px;">
-                            <input type="checkbox" id="webapp-enabled" />
-                            <label for="webapp-enabled" class="muted">action_enabled</label>
-                        </div>
-                    </div>
-                    <div class="actions" style="margin-top:18px; gap:8px;">
-                        <button class="btn-secondary" id="webapp-reload" type="button">Обновить</button>
-                        <button class="btn-primary" type="submit">Сохранить</button>
-                    </div>
-                </form>
-            </div>
-            <div class="card" style="padding:14px;">
-                <h4 style="margin-top:0;">Подсказки</h4>
-                <p class="muted">Тип действия и категория влияют на то, что откроется по кнопке. Если категория не указана, используется корневая страница витрины.</p>
-                <div class="divider"></div>
-                <p class="muted">Флаг <b>action_enabled</b> отключает кнопку без удаления настроек.</p>
-            </div>
-        </div>
-    </div>
-</section>
 
 <section class="panel" id="panel-homepage">
     <div class="card">

--- a/admin_panel/adminsite/templates/dashboard.html
+++ b/admin_panel/adminsite/templates/dashboard.html
@@ -4,7 +4,7 @@
 <div class="hero">
     <div class="card">
         <h1 style="margin-bottom:6px;">AdminSite</h1>
-        <p class="muted">Управляйте витриной, категориями и WebApp-кнопкой. Интерфейс повторяет подход AdminBot: единый хедер, меню и карточки.</p>
+        <p class="muted">Управляйте витриной: категории и товары/мастер-классы. Интерфейс повторяет подход AdminBot: единый хедер, меню и карточки.</p>
         <div class="page-actions" style="margin-top:12px;">
             <a class="btn-primary" href="/adminsite/constructor">Перейти в конструктор</a>
             <a class="btn-secondary" href="/adminbot">К админке бота</a>
@@ -40,7 +40,7 @@
                 <tbody>
                 <tr>
                     <td>Конструктор</td>
-                    <td>Категории, товары/мастер-классы и WebApp кнопка.</td>
+                    <td>Категории и товары/мастер-классы.</td>
                     <td><a class="btn-primary" href="/adminsite/constructor">Открыть</a></td>
                 </tr>
                 <tr>

--- a/database.py
+++ b/database.py
@@ -251,6 +251,14 @@ def init_db() -> None:
 
     _ensure_bot_buttons_extensions()
 
+    def _drop_adminsite_webapp_settings() -> None:
+        """Удаление устаревшей таблицы настроек WebApp-кнопки AdminSite."""
+
+        with engine.begin() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS adminsite_webapp_settings"))
+
+    _drop_adminsite_webapp_settings()
+
     def _ensure_bot_runtime_settings() -> None:
         alter_statements = [
             "ALTER TABLE bot_runtime ADD COLUMN IF NOT EXISTS start_node_code VARCHAR(64)",

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -649,47 +649,6 @@ class AdminSiteItem(Base):
     category = relationship("AdminSiteCategory", back_populates="items")
 
 
-class AdminSiteWebAppSettings(Base):
-    __tablename__ = "adminsite_webapp_settings"
-
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    scope = Column(String(32), nullable=False)
-    type = Column(String(32), nullable=False)
-    category_id = Column(
-        Integer, ForeignKey("adminsite_categories.id"), nullable=True
-    )
-    action_enabled = Column(
-        Boolean,
-        nullable=False,
-        default=True,
-        server_default="true",
-    )
-    action_label = Column(Text, nullable=True)
-    min_selected = Column(Integer, nullable=False, default=1, server_default="1")
-
-    __table_args__ = (
-        CheckConstraint(
-            "scope IN ('global', 'category')",
-            name="ck_adminsite_settings_scope",
-        ),
-        CheckConstraint(
-            "type IN ('product', 'course')",
-            name="ck_adminsite_settings_type",
-        ),
-        CheckConstraint(
-            "(scope = 'category' AND category_id IS NOT NULL) OR (scope = 'global' AND category_id IS NULL)",
-            name="ck_adminsite_settings_scope_category",
-        ),
-        Index(
-            "uq_adminsite_webapp_settings_scope_type_category",
-            "scope",
-            "type",
-            func.coalesce(category_id, -1),
-            unique=True,
-        ),
-    )
-
-
 class AdminSitePage(Base):
     __tablename__ = "adminsite_pages"
 
@@ -733,6 +692,5 @@ __all__ = [
     "WebChatMessage",
     "AdminSiteCategory",
     "AdminSiteItem",
-    "AdminSiteWebAppSettings",
     "AdminSitePage",
 ]


### PR DESCRIPTION
## Summary
- remove AdminSite WebApp button settings model, endpoints, and related database table cleanup
- delete WebApp configuration UI/assets from the AdminSite constructor and dashboard
- update documentation and examples to reflect removal and unblock category deletion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b636f7288326aa5ded173eb3769a)