### PR TITLE
Ensure admin deploy endpoints return JSON responses

### DIFF
--- a/admin_panel/templates/adminbot_runtime.html
+++ b/admin_panel/templates/adminbot_runtime.html
@@ -95,10 +95,11 @@
         async function fetchStatus(showToast = true) {
             try {
                 const response = await fetch('/admin/deploy/status');
-                const payload = await response.json();
                 if (!response.ok) {
-                    throw new Error(payload?.detail || 'Не удалось получить статус');
+                    const errorText = await response.text();
+                    throw new Error(errorText || 'Не удалось получить статус');
                 }
+                const payload = await response.json();
                 renderStatus(payload);
                 if (showToast) {
                     alert(`Статус: ${payload.running ? 'идёт' : 'нет'}${payload.pid ? ` (pid ${payload.pid})` : ''}`);
@@ -112,10 +113,12 @@
         async function runDeploy() {
             try {
                 const response = await fetch('/admin/deploy/run', { method: 'POST' });
-                const payload = await response.json();
                 if (!response.ok) {
-                    throw new Error(payload?.detail || 'Не удалось запустить deploy');
+                    const errorText = await response.text();
+                    throw new Error(errorText || 'Не удалось запустить deploy');
                 }
+
+                const payload = await response.json();
 
                 if (payload.status === 'already_running') {
                     alert(`⏳ Deploy уже выполняется (pid ${payload.pid || 'неизвестен'})`);

--- a/webapi.py
+++ b/webapi.py
@@ -420,13 +420,13 @@ def _ensure_deploy_prerequisites() -> None:
 def _ensure_deploy_admin(request: Request, db: Session) -> None:
     user = require_admin(request, db, roles=DEPLOY_ROLES)
     if not user:
-        raise HTTPException(status_code=403, detail="Требуется авторизация администратора")
+        raise HTTPException(status_code=403, detail="Forbidden")
 
 
 deploy_router = APIRouter(prefix="/admin/deploy", tags=["AdminDeploy"])
 
 
-@deploy_router.post("/run")
+@deploy_router.post("/run", response_class=JSONResponse)
 async def run_deploy(request: Request, db: Session = Depends(get_db_session)):
     _ensure_deploy_admin(request, db)
 
@@ -465,7 +465,7 @@ async def run_deploy(request: Request, db: Session = Depends(get_db_session)):
     return {"status": "started", "pid": process.pid}
 
 
-@deploy_router.get("/status")
+@deploy_router.get("/status", response_class=JSONResponse)
 async def deploy_status(request: Request, db: Session = Depends(get_db_session)):
     _ensure_deploy_admin(request, db)
 


### PR DESCRIPTION
## Summary
- ensure admin deploy endpoints return JSON with explicit response classes and consistent 403 errors
- adjust admin deploy UI fetch logic to handle non-OK responses without JSON parse errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580dfa8e7c83268399f0621cdea86e)