### PR TITLE
Improve Telegram photo reliability and cache file ids

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -927,6 +927,7 @@ Front reset: theme-only + constructor-driven site
 - Documented unified structure, run commands, and deploy expectations.
 - Fixed AdminSite constructor modals so category/product dialogs close on Отмена, Esc, and backdrop clicks without page reloads; touched `admin_panel/adminsite/static/adminsite/modals.js`, verify with the constructor smoke steps.
 - Unified бот-кнопки: у BotButton добавлены поля render/action_payload, поддержка REPLY-кнопок по узлам, новые API `/adminbot/api/buttons`, `/adminbot/api/buttons/save`, `/adminbot/api/buttons/delete`.
+- Устойчивость стартовых фото бота: добавлены ретраи/фолбэки для answer_photo, кэширование file_id после первой загрузки и увеличен HTTP-timeout сессии.
 
 Важно: AdminSite / Версии / Кэш
 - Публичный эндпоинт `/api/site/home` должен отдавать заголовок Cache-Control: no-store (плюс совместимый Pragma: no-cache).

--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,8 @@ from aiogram.exceptions import TelegramNetworkError
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.client.default import DefaultBotProperties  # 👈 ДОБАВИЛИ ЭТОТ ИМПОРТ
-from aiohttp import ClientError
+from aiogram.client.session.aiohttp import AiohttpSession
+from aiohttp import ClientError, ClientTimeout
 from aiohttp.client_exceptions import ServerDisconnectedError
 
 from config import get_settings
@@ -38,9 +39,11 @@ async def main() -> None:
 
     # Инициализация бота
     # В aiogram 3.7.0+ parse_mode нужно передавать через DefaultBotProperties
+    session = AiohttpSession(timeout=ClientTimeout(total=60))
     bot = Bot(
         token=settings.bot_token,
         default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+        session=session,
     )
 
     # FSM-хранилище в памяти (для состояний при оформлении заказа и т.п.)


### PR DESCRIPTION
## Summary
- add retries, backoff, and fallback text responses for Telegram photo sends in the start handler and store banner file_ids for reuse
- persist node image file_ids in the bot configuration cache to avoid repeated uploads and reduce network overhead
- raise the bot HTTP client timeout to 60 seconds for more resilient polling

## Testing
- python -m compileall handlers/start.py bot.py services/bot_config.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958230f64d88326b4da79e491a74f4d)