### PR TITLE
Restore /c/<slug> route for legacy PROD_MENU links

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,7 @@ MiniDeN — Telegram-бот и веб-магазин
 Changelog / История изменений
 -----------------------------
 - 2026-06-XX: Витрина и AdminSite переведены на menu-driven модель: таблицы `menu_categories`, `menu_items`, `site_settings`; публичные данные отдаются через `/public/*`, админка управляет меню через `/api/admin/menu/*` и настройками через `/api/admin/site-settings`. Старые темы/шаблоны/блоки отключены для витрины (рендер больше не зависит от `/api/site/theme` и `/api/site/pages/*`).
+- 2026-06-XX: Вернули совместимость со старыми ссылками PROD_MENU `/c/<slug>`: сервер отдаёт `webapp/index.html` для `/c/{slug}`, фронтенд берёт категории из БД меню (`/public/menu`) и показывает 404-экран при неизвестном slug.
 - 2026-06-XX: Публичная витрина читает только опубликованные данные конструктора: тема (/api/site/theme), меню (/api/site/menu) и страницы (/api/site/pages/{key}) возвращают version/updated_at; публикация копирует draft → published и обновляет version. Тема по умолчанию Linen & Sage, webapp применяет её через CSS variables без перекомпиляции.
 - 2026-05-XX: Палитра витрины хранится в `/api/site-settings` (activePalette + cssVars); конструктор AdminSite сохраняет черновик страницы через `PUT /api/adminsite/pages/{pageKey}` и публикует через `POST /api/adminsite/pages/{pageKey}/publish`, а витрина читает опубликованные блоки по `GET /api/site/pages/{pageKey}`. Кнопка «➕» на карточке отображается только при количестве > 0 (stock/quantity/count).
 - 2026-05-XX: Добавлен health-эндпоинт `/api/adminsite/health/page/{key}` и строгий контракт черновик/публикация: сохраняем блоки через `PUT /api/adminsite/pages/{key}` (draft), публикуем через `POST /api/adminsite/pages/{key}/publish` (published), публичная витрина читает только `/api/site/pages/{key}` и `/api/site/home` (published). Публичный ответ теперь содержит `theme`, а конструктор и витрина поддерживают блок `categories` без ошибок валидации.
@@ -73,6 +74,7 @@ Menu-driven витрина (iiko-like)
 - `GET /public/menu`
 - `GET /public/menu/categories`
 - `GET /public/menu/items?category=slug|id`
+- WebApp-роут `/c/<slug>` использует эти публичные эндпоинты и ищет категорию по `menu_categories.slug`.
 
 Админские (для AdminSite):
 - `GET/POST/PUT/DELETE /api/admin/menu/categories`

--- a/webapi.py
+++ b/webapi.py
@@ -38,7 +38,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.exceptions import RequestValidationError
 from fastapi.staticfiles import StaticFiles
 from starlette.routing import NoMatchFound
@@ -108,6 +108,10 @@ setup_logging(log_file=API_LOG_FILE)
 app = FastAPI(title="MiniDeN Web API", version="1.0.0")
 
 logger = logging.getLogger(__name__)
+
+
+def _serve_webapp_index() -> FileResponse:
+    return FileResponse(WEBAPP_DIR / "index.html", media_type="text/html")
 
 
 def _detect_git_commit() -> str:
@@ -3580,5 +3584,9 @@ def categories_page():
 
 @app.get("/category/{slug}", include_in_schema=False)
 def category_page(slug: str):
-    target = f"/webapp/category.html?slug={slug}"
-    return RedirectResponse(url=target, status_code=302)
+    return RedirectResponse(url=f"/c/{slug}", status_code=302)
+
+
+@app.get("/c/{slug}", include_in_schema=False)
+def category_slug_page(slug: str):
+    return _serve_webapp_index()


### PR DESCRIPTION
### Motivation
- Restore compatibility for legacy PROD_MENU links so `/c/<slug>` from old buttons continues to open the category page in the WebApp.
- Ensure the category `slug` is resolved from the menu DB (`menu_categories.slug`) and a friendly 404 is shown if not found.
- Implement the change without modifying existing menu/item rendering logic or project architecture.

### Description
- Added a helper `_serve_webapp_index()` and imported `FileResponse` to serve the SPA `webapp/index.html` for client-side routing.
- Added `@app.get("/c/{slug}")` which returns the SPA and changed `@app.get("/category/{slug}")` to redirect to `/c/{slug}` so legacy links resolve to the same client-side route.
- Documented the back-compat behavior in `README.txt`, noting that `/c/<slug>` uses the public menu endpoints (`/public/menu`, `/public/menu/categories`, `/public/menu/items`) and looks up `menu_categories.slug`.

### Testing
- No automated tests were executed for this change set.
- Manual verification steps: start the backend (for example `uvicorn webapi:app`), open `http://localhost:8000/c/korzinki` and confirm the WebApp loads and shows the `korzinki` category, and open `http://localhost:8000/category/korzinki` to confirm it redirects to `/c/korzinki`.
- Changed files: `webapi.py` — added `FileResponse` import, `_serve_webapp_index()`, `@app.get('/c/{slug}')` handler and updated `/category/{slug}` redirect; `README.txt` — added back-compat note for `/c/<slug>`.
- README in the repository root was updated to describe the `/c/<slug>` back-compat and which public endpoints are used for category resolution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696005f7cca48326b451ef522a5a1053)