### PR TITLE
Expose AdminSite page health and categories blocks

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,7 @@ MiniDeN — Telegram-бот и веб-магазин
 Changelog / История изменений
 -----------------------------
 - 2026-05-XX: Палитра витрины хранится в `/api/site-settings` (activePalette + cssVars); конструктор AdminSite сохраняет черновик страницы через `PUT /api/adminsite/pages/{pageKey}` и публикует через `POST /api/adminsite/pages/{pageKey}/publish`, а витрина читает опубликованные блоки по `GET /api/site/pages/{pageKey}`. Кнопка «➕» на карточке отображается только при количестве > 0 (stock/quantity/count).
+- 2026-05-XX: Добавлен health-эндпоинт `/api/adminsite/health/page/{key}` и строгий контракт черновик/публикация: сохраняем блоки через `PUT /api/adminsite/pages/{key}` (draft), публикуем через `POST /api/adminsite/pages/{key}/publish` (published), публичная витрина читает только `/api/site/pages/{key}` и `/api/site/home` (published). Публичный ответ теперь содержит `theme`, а конструктор и витрина поддерживают блок `categories` без ошибок валидации.
 - 2026-05-XX: Legacy `webapp/admin.html` удалена; управление витриной и главной страницей ведётся только через AdminSite (`/adminsite`, конструктор страниц/блоков/шаблонов).
 - 2026-05-XX: Deploy управляется только вручную через `systemctl start miniden-deploy.service` (без вызовов из adminbot/adminsite). UI и API для запуска деплоя удалены; неизвестные action_type показываются как «Удалено», постоянное Reply-меню использует меню из `/adminbot/menu-buttons` (кнопки «Написать»/«О проекте» работают).
 - 2026-04-XX: Обновление товара допускает `slug=null` — API сохраняет текущий slug в БД и не возвращает 422.

--- a/admin_panel/adminsite/router.py
+++ b/admin_panel/adminsite/router.py
@@ -266,6 +266,13 @@ def adminsite_publish_page(page_key: str, request: Request, db: Session = Depend
         raise
 
 
+@router.get("/health/page/{page_key}", response_model=dict)
+def adminsite_page_health(page_key: str, request: Request, db: Session = Depends(get_db_session)):
+    service.ensure_admin(request, db)
+    slug = _safe_slug(page_key)
+    return adminsite_pages.get_page_health(slug)
+
+
 @router.post("/theme/apply", response_model=ThemeApplyResponse)
 def adminsite_apply_theme(
     payload: ThemeApplyPayload, request: Request, db: Session = Depends(get_db_session)

--- a/schemas/adminsite_page.py
+++ b/schemas/adminsite_page.py
@@ -80,8 +80,26 @@ class SocialBlock(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class CategoryRef(BaseModel):
+    title: str | None = None
+    slug: str | None = None
+    type: Literal["product", "course"] | None = "product"
+    url: str | None = None
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+
+class CategoriesBlock(BaseModel):
+    type: Literal["categories"] = "categories"
+    title: str | None = None
+    subtitle: str | None = None
+    items: list[CategoryRef] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 PageBlock = Annotated[
-    Union[HeroBlock, CardsBlock, TextBlock, SocialBlock],
+    Union[HeroBlock, CardsBlock, TextBlock, SocialBlock, CategoriesBlock],
     Field(discriminator="type"),
 ]
 


### PR DESCRIPTION
## Summary
- allow AdminSite pages to validate and store categories blocks alongside existing portfolio sections
- include theme data and published/draft health metadata with a new admin diagnostics endpoint
- document the draft/publish contract and diagnostic endpoint in the README

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597aa04b5883268bfcb56f42bb8c15)