### PR TITLE
Refine deployment workflow expectations

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -144,8 +144,11 @@ Production деплой одной командой
 --------------------------------
 - Контракт: `deploy/DEPLOY_CONTRACT.md` описывает, что именно обновляет `deploy.sh` и какие каталоги запрещено трогать.
 - Эталонные конфиги для прод-сервера лежат в `deploy/nginx/miniden.conf` и `deploy/systemd/*.service`; скрипт деплоя копирует их в `/etc/nginx/` и `/etc/systemd/system/`.
-- Ожидаемая команда на сервере: `sudo /opt/miniden/deploy.sh` (обновляет код, зависимости, webapp и перезапускает сервисы по контракту).
+- Ожидаемая команда на сервере: `sudo /opt/miniden/deploy.sh` (обновляет код, webapp и перезапускает сервисы по контракту).
+- Перед запуском деплоя администратор сам обновляет зависимости внутри `venv` (например, `source venv/bin/activate && pip install -r requirements.txt`, если менялся `requirements.txt`).
+- Пользователь/группа `miniden` и права на `/opt/miniden` настраиваются заранее (deploy.sh больше не создаёт пользователя и не делает `chown -R`).
 - Защищённые пути (деплой не трогает): `/opt/miniden/.env`, `/opt/miniden/media/`, `/opt/miniden/data/`.
+- Deploy должен выполняться от root (через systemd юнит или `sudo`), чтобы перезаписывать конфиги nginx/systemd и рестартовать сервисы.
 - Быстрый чек после деплоя: `curl http://127.0.0.1:8000/api/health`.
 
 Deploy через systemd (root)

--- a/deploy/DEPLOY_CONTRACT.md
+++ b/deploy/DEPLOY_CONTRACT.md
@@ -13,7 +13,6 @@ sudo /opt/miniden/deploy.sh
 
 ## Что деплой ОБЯЗАН обновлять
 -- git reset --hard origin/<branch> в /opt/miniden
-- зависимости Python (если менялся requirements.txt)
 - webapp -> /opt/miniden/webapp
 - nginx config -> /etc/nginx/sites-available/miniden.conf (+ symlink sites-enabled)
 - systemd units -> /etc/systemd/system/
@@ -34,3 +33,8 @@ sudo /opt/miniden/deploy.sh
 - /opt/miniden/media/
 - /opt/miniden/data/
 - действующий SSL-сертификат (Let’s Encrypt) и /etc/letsencrypt/*.pem
+
+## Предварительные условия (делаются вручную до запуска deploy.sh)
+- Python-зависимости устанавливаются вручную в `venv` (если менялся `requirements.txt`).
+- Системный пользователь/группа `miniden` и права на каталоги `/opt/miniden`, `/opt/miniden/logs`, `/opt/miniden/media`, `/opt/miniden/uploads`, `/opt/miniden/data` подготовлены заранее.
+- deploy.sh запускается от root (systemd юнит или `sudo`), чтобы обновлять конфиги и перезапускать сервисы.


### PR DESCRIPTION
## Summary
- Remove system-user creation and dependency installation from deploy.sh while preserving runtime directories and data
- Make deploy.sh exit explicitly on success and maintain permission creation for logs/media/uploads
- Update deployment docs to note manual dependency installs, pre-created miniden user, root execution, and preserved data

## Testing
- Not run (deployment script changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695824cd2cfc83268d0f941746d0b01c)