### PR TITLE
Add debug logging for modal close button

### DIFF
--- a/admin_panel/adminsite/static/adminsite/modals.js
+++ b/admin_panel/adminsite/static/adminsite/modals.js
@@ -30,7 +30,14 @@ export class BaseModal {
             }
         };
         this.backdrop.addEventListener('click', this.handleBackdropClick);
-        this.closeButton.addEventListener('click', () => this.requestClose('button'));
+        if (this.closeButton) {
+            this.closeButton.addEventListener('click', () => {
+                console.debug('[AdminSite] close button clicked');
+                this.requestClose('button');
+            });
+        } else {
+            console.warn('[AdminSite] modal close button not found');
+        }
 
         this.handleEscape = (event) => {
             if (event.key === 'Escape') {


### PR DESCRIPTION
## Summary
- add debug logging to modal close button handler and guard when button missing

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959857b1ac48326889943b7c5d2290c)