### PR TITLE
Add fallback bot token env support

### DIFF
--- a/config.py
+++ b/config.py
@@ -94,6 +94,14 @@ ADMIN_IDS: list[int] = _load_admin_ids()
 ADMIN_IDS_SET: Set[int] = set(ADMIN_IDS)
 
 
+def _load_bot_token() -> str:
+    token = os.getenv("BOT_TOKEN") or os.getenv("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise ValueError("Не найден BOT_TOKEN или TELEGRAM_BOT_TOKEN в окружении")
+
+    return token
+
+
 def get_settings() -> Settings:
     """
     Возвращает объект настроек.
@@ -104,9 +112,7 @@ def get_settings() -> Settings:
     - payments_provider_token
     - required_channel_id / required_channel_link (для проверки подписки)
     """
-    token = os.getenv("BOT_TOKEN")
-    if not token:
-        raise ValueError("Не найден BOT_TOKEN в .env")
+    token = _load_bot_token()
 
     payments_token = os.getenv("PAYMENTS_PROVIDER_TOKEN") or None
 

--- a/tests/test_static_uploads.py
+++ b/tests/test_static_uploads.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
+import sys
 from pathlib import Path
 import unittest
 
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 os.environ.setdefault("BOT_TOKEN", "test-bot-token")
 
+from config import get_settings
 from webapi import STATIC_DIR_PUBLIC, app
 
 
@@ -45,6 +51,15 @@ async def _call_app(path: str) -> tuple[int, dict[str, str], bytes]:
 
     await app(scope, receive, send)
     return status or 500, {k.decode(): v.decode() for k, v in headers}, bytes(response_body)
+
+
+def test_get_settings_accepts_telegram_bot_token(monkeypatch: object) -> None:
+    monkeypatch.delenv("BOT_TOKEN", raising=False)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token-from-telegram")
+
+    settings = get_settings()
+
+    assert settings.bot_token == "token-from-telegram"
 
 
 class StaticUploadsTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary
- allow the bot to read TELEGRAM_BOT_TOKEN when BOT_TOKEN is absent to avoid startup failures
- add a regression test confirming the fallback and ensure tests import project modules reliably

## Testing
- pytest tests/test_static_uploads.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695829ac6da4832699573cbc0d618f6b)