### PR TITLE
Fix: AdminSite DB dependency injection — use `Depends(get_db)`

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -934,6 +934,7 @@ Front reset: theme-only + constructor-driven site
 - Unified бот-кнопки: у BotButton добавлены поля render/action_payload, поддержка REPLY-кнопок по узлам, новые API `/adminbot/api/buttons`, `/adminbot/api/buttons/save`, `/adminbot/api/buttons/delete`.
 - Устойчивость стартовых фото бота: добавлены ретраи/фолбэки для answer_photo, кэширование file_id после первой загрузки и увеличен HTTP-timeout сессии.
 - Восстановлена обработка OPEN_NODE: кнопки CONTACT/ABOUT с payload вида `OPEN_NODE CONTACT` корректно открывают узлы и логируют причины ошибок.
+- Исправлена зависимость DB для AdminSite API: в FastAPI используется `Depends(get_db)` (yield Session), а `database.get_session()` остаётся контекстным менеджером.
 
 Важно: AdminSite / Версии / Кэш
 - Публичный эндпоинт `/api/site/home` должен отдавать заголовок Cache-Control: no-store (плюс совместимый Pragma: no-cache).

--- a/database.py
+++ b/database.py
@@ -50,6 +50,14 @@ def get_session() -> Iterator[Session]:
         session.close()
 
 
+def get_db() -> Iterator[Session]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
 def init_db() -> None:
     from config import ADMIN_IDS_SET  # noqa: WPS433
     from models import Base, HomeBanner, User  # noqa: WPS433

--- a/webapi.py
+++ b/webapi.py
@@ -58,7 +58,7 @@ from admin_panel.routes import adminbot, adminsite
 from admin_panel.routes import auth as admin_auth
 from admin_panel.routes import users as admin_users
 from config import get_settings
-from database import get_session, init_db
+from database import get_db, get_session, init_db
 from media_paths import (
     ADMIN_BOT_MEDIA_ROOT,
     ADMIN_SITE_MEDIA_ROOT,
@@ -1935,7 +1935,7 @@ def site_settings():
 
 
 @app.put("/api/site-settings")
-def update_site_settings(payload: SiteSettingsPayload, request: Request, db: Session = Depends(get_session)):
+def update_site_settings(payload: SiteSettingsPayload, request: Request, db: Session = Depends(get_db)):
     adminsite_service.ensure_admin(request, db)
     return menu_catalog.update_site_settings(payload.model_dump())
 
@@ -2471,7 +2471,7 @@ def admin_update_branding(
 
 
 @app.get("/api/admin/site-settings")
-def admin_get_site_settings(request: Request, db: Session = Depends(get_session)):
+def admin_get_site_settings(request: Request, db: Session = Depends(get_db)):
     adminsite_service.ensure_admin(request, db)
     return menu_catalog.get_site_settings()
 
@@ -2480,7 +2480,7 @@ def admin_get_site_settings(request: Request, db: Session = Depends(get_session)
 def admin_update_site_settings(
     payload: SiteSettingsPayload,
     request: Request,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     return menu_catalog.update_site_settings(payload.model_dump())
@@ -2490,7 +2490,7 @@ def admin_update_site_settings(
 def admin_menu_categories(
     request: Request,
     include_inactive: bool = True,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     return {"items": menu_catalog.list_categories(include_inactive=include_inactive)}
@@ -2500,7 +2500,7 @@ def admin_menu_categories(
 def admin_menu_create_category(
     payload: MenuCategoryPayload,
     request: Request,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     try:
@@ -2514,7 +2514,7 @@ def admin_menu_update_category(
     category_id: int,
     payload: MenuCategoryUpdatePayload,
     request: Request,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     try:
@@ -2529,7 +2529,7 @@ def admin_menu_update_category(
 def admin_menu_delete_category(
     category_id: int,
     request: Request,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     try:
@@ -2547,7 +2547,7 @@ def admin_menu_items(
     category_id: int | None = None,
     type: str | None = None,
     include_inactive: bool = True,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     try:
@@ -2566,7 +2566,7 @@ def admin_menu_items(
 def admin_menu_create_item(
     payload: MenuItemPayload,
     request: Request,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     try:
@@ -2582,7 +2582,7 @@ def admin_menu_update_item(
     item_id: int,
     payload: MenuItemUpdatePayload,
     request: Request,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     try:
@@ -2597,7 +2597,7 @@ def admin_menu_update_item(
 def admin_menu_delete_item(
     item_id: int,
     request: Request,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     try:
@@ -2611,7 +2611,7 @@ def admin_menu_delete_item(
 def admin_menu_reorder(
     payload: MenuReorderPayload,
     request: Request,
-    db: Session = Depends(get_session),
+    db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     menu_catalog.reorder_entities(payload.model_dump())


### PR DESCRIPTION
### Motivation
- Fix AttributeError `_GeneratorContextManager` has no attribute `query` by ensuring FastAPI receives a real `sqlalchemy.orm.Session` instead of a contextmanager/generator.
- Ensure admin endpoints (AdminSite chain: `get_current_admin` / `ensure_admin` / admin endpoints) receive a proper `Session` so auth/session checks work and return 200/401/403 as intended.
- Keep existing admin auth logic and tokens unchanged while only correcting DB dependency injection.

### Description
- Add a FastAPI-compatible dependency `get_db()` in `database.py` that `yield`s a `Session` from `SessionLocal` and closes it after use.
- Switch admin-related endpoints in `webapi.py` from `Depends(get_session)` (contextmanager) to `Depends(get_db)` so DI injects a real `Session` object.
- Import `get_db` where needed and leave `get_session()` (contextmanager) intact for manual `with get_session()` usage elsewhere.
- Changed files: `database.py`, `webapi.py`, `README.txt` (maintenance log entry documenting the fix).

### Testing
- Automated tests: none were executed as part of this change.
- Manual verification (recommended smoke steps): start the API and call `GET /api/site/theme` and `GET /api/adminsite/media` with a valid admin session token and confirm expected 200; repeat with invalid/expired token and confirm 401/403.
- Confirm there are no tracebacks containing `_GeneratorContextManager has no attribute query` in logs after exercising the admin endpoints.
- README: updated (`README.txt`) with a short maintenance-log note describing the `Depends(get_db)` fix for AdminSite API sessions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fff94416c83269404d1cf7adb08d9)