### PR TITLE
Make deploy systemd-only

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -143,12 +143,10 @@ ReplyKeyboard-меню из конструктора AdminBot
 Production деплой одной командой
 --------------------------------
 - Контракт: `deploy/DEPLOY_CONTRACT.md` описывает, что именно обновляет `deploy.sh` и какие каталоги запрещено трогать.
-- Эталонные конфиги для прод-сервера лежат в `deploy/nginx/miniden.conf` и `deploy/systemd/*.service`; скрипт деплоя копирует их в `/etc/nginx/` и `/etc/systemd/system/`.
-- Ожидаемая команда на сервере: `sudo /opt/miniden/deploy.sh` (обновляет код, webapp и перезапускает сервисы по контракту).
+- Скрипт `deploy.sh` обновляет git-репозиторий, применяет Alembic-миграции и перезапускает сервисы `miniden-api`/`miniden-bot`. Конфиги nginx/systemd ставятся вручную из `deploy/nginx` и `deploy/systemd`.
+- Ожидаемая команда на сервере: `sudo /opt/miniden/deploy.sh` или `systemctl start miniden-deploy.service` (root). Deploy запускается только через systemd; в боте нет кнопок/команд для деплоя.
 - Перед запуском деплоя администратор сам обновляет зависимости внутри `venv` (например, `source venv/bin/activate && pip install -r requirements.txt`, если менялся `requirements.txt`).
-- Пользователь/группа `miniden` и права на `/opt/miniden` настраиваются заранее (deploy.sh больше не создаёт пользователя и не делает `chown -R`).
 - Защищённые пути (деплой не трогает): `/opt/miniden/.env`, `/opt/miniden/media/`, `/opt/miniden/data/`.
-- Deploy должен выполняться от root (через systemd юнит или `sudo`), чтобы перезаписывать конфиги nginx/systemd и рестартовать сервисы.
 - Быстрый чек после деплоя: `curl http://127.0.0.1:8000/api/health`.
 
 Deploy через systemd (root)
@@ -168,9 +166,9 @@ miniden ALL=(root) NOPASSWD: \
 
 Deploy из AdminSite (страница «Работа бота»)
 -------------------------------------------
-- На странице `/adminbot/runtime` появилась секция «Deploy проекта» с двумя кнопками: «🚀 Запустить Deploy» (POST `/admin/deploy/run`) и «📄 Статус Deploy» (GET `/admin/deploy/status`).
+- На странице `/adminbot/runtime` есть секция «Deploy проекта» с двумя кнопками: «🚀 Запустить Deploy» (POST `/admin/deploy/run`) и «📄 Статус (systemd)» (GET `/admin/deploy/status`).
 - Запуск инициируется командой `systemctl start miniden-deploy.service` от root; система не запрашивает пароль у пользователя `miniden` благодаря sudoers-конфигурации выше.
-- Статус определяется через `systemctl is-active/show miniden-deploy.service` и вывод последних строк `/opt/miniden/logs/deploy.log` (папка `/opt/miniden/logs` должна существовать заранее и быть доступной на чтение сервису API).
+- Статус строится по `systemctl status miniden-deploy.service` без запуска оболочки и без хвостов логов (отображается вывод systemd и PID, если есть).
 - Конечные точки и UI доступны только авторизованным администраторам AdminSite/AdminBot; путь до скрипта зашит в коде и не принимается из запросов.
 
 Почему 405 на curl -I — это нормально
@@ -897,15 +895,14 @@ Front reset: theme-only + constructor-driven site
 - Web front: serve `webapp/` via nginx or any static server (`/css`, `/js`, `/media` mounts needed for uploads/JS/CSS).
 
 ## Deploy notes
-- Single entrypoint: run `sudo /opt/miniden/deploy.sh` on the server to sync code, dependencies, nginx config and systemd units.
-- Nginx copies from `deploy/nginx/miniden.conf` (ensures `/static/adminsite/*` is served as JavaScript/CSS, webapp fallback is `/index.html`).
-- Systemd units: `deploy/systemd/miniden-api.service` and `miniden-bot.service` are installed/reloaded by the script, then restarted sequentially.
-- Protected paths: deploy script keeps existing `.env`, `media/`, `data/`, and runtime `logs/` untouched while updating code.
+- Single entrypoint: run `sudo /opt/miniden/deploy.sh` or `systemctl start miniden-deploy.service` to update code, run Alembic migrations, and restart services.
+- Reference configs live in `deploy/nginx/miniden.conf` and `deploy/systemd/*.service` and are installed manually (deploy.sh больше не копирует их автоматически).
+- Service restarts: `deploy.sh` touches only `miniden-api` и `miniden-bot`, оставляя `.env`, `media/`, `data/` и `logs/` нетронутыми.
 
 ### Deploy из AdminSite
-- Секция «Deploy проекта» на странице `/adminbot/runtime` запускает фиксированный скрипт `/opt/miniden/deploy.sh` (POST `/admin/deploy/run`) и показывает статус (GET `/admin/deploy/status`).
-- Статус сообщает, выполняется ли процесс, какой PID записан в `/opt/miniden/logs/deploy.pid`, и отдаёт хвост `/opt/miniden/logs/deploy.log` (папку `/opt/miniden/logs` нужно создать вручную с правами на запись).
-- Кнопки и эндпоинты доступны только авторизованным администраторам; путь до скрипта зашит в коде и не подменяется из UI или запроса.
+- Секция «Deploy проекта» на странице `/adminbot/runtime` запускает `systemctl start miniden-deploy.service` (POST `/admin/deploy/run`) и показывает вывод `systemctl status` (GET `/admin/deploy/status`).
+- Путь до скрипта/юнита зашит в коде, shell не используется; вывод status отдаётся как есть, без чтения логов и PID-файлов.
+- Кнопки и эндпоинты доступны только авторизованным администраторам.
 
 ## AdminSite/Constructor: Категории → Страницы
 - При создании/обновлении категории товаров или мастер-классов автоматически создаётся страница конструктора (таблица `adminsite_categories`) и `page_id` сохраняется в `product_categories.page_id`.

--- a/admin_panel/templates/adminbot_runtime.html
+++ b/admin_panel/templates/adminbot_runtime.html
@@ -50,14 +50,14 @@
 
 <div class="card" style="margin-top:16px;">
     <h2>Deploy проекта</h2>
-    <p class="muted">Запуск выполняет только серверный скрипт <code>/opt/miniden/deploy.sh</code>. Второй запуск блокируется, если деплой уже идёт.</p>
+    <p class="muted">Deploy запускается только через systemd-юнит <code>miniden-deploy.service</code> (root → <code>/opt/miniden/deploy.sh</code>).</p>
     <div style="display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin-top:8px;">
         <button type="button" id="deploy-run" class="button">🚀 Запустить Deploy</button>
-        <button type="button" id="deploy-status" class="button" style="background:#475569;">📄 Статус Deploy</button>
+        <button type="button" id="deploy-status" class="button" style="background:#475569;">📄 Статус (systemd)</button>
         <span id="deploy-running" class="muted"></span>
     </div>
-    <div id="deploy-meta" class="muted" style="margin-top:8px;">Нажмите «Статус Deploy», чтобы увидеть PID и хвост логов.</div>
-    <pre id="deploy-log" class="log-box" style="margin-top:12px;">Логи ещё не загружены.</pre>
+    <div id="deploy-meta" class="muted" style="margin-top:8px;">Вывод <code>systemctl status miniden-deploy.service</code> появится ниже.</div>
+    <pre id="deploy-log" class="log-box" style="margin-top:12px;">Статус ещё не загружен.</pre>
 </div>
 
 <script>
@@ -83,11 +83,14 @@
         function renderStatus(data) {
             const running = Boolean(data?.running);
             const pidText = data?.pid ? `PID ${data.pid}` : 'PID не найден';
-            runningLabel.textContent = running ? 'Статус: работает' : 'Статус: не запущен';
-            meta.textContent = running ? `Deploy выполняется (${pidText})` : `Deploy не запущен (${pidText})`;
+            const activeState = data?.active_state || 'unknown';
+            const result = data?.result || 'unknown';
+            const statusOutput = data?.status_output || 'Статус systemd недоступен.';
 
-            const lines = Array.isArray(data?.last_lines) ? data.last_lines : [];
-            logBox.textContent = lines.length ? lines.join('\n') : 'Лог пуст или отсутствует.';
+            runningLabel.textContent = running ? 'Статус: выполняется' : 'Статус: не запущен';
+            meta.textContent = `systemd: ${activeState} / ${result} (${pidText})`;
+
+            logBox.textContent = statusOutput;
 
             scheduleRefresh(running);
         }
@@ -123,10 +126,10 @@
                 if (payload.status === 'already_running') {
                     alert(`⏳ Deploy уже выполняется (pid ${payload.pid || 'неизвестен'})`);
                 } else if (payload.status === 'started') {
-                    alert(`✅ Deploy запущен (pid ${payload.pid})`);
+                    alert(`✅ Deploy запущен (pid ${payload.pid || 'неизвестен'})`);
                 }
 
-                fetchStatus(false);
+                renderStatus(payload);
             } catch (error) {
                 scheduleRefresh(false);
                 alert(`Ошибка запуска: ${error?.message || error}`);

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,19 +4,9 @@ trap 'warn "Command failed (exit $?): $BASH_COMMAND"' ERR
 
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV_BIN="$PROJECT_DIR/venv/bin"
-PIP_BIN="$VENV_BIN/pip"
 ALEMBIC_BIN="$VENV_BIN/alembic"
-SERVICE_USER="miniden"
-SERVICE_GROUP="miniden"
 LOG_DIR="$PROJECT_DIR/logs"
 LOG_FILE="$LOG_DIR/deploy.log"
-BACKUP_DIR="$PROJECT_DIR/backups"
-NGINX_SRC="$PROJECT_DIR/deploy/nginx/miniden.conf"
-NGINX_DST="/etc/nginx/sites-available/miniden.conf"
-NGINX_ENABLED_DST="/etc/nginx/sites-enabled/miniden.conf"
-SYSTEMD_SRC_DIR="$PROJECT_DIR/deploy/systemd"
-SYSTEMD_DST_DIR="/etc/systemd/system"
-BACKEND_HEALTH="http://127.0.0.1:8000/api/health"
 
 log() {
   echo "[deploy] $*"
@@ -26,144 +16,25 @@ warn() {
   echo "[deploy][WARN] $*" >&2
 }
 
-ts() {
-  date +%F_%H%M%S
-}
-
-backup_file() {
-  local src="$1"
-  local name="$2"
-  if [ ! -f "$src" ]; then
-    return
-  fi
-
-  local target="$BACKUP_DIR/${name}.$(ts)"
-  mkdir -p "$(dirname "$target")"
-  cp -a "$src" "$target"
-  log "-> Backup saved: $src -> $target"
+setup_logging() {
+  mkdir -p "$LOG_DIR"
+  touch "$LOG_FILE"
+  exec > >(tee -a "$LOG_FILE") 2>&1
 }
 
 fail_with_logs() {
   warn "$1"
-  warn "---- journalctl -u miniden-api.service (last 120 lines) ----"
-  journalctl -u miniden-api.service -n 120 --no-pager || true
-  warn "---- journalctl -u miniden-bot.service (last 120 lines) ----"
-  journalctl -u miniden-bot.service -n 120 --no-pager || true
-  if test -f /var/log/nginx/miniden.error.log; then
-    warn "---- /var/log/nginx/miniden.error.log (last 120 lines) ----"
-    tail -n 120 /var/log/nginx/miniden.error.log || true
-  fi
   exit 1
 }
 
-setup_logging() {
-  mkdir -p "$LOG_DIR"
-  chmod 755 "$LOG_DIR"
-  touch "$LOG_FILE"
-  chmod 664 "$LOG_FILE"
-  mkdir -p "$BACKUP_DIR/nginx" "$BACKUP_DIR/systemd"
-  exec > >(tee -a "$LOG_FILE") 2>&1
-}
-
-check_http_ok() {
-  local url="$1"
-  if ! curl -fsS "$url" > /dev/null; then
-    fail_with_logs "Healthcheck failed: $url"
-  fi
-}
-
-check_head_ok() {
-  local url="$1"
-  if ! curl -fsSI "$url" > /dev/null; then
-    fail_with_logs "Healthcheck (HEAD) failed: $url"
-  fi
-}
-
-ensure_js_content_type() {
-  local url="$1"
-  local headers
-  headers=$(curl -fsSI "$url" | tr -d '\r') || fail_with_logs "Failed to read headers for $url"
-  if echo "$headers" | grep -qi "content-type: text/html"; then
-    fail_with_logs "Unexpected text/html Content-Type for $url"
-  fi
-  if ! echo "$headers" | grep -Eqi "content-type: .*javascript"; then
-    fail_with_logs "Content-Type for $url is not JavaScript: $(echo "$headers" | grep -i 'content-type')"
-  fi
-}
-
-ensure_permissions() {
-  for path in "$PROJECT_DIR/logs" "$PROJECT_DIR/media" "$PROJECT_DIR/uploads"; do
-    install -d -m 775 -o "$SERVICE_USER" -g "$SERVICE_GROUP" "$path"
-  done
-
-  touch "$PROJECT_DIR/logs/bot.log" "$PROJECT_DIR/logs/api.log"
-  chown "$SERVICE_USER:$SERVICE_GROUP" "$PROJECT_DIR/logs/bot.log" "$PROJECT_DIR/logs/api.log"
-  chmod 664 "$PROJECT_DIR/logs/bot.log" "$PROJECT_DIR/logs/api.log"
-}
-
-install_nginx_config() {
-  if [ ! -f "$NGINX_SRC" ]; then
-    fail_with_logs "nginx source config not found: $NGINX_SRC"
-  fi
-
-  log "-> Install nginx config: $NGINX_SRC -> $NGINX_DST"
-  local current_target
-  current_target=$(readlink -f "$NGINX_ENABLED_DST" || true)
-  local tmp_dst
-  tmp_dst="${NGINX_DST}.tmp.$(ts)"
-
-  backup_file "$NGINX_DST" "nginx/miniden.conf"
-
-  install -m 0644 "$NGINX_SRC" "$tmp_dst"
-  ln -sfn "$tmp_dst" "$NGINX_ENABLED_DST"
-
-  log "-> Guard: verifying https listener is present"
-  grep -q 'listen 443 ssl' "$tmp_dst" || fail_with_logs "nginx config does not contain https listener"
-
-  log "-> nginx config test"
-  if ! nginx -t; then
-    warn "nginx -t failed; restoring previous config"
-    rm -f "$tmp_dst"
-    if [ -n "$current_target" ]; then
-      ln -sfn "$current_target" "$NGINX_ENABLED_DST"
-    else
-      rm -f "$NGINX_ENABLED_DST"
-    fi
-    fail_with_logs "nginx config test failed"
-  fi
-
-  mv "$tmp_dst" "$NGINX_DST"
-  ln -sfn "$NGINX_DST" "$NGINX_ENABLED_DST"
-  log "-> Active nginx config: $(readlink -f "$NGINX_ENABLED_DST")"
-}
-
-sync_systemd_units() {
-  log "-> Syncing systemd units"
-  if [ -d "$SYSTEMD_SRC_DIR" ]; then
-    for unit in "$SYSTEMD_SRC_DIR"/*.service; do
-      [ -f "$unit" ] || continue
-      local target="$SYSTEMD_DST_DIR/$(basename "$unit")"
-      backup_file "$target" "systemd/$(basename "$unit")"
-      install -m 0644 "$unit" "$target"
-    done
-    systemctl daemon-reload
-  else
-    warn "Systemd source dir not found: $SYSTEMD_SRC_DIR"
-  fi
-}
-
-restart_services() {
-  for service_name in miniden-api miniden-bot; do
-    log "-> Restarting $service_name"
-    systemctl reset-failed "$service_name" || true
-    if ! systemctl restart "$service_name"; then
-      fail_with_logs "Failed to restart $service_name"
-    fi
-    if ! systemctl is-active --quiet "$service_name"; then
-      fail_with_logs "$service_name is not active after restart"
-    fi
-    systemctl status "$service_name" --no-pager || warn "status check failed for $service_name"
-  done
+update_repo() {
+  log "-> Updating repository"
+  local current_branch
+  current_branch=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD)
+  git -C "$PROJECT_DIR" fetch --all
+  git -C "$PROJECT_DIR" reset --hard "origin/${current_branch}"
+  log "-> Cleaning working tree (preserving .env, data, logs, media, uploads, backups)"
+  git -C "$PROJECT_DIR" clean -fd -e .env -e data -e logs -e media -e uploads -e backups || warn "git clean reported issues"
 }
 
 apply_migrations() {
@@ -175,50 +46,22 @@ apply_migrations() {
   fi
 }
 
+restart_services() {
+  for service_name in miniden-api miniden-bot; do
+    log "-> Restarting $service_name"
+    systemctl reset-failed "$service_name" || true
+    systemctl restart "$service_name"
+    systemctl is-active --quiet "$service_name" || fail_with_logs "$service_name is not active after restart"
+    systemctl status "$service_name" --no-pager || warn "status check failed for $service_name"
+  done
+}
+
 setup_logging
+log "=== deploy start $(date -Iseconds) ==="
 
-log "-> Ensuring permissions for runtime dirs"
-ensure_permissions
-
-log "-> Updating repository"
-current_branch=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD)
-git -C "$PROJECT_DIR" fetch --all
-git -C "$PROJECT_DIR" reset --hard "origin/${current_branch}"
-log "-> Cleaning working tree (preserving .env, data, logs, media, uploads, backups)"
-git -C "$PROJECT_DIR" clean -fd -e .env -e data -e logs -e media -e uploads -e backups || warn "git clean reported issues"
-
+update_repo
 apply_migrations
-
-sync_systemd_units
-install_nginx_config
-
-log "-> Reload systemd configuration"
-systemctl daemon-reload
-
 restart_services
 
-log "-> Reload nginx"
-systemctl reload nginx
-
-log "-> Post-deploy healthchecks (local)"
-check_http_ok "$BACKEND_HEALTH"
-check_http_ok "http://127.0.0.1:8000/adminsite/"
-check_http_ok "http://127.0.0.1:8000/adminsite/constructor"
-check_http_ok "http://127.0.0.1:8000/static/adminsite/base.css"
-check_http_ok "http://127.0.0.1:8000/static/adminsite/constructor.js"
-ensure_js_content_type "http://127.0.0.1:8000/static/adminsite/constructor.js"
-check_http_ok "http://127.0.0.1:8000/js/site_app.js"
-ensure_js_content_type "http://127.0.0.1:8000/js/site_app.js"
-
-log "-> Post-deploy healthchecks (public domain)"
-check_head_ok "https://miniden.ru/"
-check_head_ok "https://miniden.ru/adminsite/"
-check_head_ok "https://miniden.ru/adminsite/constructor"
-check_head_ok "https://miniden.ru/static/adminsite/constructor.js"
-ensure_js_content_type "https://miniden.ru/static/adminsite/constructor.js"
-check_head_ok "https://miniden.ru/js/site_app.js"
-ensure_js_content_type "https://miniden.ru/js/site_app.js"
-
-log "-> Healthchecks succeeded"
-
+log "-> Deploy finished"
 exit 0

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -44,7 +44,6 @@ from services.subscription import (
     check_channels_subscription,
     is_user_subscribed,
 )
-from handlers import admin as admin_handlers
 from utils.texts import format_start_text, format_subscription_required_text
 
 
@@ -217,19 +216,6 @@ async def _apply_reply_keyboard(message: types.Message, keyboard: ReplyKeyboardM
 async def _dispatch_button_action(message: types.Message, button: NodeButtonView) -> None:
     action_type = (button.action_type or "").upper()
     payload = (button.action_payload or "").strip()
-
-    if action_type in {"DEPLOY", "DEPLOY_STATUS"}:
-        if message.from_user.id not in _get_admin_telegram_ids():
-            await _answer_and_track(message, "Доступно только администраторам.")
-            return
-
-        if action_type == "DEPLOY":
-            started, response = admin_handlers.start_deploy_process()
-            await _answer_and_track(message, response)
-        else:
-            status_text = admin_handlers.build_deploy_status_text()
-            await _answer_and_track(message, status_text)
-        return
 
     if action_type == "NODE":
         target_code = button.target_node_code or payload

--- a/keyboards/main_menu.py
+++ b/keyboards/main_menu.py
@@ -110,9 +110,6 @@ def get_admin_menu() -> ReplyKeyboardMarkup:
 
     keyboard.append([KeyboardButton(text="🎓 Доступ к курсам")])
 
-    keyboard.append([KeyboardButton(text="🚀 Deploy")])
-    keyboard.append([KeyboardButton(text="📄 Deploy статус")])
-
     if getattr(settings, "webapp_admin_url", None):
         keyboard.append(
             [


### PR DESCRIPTION
## Summary
- remove deploy-related bot handlers and menu buttons so deployment is only available via systemd
- update AdminSite runtime page and API to start the miniden-deploy.service unit and show systemctl status output
- simplify deploy.sh to git sync, migrations, and service restarts and document the systemd-only deployment flow

## Testing
- python -m pytest tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958264aef2c8326a79132f1ab891e44)