### PR TITLE
Align webapp layout with iiko-style grid

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,6 +3,7 @@ MiniDeN — Telegram-бот и веб-магазин
 
 Changelog / История изменений
 -----------------------------
+- 2026-06-XX: WebApp витрина приведена к iiko-like layout: единый контейнер, sticky header, фиксированный sidebar и отдельный скролл для main/sidebar; карточки и кнопки приведены к единой сетке и design tokens.
 - 2026-06-XX: Витрина обновлена под iiko-like UX: единые design tokens, фиксированный header, левый сайдбар категорий, карточки позиций и единый стиль страниц. Контентные блоки вынесены в таблицу `site_blocks`, добавлены публичные `/api/public/*` и админские `/api/admin/blocks` эндпоинты. Добавлены поля `hero_enabled`, `menu_categories.image_url`, `menu_items.legacy_link`, а также авто-сид для slug `korzinki/basket/cradle/set` для back-compat `/c/<slug>`.
 - 2026-06-XX: AdminSite — восстановлены кликабельность конструктора и навигация старых разделов (товары/категории/курсы/мастер-классы/главная), отдельным пунктом оставлено «Меню витрины»; скрытые оверлеи больше не перекрывают клики.
 - 2026-06-XX: Витрина и AdminSite переведены на menu-driven модель: таблицы `menu_categories`, `menu_items`, `site_settings`; публичные данные отдаются через `/public/*`, админка управляет меню через `/api/admin/menu/*` и настройками через `/api/admin/site-settings`. Старые темы/шаблоны/блоки отключены для витрины (рендер больше не зависит от `/api/site/theme` и `/api/site/pages/*`).
@@ -58,6 +59,20 @@ Menu-driven витрина (iiko-like)
 - Блоки страницы выводятся из `site_blocks` через `/api/public/blocks?page=...` (home/category/footer/custom).
 - Порядок определяется `order_index` у категорий и позиций; флаг `is_active=false` скрывает записи на сайте и в боте.
 - AdminSite управляет меню через `/api/admin/menu/*`, блоками через `/api/admin/blocks` и настройками сайта через `/api/admin/site-settings`.
+
+WebApp layout и design tokens
+-----------------------------
+- Layout витрины реализован в `webapp/index.html` и `webapp/cart.html`: `header.site-header` + `div.site-layout` (grid: sidebar + main) + `aside.site-sidebar` и `main.site-content`.
+- Sticky header использует высоту `--headerH`, контейнер центруется через `--container`, а sidebar/main скроллятся независимо за счёт `height: calc(100vh - var(--headerH))` и `overflow: auto`.
+- Design tokens объявлены в `webapp/css/theme.css` и используются через CSS variables (`--font`, `--bg`, `--surface`, `--text`, `--primary`, `--radius*`, `--shadow*`, `--container`, `--sidebarW`, `--gap`, `--pad`).
+- Точки входа витрины: `/` и `/c/<slug>` (оба используют `webapp/index.html`), `/cart` использует `webapp/cart.html`, карточка позиции открывается во view `#view-product` внутри `index.html`.
+
+Как проверить верстку витрины
+-----------------------------
+1. Открыть `/` и убедиться, что header фиксирован, sidebar слева, main справа в контейнере 1200px.
+2. Перейти в `/c/korzinki` (или любой slug) и проверить сетку карточек: 4 колонки на desktop, 2 на tablet, 1 на mobile.
+3. Открыть `/cart` и проверить, что layout совпадает с главной страницей (тот же header/sidebar/main).
+4. На ширине <=1024px открыть меню через кнопку «Категории» и убедиться, что sidebar открывается как drawer.
 
 Архитектура проекта
 -------------------

--- a/webapp/cart.html
+++ b/webapp/cart.html
@@ -25,84 +25,87 @@
         </div>
       </div>
       <div class="header-actions">
-        <button class="menu-toggle" aria-label="Открыть меню">Меню</button>
+        <button class="menu-toggle" aria-label="Открыть категории">Категории</button>
         <a class="btn cart-button" href="/cart">Корзина</a>
       </div>
     </div>
   </header>
 
-  <aside class="site-sidebar app-sidebar">
-    <div class="sidebar-head">
-      <div class="brand brand--inline" data-branding-block>
-        <div class="brand__logo-wrapper brand__logo-placeholder" aria-hidden="true">
-          <img data-branding-logo class="brand__logo" alt="Логотип MiniDeN" />
+  <div class="site-container site-layout">
+    <aside class="site-sidebar app-sidebar">
+      <div class="sidebar-head">
+        <div class="brand brand--inline" data-branding-block>
+          <div class="brand__logo-wrapper brand__logo-placeholder" aria-hidden="true">
+            <img data-branding-logo class="brand__logo" alt="Логотип MiniDeN" />
+          </div>
+          <div class="brand__text">
+            <div class="brand__title" data-branding-title data-branding-default="Miniden">Miniden</div>
+            <span data-branding-tagline class="muted">меню и витрина</span>
+          </div>
         </div>
-        <div class="brand__text">
-          <div class="brand__title" data-branding-title data-branding-default="Miniden">Miniden</div>
-          <span data-branding-tagline class="muted">меню и витрина</span>
+        <button class="menu-close" aria-label="Закрыть меню">✕</button>
+      </div>
+      <div class="sidebar-section">
+        <a href="/" class="category-link">Главная</a>
+        <a href="/cart" class="category-link is-active">Корзина</a>
+        <a href="/adminsite" id="admin-link" style="display:none;">Админка</a>
+      </div>
+    </aside>
+
+    <main class="site-content">
+      <div class="cart-header">
+        <h1>Корзина</h1>
+        <p class="muted">Здесь отображаются товары и мастер-классы из вашего Telegram-аккаунта.</p>
+      </div>
+
+      <div class="note" id="note"></div>
+
+      <table class="cart-table" aria-label="Корзина">
+        <thead>
+          <tr>
+            <th>Товар</th>
+            <th>Категория</th>
+            <th>Цена</th>
+            <th>Кол-во</th>
+            <th>Сумма</th>
+          </tr>
+        </thead>
+        <tbody id="cart-body"></tbody>
+      </table>
+
+      <div class="total-card" id="cart-panel" style="display:none;">
+        <div class="total-row"><span>Итого</span><span id="cart-total">0 ₽</span></div>
+        <div class="promo-row" id="promo-info" style="display:none; color: var(--muted); font-weight:600;">
+          <div>
+            <div id="promo-label"></div>
+            <div id="promo-scope" style="font-size:13px; color: var(--muted);"></div>
+          </div>
+          <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+            <strong id="promo-discount" style="color: var(--accent);"></strong>
+            <button class="btn secondary" type="button" id="remove-promo">Удалить промокод</button>
+          </div>
+        </div>
+        <div class="input-row">
+          <input type="text" placeholder="Промокод" id="promo-code" />
+          <button class="btn secondary" type="button" id="apply-promo">Применить</button>
+        </div>
+        <div class="input-row">
+          <input type="text" placeholder="Ваше имя" id="customer-name" />
+          <input type="text" placeholder="Телефон или ник" id="customer-contact" />
+        </div>
+        <div class="input-row">
+          <textarea id="customer-comment" placeholder="Комментарий к заказу (необязательно)"></textarea>
+        </div>
+        <div class="input-row">
+          <button class="btn secondary" type="button" id="clear-cart">Очистить корзину</button>
+          <button class="btn" type="button" id="checkout">Оформить заказ</button>
         </div>
       </div>
-    </div>
-    <div class="sidebar-section">
-      <a href="/" class="category-link">Главная</a>
-      <a href="/cart" class="category-link is-active">Корзина</a>
-      <a href="/adminsite" id="admin-link" style="display:none;">Админка</a>
-    </div>
-  </aside>
+    </main>
+  </div>
 
   <div class="app-sidebar-overlay"></div>
   <div id="toast-container"></div>
-
-  <main class="site-container">
-    <div class="cart-header">
-      <h1>Корзина</h1>
-      <p class="muted">Здесь отображаются товары и мастер-классы из вашего Telegram-аккаунта.</p>
-    </div>
-
-    <div class="note" id="note"></div>
-
-    <table class="cart-table" aria-label="Корзина">
-      <thead>
-        <tr>
-          <th>Товар</th>
-          <th>Категория</th>
-          <th>Цена</th>
-          <th>Кол-во</th>
-          <th>Сумма</th>
-        </tr>
-      </thead>
-      <tbody id="cart-body"></tbody>
-    </table>
-
-    <div class="total-card" id="cart-panel" style="display:none;">
-      <div class="total-row"><span>Итого</span><span id="cart-total">0 ₽</span></div>
-      <div class="promo-row" id="promo-info" style="display:none; color: var(--muted); font-weight:600;">
-        <div>
-          <div id="promo-label"></div>
-          <div id="promo-scope" style="font-size:13px; color: var(--muted);"></div>
-        </div>
-        <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
-          <strong id="promo-discount" style="color: var(--accent);"></strong>
-          <button class="btn secondary" type="button" id="remove-promo">Удалить промокод</button>
-        </div>
-      </div>
-      <div class="input-row">
-        <input type="text" placeholder="Промокод" id="promo-code" />
-        <button class="btn secondary" type="button" id="apply-promo">Применить</button>
-      </div>
-      <div class="input-row">
-        <input type="text" placeholder="Ваше имя" id="customer-name" />
-        <input type="text" placeholder="Телефон или ник" id="customer-contact" />
-      </div>
-      <div class="input-row">
-        <textarea id="customer-comment" placeholder="Комментарий к заказу (необязательно)"></textarea>
-      </div>
-      <div class="input-row">
-        <button class="btn secondary" type="button" id="clear-cart">Очистить корзину</button>
-        <button class="btn" type="button" id="checkout">Оформить заказ</button>
-      </div>
-    </div>
-  </main>
 
   <script src="js/app.js?v=20251218"></script>
   <script src="js/api.js?v=20250605"></script>

--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -1,25 +1,45 @@
 :root {
-  --font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
-  --color-page-bg: #f6f7fb;
-  --color-surface: #ffffff;
-  --color-text-primary: #111827;
-  --color-text-secondary: #6b7280;
-  --color-border: #e5e7eb;
-  --color-primary: #2563eb;
-  --color-primary-hover: #1d4ed8;
+  --font: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --text: #111827;
+  --muted: #6b7280;
+  --border: #e5e7eb;
+  --primary: #2563eb;
+  --primaryHover: #1d4ed8;
+  --radiusSm: 10px;
+  --radiusMd: 14px;
+  --radiusLg: 18px;
+  --shadowSm: 0 1px 2px rgba(16, 24, 40, 0.06);
+  --shadowMd: 0 12px 24px rgba(16, 24, 40, 0.1);
+  --container: 1200px;
+  --headerH: 64px;
+  --sidebarW: 260px;
+  --gap: 16px;
+  --pad: 16px;
+
+  --font-family: var(--font);
+  --color-page-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-text-primary: var(--text);
+  --color-text-secondary: var(--muted);
+  --color-border: var(--border);
+  --color-primary: var(--primary);
+  --color-primary-hover: var(--primaryHover);
   --color-accent: #7c3aed;
   --color-success: #16a34a;
   --color-danger: #dc2626;
-  --radius-sm: 10px;
-  --radius-md: 14px;
-  --radius-lg: 18px;
-  --shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.06);
-  --shadow-md: 0 12px 24px rgba(16, 24, 40, 0.1);
-  --container-max: 1200px;
-  --sidebar-width: 260px;
-  --gap: 16px;
+  --accent: var(--color-accent);
+  --radius-sm: var(--radiusSm);
+  --radius-md: var(--radiusMd);
+  --radius-lg: var(--radiusLg);
+  --shadow-sm: var(--shadowSm);
+  --shadow-md: var(--shadowMd);
+  --container-max: var(--container);
+  --sidebar-width: var(--sidebarW);
   --card-padding: 14px;
   --button-height: 40px;
+  --button-radius: 12px;
 
   --color-bg: var(--color-page-bg);
   --color-bg-card: var(--color-surface);
@@ -33,7 +53,7 @@
   --color-accent-danger: var(--color-danger);
   --shadow-strong: var(--shadow-md);
   --radius-card: var(--radius-md);
-  --radius-button: var(--radius-sm);
+  --radius-button: var(--button-radius);
 }
 
 * {
@@ -44,13 +64,14 @@ html,
 body {
   margin: 0;
   padding: 0;
+  height: 100%;
 }
 
 body {
   font-family: var(--font-family);
-  background: var(--color-page-bg);
-  color: var(--color-text-primary);
-  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100%;
 }
 
 a {
@@ -71,15 +92,15 @@ img {
   width: 100%;
   max-width: var(--container-max);
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0 var(--pad);
 }
 
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 1000;
-  height: 64px;
-  background: var(--color-surface);
+  z-index: 50;
+  height: var(--headerH);
+  background: var(--surface);
   border-bottom: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
   display: flex;
@@ -166,8 +187,8 @@ button.btn {
   justify-content: center;
   gap: 8px;
   height: var(--button-height);
-  padding: 0 16px;
-  border-radius: var(--radius-sm);
+  padding: 0 14px;
+  border-radius: var(--button-radius);
   border: 1px solid var(--color-primary);
   background: var(--color-primary);
   color: #ffffff;
@@ -206,24 +227,34 @@ button.btn:hover {
   display: grid;
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   gap: var(--gap);
-  padding: 24px 0 32px;
+  padding: 0;
+  height: calc(100vh - var(--headerH));
 }
 
 .site-content {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--gap);
+  height: 100%;
+  overflow: auto;
+  padding: var(--pad);
+}
+
+.site-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
 }
 
 .site-sidebar {
-  background: var(--color-surface);
+  background: var(--surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
-  padding: 16px;
-  height: fit-content;
-  position: sticky;
-  top: 88px;
+  padding: var(--pad);
+  height: 100%;
+  overflow: auto;
+  position: static;
 }
 
 .sidebar-head {
@@ -258,6 +289,7 @@ button.btn:hover {
   display: flex;
   align-items: center;
   gap: 8px;
+  height: 40px;
   padding: 10px 12px;
   border-radius: var(--radius-sm);
   color: var(--color-text-primary);
@@ -265,14 +297,13 @@ button.btn:hover {
 }
 
 .category-link:hover {
-  border-color: var(--color-primary);
+  background: rgba(37, 99, 235, 0.08);
   color: var(--color-primary);
 }
 
 .category-link.is-active {
-  background: rgba(37, 99, 235, 0.1);
+  background: rgba(37, 99, 235, 0.14);
   color: var(--color-primary);
-  border-color: rgba(37, 99, 235, 0.2);
 }
 
 .nav-divider {
@@ -284,7 +315,7 @@ button.btn:hover {
 .menu-toggle,
 .menu-close {
   border: 1px solid var(--color-border);
-  background: var(--color-surface);
+  background: var(--surface);
   color: var(--color-text-primary);
   border-radius: var(--radius-sm);
   height: var(--button-height);
@@ -308,7 +339,7 @@ button.btn:hover {
 }
 
 .hero-banner {
-  background: var(--color-surface);
+  background: var(--surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   padding: 24px;
@@ -362,7 +393,7 @@ button.btn:hover {
 }
 
 .catalog-card {
-  background: var(--color-surface);
+  background: var(--surface);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   overflow: hidden;
@@ -377,6 +408,8 @@ button.btn:hover {
   align-items: center;
   justify-content: center;
   aspect-ratio: 4 / 3;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
 }
 
 .catalog-card-image img {
@@ -441,7 +474,7 @@ button.btn:hover {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: var(--gap);
-  background: var(--color-surface);
+  background: var(--surface);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   padding: 24px;
@@ -461,6 +494,14 @@ button.btn:hover {
   padding: 18px;
   text-align: center;
   color: var(--color-text-secondary);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  gap: 8px;
 }
 
 .blocks-stack {
@@ -470,7 +511,7 @@ button.btn:hover {
 }
 
 .content-block {
-  background: var(--color-surface);
+  background: var(--surface);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   padding: 18px;
@@ -487,7 +528,8 @@ button.btn:hover {
 .site-footer {
   padding: 24px 0 40px;
   border-top: 1px solid var(--color-border);
-  background: var(--color-surface);
+  background: var(--surface);
+  margin-top: var(--gap);
 }
 
 .footer-grid {
@@ -511,7 +553,7 @@ button.btn:hover {
 .cart-table {
   width: 100%;
   border-collapse: collapse;
-  background: var(--color-surface);
+  background: var(--surface);
   border-radius: var(--radius-md);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
@@ -531,7 +573,7 @@ button.btn:hover {
 }
 
 .total-card {
-  background: var(--color-surface);
+  background: var(--surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   padding: 16px;
@@ -584,22 +626,28 @@ textarea {
   resize: vertical;
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 1024px) {
   .catalog-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1024px) {
   .site-layout {
     grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .site-content {
+    height: auto;
+    overflow: visible;
   }
 
   .site-sidebar {
     position: fixed;
-    top: 0;
+    top: var(--headerH);
     left: 0;
-    height: 100vh;
+    height: calc(100vh - var(--headerH));
     width: min(320px, 80vw);
     transform: translateX(-100%);
     transition: transform 0.2s ease;
@@ -623,5 +671,13 @@ textarea {
 
   .header-actions {
     gap: 6px;
+  }
+
+  .input-row {
+    flex-direction: column;
+  }
+
+  .site-content .btn {
+    width: 100%;
   }
 }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -32,33 +32,30 @@
   </div>
 </header>
 
-<aside class="site-sidebar app-sidebar" id="nav-links">
-  <div class="sidebar-head">
-    <div class="brand brand--inline" data-branding-block>
-      <div class="brand__logo-wrapper brand__logo-placeholder" aria-hidden="true">
-        <img class="brand__logo" data-brand-logo alt="Логотип" />
-      </div>
-      <div class="brand__text">
-        <div class="brand__title">MiniDeN</div>
-        <span class="muted">меню и витрина</span>
-      </div>
-    </div>
-    <button class="menu-close" aria-label="Закрыть меню">✕</button>
-  </div>
-  <div class="sidebar-section">
-    <a href="/" data-router-link class="category-link">Главная</a>
-  </div>
-  <div class="nav-divider"></div>
-  <div class="sidebar-section">
-    <div class="sidebar-title">Категории</div>
-    <div id="nav-menu" class="category-list"></div>
-  </div>
-</aside>
-
-<div class="app-sidebar-overlay"></div>
-<div id="toast-container"></div>
-
 <div class="site-container site-layout">
+  <aside class="site-sidebar app-sidebar" id="nav-links">
+    <div class="sidebar-head">
+      <div class="brand brand--inline" data-branding-block>
+        <div class="brand__logo-wrapper brand__logo-placeholder" aria-hidden="true">
+          <img class="brand__logo" data-brand-logo alt="Логотип" />
+        </div>
+        <div class="brand__text">
+          <div class="brand__title">MiniDeN</div>
+          <span class="muted">меню и витрина</span>
+        </div>
+      </div>
+      <button class="menu-close" aria-label="Закрыть меню">✕</button>
+    </div>
+    <div class="sidebar-section">
+      <a href="/" data-router-link class="category-link">Главная</a>
+    </div>
+    <div class="nav-divider"></div>
+    <div class="sidebar-section">
+      <div class="sidebar-title">Категории</div>
+      <div id="nav-menu" class="category-list"></div>
+    </div>
+  </aside>
+
   <main class="site-content">
     <section id="view-home" class="site-view">
       <section class="hero-banner" id="hero-section">
@@ -72,13 +69,6 @@
         </div>
       </section>
       <div id="home-blocks" class="blocks-stack hidden"></div>
-      <section class="home-section">
-        <div class="section-head">
-          <h2>Категории</h2>
-          <p class="muted">Выберите категорию, чтобы посмотреть позиции.</p>
-        </div>
-        <div class="pill-list" id="home-categories"></div>
-      </section>
       <section class="home-section">
         <div class="section-head">
           <h2>Позиции</h2>
@@ -129,21 +119,23 @@
         </div>
       </div>
     </section>
+    <footer class="site-footer">
+      <div class="footer-grid">
+        <div>
+          <div class="muted">Контакты</div>
+          <div id="footer-contacts"></div>
+        </div>
+        <div>
+          <div class="muted">Соцсети</div>
+          <div class="footer-links" id="footer-social"></div>
+        </div>
+      </div>
+    </footer>
   </main>
 </div>
 
-<footer class="site-footer">
-  <div class="site-container footer-grid">
-    <div>
-      <div class="muted">Контакты</div>
-      <div id="footer-contacts"></div>
-    </div>
-    <div>
-      <div class="muted">Соцсети</div>
-      <div class="footer-links" id="footer-social"></div>
-    </div>
-  </div>
-</footer>
+<div class="app-sidebar-overlay"></div>
+<div id="toast-container"></div>
 
 <script type="module" src="/js/site_app.js?v=20251220"></script>
 </body>

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -65,6 +65,7 @@ function initSidebar() {
   const sidebar = document.querySelector('.app-sidebar');
   const overlay = document.querySelector('.app-sidebar-overlay');
   const toggle = document.querySelector('.menu-toggle');
+  const closeBtn = document.querySelector('.menu-close');
   const sidebarLinks = document.querySelectorAll('.app-sidebar a');
 
   const openSidebar = () => {
@@ -88,6 +89,7 @@ function initSidebar() {
 
   toggle?.addEventListener('click', toggleSidebar);
   overlay?.addEventListener('click', closeSidebar);
+  closeBtn?.addEventListener('click', closeSidebar);
   sidebarLinks.forEach((link) => link.addEventListener('click', closeSidebar));
 }
 

--- a/webapp/js/site_app.js
+++ b/webapp/js/site_app.js
@@ -324,8 +324,10 @@ function renderBlocks(blocks, container) {
 }
 
 function renderHome(categories) {
-  if (!homeCategories || !homeItems) return;
-  homeCategories.innerHTML = '';
+  if (!homeItems) return;
+  if (homeCategories) {
+    homeCategories.innerHTML = '';
+  }
   homeItems.innerHTML = '';
 
   if (!categories.length) {
@@ -336,10 +338,6 @@ function renderHome(categories) {
   }
 
   homeEmpty?.classList.add('hidden');
-  categories.forEach((category) => {
-    homeCategories.appendChild(buildCategoryButton(category));
-  });
-
   const firstCategory = categories[0];
   const items = firstCategory.items || [];
   items.forEach((item) => homeItems.appendChild(buildItemCard(item)));


### PR DESCRIPTION
### Motivation
- Fix floating elements and inconsistent widths so header, sidebar and main content align across pages.  
- Provide a single, reusable Layout and unified design tokens to make the storefront visually consistent.  
- Ensure independent scrolling for `sidebar` and `main` and enforce a centered container with max width for desktop.  
- Improve responsive behavior so grid of item cards becomes 4/2/1 columns on desktop/tablet/mobile.

### Description
- Introduced CSS design tokens and layout rules in `webapp/css/theme.css` (variables like `--font`, `--bg`, `--sidebarW`, `--headerH`, `--container`, etc.) and adjusted component styles to use them.  
- Reworked DOM structure in `webapp/index.html` and `webapp/cart.html` to use a single grid container (`.site-layout`) holding `aside.site-sidebar` + `main.site-content`, moved footer into main and added overlay/toast placement.  
- Made header sticky (`--headerH`), constrained overall height with `height: calc(100vh - var(--headerH))`, and enabled separate `overflow: auto` scrolling for `main` and `sidebar`; added responsive breakpoints for drawer behavior at `<=1024px`.  
- Updated JS to control the sidebar (`webapp/js/app.js`) and simplified home render logic to keep category controls in the sidebar (`webapp/js/site_app.js`), and documented layout/tokens and verification steps in `README.txt`.

### Testing
- Started a local static server with `python -m http.server 8000` in `webapp` and the server served `index.html` successfully.  
- Captured a desktop smoke screenshot using Playwright (artifact `artifacts/webapp-layout-desktop.png`) after loading `http://127.0.0.1:8000/index.html`, which completed successfully.  
- Verified sidebar open/close wiring by adding `menu-close` handling in `webapp/js/app.js` and exercised the toggle via the page during the smoke check.  
- No unit/integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696141e5133c8326bbdf8e9e44e8748d)