### PR TITLE
Handle missing home page fallback and show add-to-cart button

### DIFF
--- a/webapp/js/site_app.js
+++ b/webapp/js/site_app.js
@@ -375,9 +375,7 @@ function buildItemCard(item) {
   more.setAttribute('data-router-link', '');
 
   const canUseTelegram = !!(window.isTelegramWebApp && window.Telegram?.WebApp);
-  const availableStock = Number(item?.quantity ?? item?.stock ?? item?.count ?? 0);
-  const canAddToCart =
-    canUseTelegram && Number.isFinite(availableStock) && availableStock > 0 && item?.id !== undefined;
+  const canAddToCart = canUseTelegram && item?.id !== undefined;
 
   if (canAddToCart) {
     const addButton = document.createElement('button');


### PR DESCRIPTION
## Summary
- ensure the home page summary falls back to a default page when no published version exists
- simplify item card add-to-cart visibility to show the button whenever Telegram WebApp is available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957a047ac0c832688650352c97ef384)