### PR TITLE
Fix AdminSite block picker modal closing interactions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -910,6 +910,7 @@ Front reset: theme-only + constructor-driven site
 - Removed unused placeholder `admin_panel/static/.keep` to avoid duplicate sentinel files.
 - Documented unified structure, run commands, and deploy expectations.
 - Fixed AdminSite constructor modals so category/product dialogs close on Отмена, Esc, and backdrop clicks without page reloads; touched `admin_panel/adminsite/static/adminsite/modals.js`, verify with the constructor smoke steps.
+- Fixed AdminSite constructor block picker: окно «Добавить блок» закрывается по крестику, клику на фон и клавише Esc без нарушения истории браузера.
 - Unified бот-кнопки: у BotButton добавлены поля render/action_payload, поддержка REPLY-кнопок по узлам, новые API `/adminbot/api/buttons`, `/adminbot/api/buttons/save`, `/adminbot/api/buttons/delete`.
 - Устойчивость стартовых фото бота: добавлены ретраи/фолбэки для answer_photo, кэширование file_id после первой загрузки и увеличен HTTP-timeout сессии.
 - Восстановлена обработка OPEN_NODE: кнопки CONTACT/ABOUT с payload вида `OPEN_NODE CONTACT` корректно открывают узлы и логируют причины ошибок.

--- a/admin_panel/adminsite/static/adminsite/constructor.css
+++ b/admin_panel/adminsite/static/adminsite/constructor.css
@@ -302,11 +302,34 @@ tr:nth-child(even) {
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
 }
 
+
 .modal header {
     position: static;
     background: none;
     color: var(--text);
     padding: 0 0 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.modal .modal-close {
+    border: none;
+    background: none;
+    color: var(--text);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 8px;
+    margin: -4px -4px -4px 0;
+    pointer-events: auto;
+    z-index: 1;
+}
+
+.modal .modal-close:focus-visible {
+    outline: 2px solid var(--border);
+    outline-offset: 2px;
 }
 
 .modal h3 {

--- a/admin_panel/adminsite/static/adminsite/modals.js
+++ b/admin_panel/adminsite/static/adminsite/modals.js
@@ -11,6 +11,7 @@ export class BaseModal {
         this.title = title;
         this.status = createElement('<div class="status"></div>');
         this.onCloseHandlers = [];
+        this.isOpen = false;
         this.requestClose = (reason = 'manual') => this.close(reason);
         const header = createElement(
             '<header><h3></h3><button class="modal-close" type="button" aria-label="Закрыть">×</button></header>',
@@ -23,7 +24,12 @@ export class BaseModal {
         document.body.appendChild(this.backdrop);
 
         this.modal.addEventListener('click', (event) => event.stopPropagation());
-        this.backdrop.addEventListener('click', () => this.requestClose('backdrop'));
+        this.handleBackdropClick = (event) => {
+            if (event.target === this.backdrop) {
+                this.requestClose('backdrop');
+            }
+        };
+        this.backdrop.addEventListener('click', this.handleBackdropClick);
         this.closeButton.addEventListener('click', () => this.requestClose('button'));
 
         this.handleEscape = (event) => {
@@ -41,11 +47,15 @@ export class BaseModal {
     }
 
     open() {
+        if (this.isOpen) return;
+        this.isOpen = true;
         this.backdrop.hidden = false;
         document.addEventListener('keydown', this.handleEscape);
     }
 
     close(reason = 'manual') {
+        if (!this.isOpen) return;
+        this.isOpen = false;
         this.backdrop.hidden = true;
         this.showMessage('');
         document.removeEventListener('keydown', this.handleEscape);


### PR DESCRIPTION
## Summary
- ensure BaseModal tracks open state and closes reliably from backdrop, close button, and Escape key
- style the modal header close button to remain clickable and visible above content
- document the block picker modal fix in the README maintenance log

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695978b858c48326afc325c6a0925b9f)