### PR TITLE
Add palette settings endpoint and publishable AdminSite pages

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,6 +3,7 @@ MiniDeN — Telegram-бот и веб-магазин
 
 Changelog / История изменений
 -----------------------------
+- 2026-05-XX: Палитра витрины хранится в `/api/site-settings` (activePalette + cssVars); конструктор AdminSite сохраняет черновик страницы через `PUT /api/adminsite/pages/{pageKey}` и публикует через `POST /api/adminsite/pages/{pageKey}/publish`, а витрина читает опубликованные блоки по `GET /api/site/pages/{pageKey}`. Кнопка «➕» на карточке отображается только при количестве > 0 (stock/quantity/count).
 - 2026-04-XX: Обновление товара допускает `slug=null` — API сохраняет текущий slug в БД и не возвращает 422.
 - 2026-04-XX: Обработчик валидации упаковывает ошибки безопасно (без ValidationInfo в Pydantic v2) и возвращает 422 в формате JSON.
 - 2026-04-XX: /api/adminsite/items стабилизирован: бэкенд логирует ошибки и отдаёт 200 с пустым списком вместо 500, конструктор AdminSite игнорирует некорректный ответ и не падает при пустых данных.
@@ -153,6 +154,20 @@ Production деплой одной командой
 ----------------
 - /adminbot/login
 - /adminsite/login
+
+Обновление палитры и публикации блоков (коротко)
+-----------------------------------------------
+- Настройка палитры: `GET /api/site-settings` → `{ "activePalette": "services", "theme": { cssVars... } }`; смена палитры: `PUT /api/site-settings` с телом `{ "activePalette": "electronics" }` (доступно только администратору AdminSite).
+- Черновик страницы: `GET /api/adminsite/pages/{pageKey}` возвращает `{ draft: {blocks, version}, published: {…} }`; сохранение черновика — `PUT /api/adminsite/pages/{pageKey}` с `{ templateId, blocks }`.
+- Публикация: `POST /api/adminsite/pages/{pageKey}/publish` копирует текущий черновик в опубликованную версию.
+- Публичные блоки: `GET /api/site/pages/{pageKey}` отдаёт только опубликованные блоки (`pageKey`, `templateId`, `version`, `blocks`). Главная (`/api/site/home`) использует те же опубликованные данные.
+- Плюс-кнопка на витрине видна только если `quantity/stock/count > 0`.
+
+Тронутые файлы (ключевые изменения)
+----------------------------------
+- `services/adminsite_pages.py`, `services/adminsite_public.py`, `webapi.py` — единый цикл черновик/публикация + новый `/api/site-settings`.
+- `admin_panel/adminsite/router.py`, `admin_panel/adminsite/static/adminsite/constructor.js`, `admin_panel/adminsite/templates/constructor.html` — конструктор получает черновик и публикует страницу.
+- `webapp/js/site_api.js`, `webapp/js/site_app.js` — витрина берёт палитру из API, рендерит опубликованные блоки; «➕» зависит от количества.
 
 AdminSite UI / шаблоны
 ----------------------

--- a/admin_panel/adminsite/templates/constructor.html
+++ b/admin_panel/adminsite/templates/constructor.html
@@ -67,6 +67,7 @@
             </div>
         <div class="homepage-actions">
             <a class="btn-secondary" href="/?debug=1" target="_blank" rel="noopener" id="homepage-preview">Предпросмотр</a>
+            <button class="btn-primary" type="button" id="homepage-publish">Опубликовать</button>
             <button class="btn-primary" type="button" id="homepage-save">Сохранить</button>
         </div>
     </div>

--- a/services/adminsite_public.py
+++ b/services/adminsite_public.py
@@ -224,7 +224,7 @@ def _extract_page_meta(page: dict[str, Any]) -> dict[str, Any]:
 
 
 def get_home_summary(limit: int = 6) -> dict[str, Any]:
-    page = adminsite_pages.get_page()
+    page = adminsite_pages.get_published_page()
     meta = _extract_page_meta(page)
     theme_meta = theme_service.get_theme_metadata()
     with get_session() as session:
@@ -256,3 +256,7 @@ def get_home_summary(limit: int = 6) -> dict[str, Any]:
         "theme": theme_meta,
         "themeVersion": theme_meta.get("timestamp"),
     }
+
+
+def get_public_page(page_key: str) -> dict[str, Any]:
+    return adminsite_pages.get_published_page(page_key)

--- a/webapp/js/site_api.js
+++ b/webapp/js/site_api.js
@@ -70,6 +70,14 @@ export function fetchHome(limit = 6, version = null, extraParams = {}) {
   return requestWithStatus('/api/site/home', params);
 }
 
+export function fetchPageByKey(pageKey) {
+  return request(`/api/site/pages/${encodeURIComponent(pageKey)}`);
+}
+
+export function fetchSiteSettings() {
+  return request('/api/site-settings');
+}
+
 export function fetchCategories(type = null) {
   return request('/api/site/categories', { type });
 }


### PR DESCRIPTION
## Summary
- add site settings API to expose active palette and apply it across the storefront
- switch AdminSite pages to draft + publish lifecycle and expose published pages publicly
- update storefront and AdminSite UI to respect palettes, render published blocks, and hide the plus button when quantity is zero

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bea79b1883269839fb46f102ead1)