### PR TITLE
Add reply button rendering and unified actions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -905,3 +905,4 @@ Front reset: theme-only + constructor-driven site
 - Removed unused placeholder `admin_panel/static/.keep` to avoid duplicate sentinel files.
 - Documented unified structure, run commands, and deploy expectations.
 - Fixed AdminSite constructor modals so category/product dialogs close on Отмена, Esc, and backdrop clicks without page reloads; touched `admin_panel/adminsite/static/adminsite/modals.js`, verify with the constructor smoke steps.
+- Unified бот-кнопки: у BotButton добавлены поля render/action_payload, поддержка REPLY-кнопок по узлам, новые API `/adminbot/api/buttons`, `/adminbot/api/buttons/save`, `/adminbot/api/buttons/delete`.

--- a/admin_panel/templates/adminbot_button_edit.html
+++ b/admin_panel/templates/adminbot_button_edit.html
@@ -50,6 +50,14 @@
     </select>
     <div class="hint">Callback — действие в боте. Ссылка — открытие в браузере. WebApp — сайт внутри Telegram.</div>
 
+    <label>Отображение</label>
+    <select name="render" id="render_type">
+        {% for value, label in render_types %}
+            <option value="{{ value }}" {% if form_state.render == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+    </select>
+    <div class="hint">INLINE — кнопка под сообщением. REPLY — кнопка под полем ввода, показывает постоянное меню узла.</div>
+
     <div id="callback_block" class="block" style="display:none;">
         <label>Действие</label>
         <select name="callback_action" id="callback_action">
@@ -135,12 +143,12 @@
         <div>
             <label>Ряд</label>
             <input type="number" name="row" value="{{ button.row if button else 0 }}">
-            <div class="hint">0 = первая строка кнопок.</div>
+            <div class="hint">0 = первая строка кнопок. Для REPLY используется раскладка под вводом.</div>
         </div>
         <div>
             <label>Позиция</label>
             <input type="number" name="pos" value="{{ button.pos if button else 0 }}">
-            <div class="hint">0 = первая кнопка в ряду.</div>
+            <div class="hint">0 = первая кнопка в ряду. Работает и для INLINE, и для REPLY.</div>
         </div>
     </div>
 

--- a/admin_panel/templates/adminbot_buttons_list.html
+++ b/admin_panel/templates/adminbot_buttons_list.html
@@ -62,6 +62,7 @@
     <thead>
     <tr>
         <th>Текст кнопки</th>
+        <th>Отображение</th>
         <th>Тип</th>
         <th>Цель / payload</th>
         <th>Строка</th>
@@ -74,6 +75,7 @@
     {% for button in buttons %}
     <tr>
         <td>{{ button.title }}</td>
+        <td>{{ button.render }}</td>
         <td>{{ button.action_type }}</td>
         <td class="muted">{{ button.action_value }}</td>
         <td>{{ button.row }}</td>

--- a/database.py
+++ b/database.py
@@ -136,6 +136,7 @@ def init_db() -> None:
             "ALTER TABLE bot_nodes ADD COLUMN IF NOT EXISTS config_json JSONB",
             "ALTER TABLE bot_nodes ADD COLUMN IF NOT EXISTS clear_chat BOOLEAN NOT NULL DEFAULT FALSE",
             "ALTER TABLE user_state ADD COLUMN IF NOT EXISTS bot_message_ids JSONB",
+            "ALTER TABLE user_state ADD COLUMN IF NOT EXISTS current_node_code VARCHAR",
         ]
 
         create_user_vars = """
@@ -156,6 +157,7 @@ def init_db() -> None:
         create_user_state = """
         CREATE TABLE IF NOT EXISTS user_state (
             user_id BIGINT PRIMARY KEY,
+            current_node_code VARCHAR NULL,
             waiting_node_code VARCHAR NULL,
             waiting_input_type VARCHAR NULL,
             waiting_var_key VARCHAR NULL,
@@ -221,6 +223,8 @@ def init_db() -> None:
             "ALTER TABLE bot_buttons ADD COLUMN IF NOT EXISTS target_node_code VARCHAR(64)",
             "ALTER TABLE bot_buttons ADD COLUMN IF NOT EXISTS url TEXT",
             "ALTER TABLE bot_buttons ADD COLUMN IF NOT EXISTS webapp_url TEXT",
+            "ALTER TABLE bot_buttons ADD COLUMN IF NOT EXISTS render VARCHAR(16) NOT NULL DEFAULT 'INLINE'",
+            "ALTER TABLE bot_buttons ADD COLUMN IF NOT EXISTS action_payload TEXT",
         ]
 
         with engine.begin() as conn:

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -83,7 +83,9 @@ class BotButton(Base):
     title = Column(Text, nullable=False)
     type = Column(String, nullable=False)
     payload = Column(Text, nullable=False)
+    render = Column(String(16), nullable=False, default="INLINE", server_default="INLINE")
     action_type = Column(String(16), nullable=False, default="NODE", server_default="NODE")
+    action_payload = Column(Text, nullable=True)
     target_node_code = Column(String(64), nullable=True)
     url = Column(Text, nullable=True)
     webapp_url = Column(Text, nullable=True)
@@ -396,6 +398,7 @@ class UserState(Base):
     __tablename__ = "user_state"
 
     user_id = Column(BigInteger, primary_key=True)
+    current_node_code = Column(String, nullable=True)
     waiting_node_code = Column(String, nullable=True)
     waiting_input_type = Column(String, nullable=True)
     waiting_var_key = Column(String, nullable=True)


### PR DESCRIPTION
## Summary
- add render/action payload support for bot buttons and reply menu handling
- update bot runtime to build reply keyboards per node and dispatch actions for inline/reply buttons
- extend admin UI and API to manage inline or reply buttons with layout and unified actions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c28f492883269a69f85116b79174)