### PR TITLE
Fix OPEN_NODE callbacks for CONTACT and ABOUT buttons

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -912,6 +912,7 @@ Front reset: theme-only + constructor-driven site
 - Fixed AdminSite constructor modals so category/product dialogs close on Отмена, Esc, and backdrop clicks without page reloads; touched `admin_panel/adminsite/static/adminsite/modals.js`, verify with the constructor smoke steps.
 - Unified бот-кнопки: у BotButton добавлены поля render/action_payload, поддержка REPLY-кнопок по узлам, новые API `/adminbot/api/buttons`, `/adminbot/api/buttons/save`, `/adminbot/api/buttons/delete`.
 - Устойчивость стартовых фото бота: добавлены ретраи/фолбэки для answer_photo, кэширование file_id после первой загрузки и увеличен HTTP-timeout сессии.
+- Восстановлена обработка OPEN_NODE: кнопки CONTACT/ABOUT с payload вида `OPEN_NODE CONTACT` корректно открывают узлы и логируют причины ошибок.
 
 Важно: AdminSite / Версии / Кэш
 - Публичный эндпоинт `/api/site/home` должен отдавать заголовок Cache-Control: no-store (плюс совместимый Pragma: no-cache).


### PR DESCRIPTION
## Summary
- parse OPEN_NODE callback payloads with colons or spaces and log malformed payloads
- add explicit logging when menu/button actions fall back to temporary unavailable responses
- document restored OPEN_NODE handling for CONTACT/ABOUT buttons in README

## Testing
- python -m compileall handlers/start.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597238d5ac8326ba3e1db67fc49141)