### PR TITLE
Configure nginx to proxy admin deploy API

### DIFF
--- a/deploy/nginx/miniden.conf
+++ b/deploy/nginx/miniden.conf
@@ -62,6 +62,17 @@ server {
         proxy_redirect off;
     }
 
+    location /admin/deploy/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_redirect off;
+    }
+
     location ^~ /adminbot/ {
         proxy_pass http://127.0.0.1:8000/adminbot/;
         proxy_redirect off;


### PR DESCRIPTION
## Summary
- add explicit nginx location for /admin/deploy/ to forward requests to the FastAPI backend
- ensure deploy API calls bypass static catch-all responses and return JSON

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580f312fdc8326ada89af9501020eb)