### PR TITLE
Menu: category types/parent + item stock; WebApp item modal & deep-links; AdminSite public links

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -71,8 +71,9 @@ WebApp layout и design tokens
 -----------------------------
 1. Открыть `/` и убедиться, что header фиксирован, sidebar слева, main справа в контейнере 1200px.
 2. Перейти в `/c/korzinki` (или любой slug) и проверить сетку карточек: 4 колонки на desktop, 2 на tablet, 1 на mobile.
-3. Открыть `/cart` и проверить, что layout совпадает с главной страницей (тот же header/sidebar/main).
-4. На ширине <=1024px открыть меню через кнопку «Категории» и убедиться, что sidebar открывается как drawer.
+3. Кликнуть по карточке товара и убедиться, что открывается модалка (крестик/ESC/фон закрывают), а URL меняется на `/i/<id>`.
+4. Открыть `/cart` и проверить, что layout совпадает с главной страницей (тот же header/sidebar/main).
+5. На ширине <=1024px открыть меню через кнопку «Категории» и убедиться, что sidebar открывается как drawer.
 
 Архитектура проекта
 -------------------
@@ -90,15 +91,19 @@ WebApp layout и design tokens
 Публичные (для сайта и бота):
 - `GET /public/site-settings`
 - `GET /public/menu`
+- `GET /public/menu/tree?type=product|masterclass`
 - `GET /public/menu/categories`
 - `GET /public/menu/items?category=slug|id`
 - `GET /api/public/site-settings`
 - `GET /api/public/menu`
+- `GET /api/public/menu/tree?type=product|masterclass`
 - `GET /api/public/menu/categories`
 - `GET /api/public/menu/category/{slug}`
 - `GET /api/public/menu/items?category_slug=...`
+- `GET /api/public/item/{id}`
 - `GET /api/public/blocks?page=home|category|footer|custom`
 - WebApp-роут `/c/<slug>` использует эти публичные эндпоинты и ищет категорию по `menu_categories.slug`.
+- WebApp-роут `/i/<id>` открывает карточку позиции как модалку (deep-link).
 
 Админские (для AdminSite):
 - `GET/POST/PUT/DELETE /api/admin/menu/categories`
@@ -111,6 +116,7 @@ WebApp layout и design tokens
 Миграции меню
 -------------
 - В проекте нет Alembic: таблицы `menu_categories`, `menu_items`, `site_settings`, `site_blocks` создаются через `init_db()` при запуске backend.
+- Новые поля меню: `menu_categories.type`, `menu_categories.parent_id`, `menu_items.stock_qty` (null = без лимита).
 - Старые таблицы товаров/страниц не удаляются и остаются для legacy-функций; перенос данных в меню выполняется вручную при необходимости.
 
 Архитектура админки

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -548,10 +548,18 @@ class HomePost(Base):
 
 class MenuCategory(Base):
     __tablename__ = "menu_categories"
+    __table_args__ = (
+        CheckConstraint(
+            "type IN ('product', 'masterclass')",
+            name="ck_menu_categories_type",
+        ),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     title = Column(Text, nullable=False)
     slug = Column(String(150), nullable=False, unique=True)
+    type = Column(String(32), nullable=False, default="product", server_default="product", index=True)
+    parent_id = Column(Integer, ForeignKey("menu_categories.id"), nullable=True, index=True)
     description = Column(Text, nullable=True)
     image_url = Column(Text, nullable=True)
     order_index = Column(Integer, nullable=False, default=0, server_default="0")
@@ -559,6 +567,8 @@ class MenuCategory(Base):
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=func.now(), nullable=False)
 
+    parent = relationship("MenuCategory", remote_side=[id], back_populates="children")
+    children = relationship("MenuCategory", back_populates="parent")
     items = relationship(
         "MenuItem",
         back_populates="category",
@@ -582,7 +592,7 @@ class MenuItem(Base):
     )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    category_id = Column(Integer, ForeignKey("menu_categories.id"), nullable=False)
+    category_id = Column(Integer, ForeignKey("menu_categories.id"), nullable=False, index=True)
     title = Column(Text, nullable=False)
     subtitle = Column(Text, nullable=True)
     slug = Column(String(150), nullable=False)
@@ -594,6 +604,7 @@ class MenuItem(Base):
     legacy_link = Column(Text, nullable=True)
     order_index = Column(Integer, nullable=False, default=0, server_default="0")
     is_active = Column(Boolean, nullable=False, default=True, server_default="true")
+    stock_qty = Column(Integer, nullable=True)
     type = Column(String(32), nullable=False, default="product", server_default="product")
     meta = Column(JSONB, nullable=False, default=dict, server_default="{}")
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -223,6 +223,162 @@ button.btn:hover {
   font-weight: 600;
 }
 
+.type-tabs {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.type-tab {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.type-tab.is-active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #ffffff;
+}
+
+.catalog-card.is-out-of-stock {
+  opacity: 0.75;
+}
+
+.btn:disabled,
+button.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.item-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.6);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 80;
+}
+
+.item-modal-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.item-modal {
+  position: fixed;
+  inset: auto 16px 24px 16px;
+  max-width: 820px;
+  margin: 0 auto;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--color-border);
+  opacity: 0;
+  transform: translateY(20px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 90;
+}
+
+.item-modal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.item-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 0;
+}
+
+.item-modal__close {
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.item-modal__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: 18px;
+  padding: 16px 18px 20px;
+}
+
+.item-modal__media {
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 220px;
+}
+
+.item-modal__media img {
+  max-height: 320px;
+  object-fit: cover;
+  border-radius: var(--radius-md);
+}
+
+.item-modal__details h2 {
+  margin: 4px 0 8px;
+}
+
+.item-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.qty-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+  padding: 6px 10px;
+}
+
+.qty-btn {
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.qty-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.qty-value {
+  min-width: 24px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.body-modal-open,
+.modal-open {
+  overflow: hidden;
+}
+
+@media (max-width: 720px) {
+  .item-modal__content {
+    grid-template-columns: 1fr;
+  }
+}
+
 .site-layout {
   display: grid;
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
@@ -468,6 +624,11 @@ button.btn:hover {
   padding: 4px 10px;
   font-size: 12px;
   font-weight: 600;
+}
+
+.tag.is-danger {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--color-danger);
 }
 
 .product-layout {

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -51,6 +51,14 @@
     </div>
     <div class="nav-divider"></div>
     <div class="sidebar-section">
+      <div class="sidebar-title">Раздел</div>
+      <div class="type-tabs" id="type-tabs">
+        <button class="type-tab" type="button" data-menu-type="product">Товары</button>
+        <button class="type-tab" type="button" data-menu-type="masterclass">Мастер-классы</button>
+      </div>
+    </div>
+    <div class="nav-divider"></div>
+    <div class="sidebar-section">
       <div class="sidebar-title">Категории</div>
       <div id="nav-menu" class="category-list"></div>
     </div>
@@ -136,6 +144,34 @@
 
 <div class="app-sidebar-overlay"></div>
 <div id="toast-container"></div>
+
+<div class="item-modal-overlay" id="item-modal-overlay"></div>
+<div class="item-modal" id="item-modal" role="dialog" aria-modal="true" aria-hidden="true">
+  <div class="item-modal__header">
+    <span class="tag" id="item-modal-stock"></span>
+    <button class="item-modal__close" type="button" id="item-modal-close" aria-label="Закрыть">✕</button>
+  </div>
+  <div class="item-modal__content">
+    <div class="item-modal__media">
+      <img id="item-modal-image" alt="Фото товара" />
+    </div>
+    <div class="item-modal__details">
+      <p class="muted" id="item-modal-category"></p>
+      <h2 id="item-modal-title"></h2>
+      <p class="muted" id="item-modal-subtitle"></p>
+      <div class="price" id="item-modal-price"></div>
+      <p class="catalog-card-description" id="item-modal-description"></p>
+      <div class="item-modal__actions">
+        <div class="qty-control">
+          <button type="button" class="qty-btn" id="item-modal-minus">−</button>
+          <span class="qty-value" id="item-modal-qty">1</span>
+          <button type="button" class="qty-btn" id="item-modal-plus">+</button>
+        </div>
+        <button class="btn" type="button" id="item-modal-add">В корзину</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <script type="module" src="/js/site_app.js?v=20251220"></script>
 </body>

--- a/webapp/js/site_api.js
+++ b/webapp/js/site_api.js
@@ -56,8 +56,8 @@ export async function requestWithStatus(path, params = null) {
   return { payload, status, statusText, url: url.toString() };
 }
 
-export function fetchMenu() {
-  return request('/api/public/menu');
+export function fetchMenu(type = null) {
+  return request('/api/public/menu/tree', { type });
 }
 
 export function fetchSiteSettings() {
@@ -68,10 +68,18 @@ export function fetchCategories() {
   return request('/api/public/menu/categories');
 }
 
-export function fetchCategoryItems(category) {
-  return request('/api/public/menu/items', { category_slug: category });
+export function fetchCategoryItems(category, type = null) {
+  return request('/api/public/menu/items', { category_slug: category, type });
 }
 
 export function fetchBlocks(page) {
   return request('/api/public/blocks', { page });
+}
+
+export function fetchCategoryDetails(slug, type = null) {
+  return request(`/api/public/menu/category/${slug}`, { type });
+}
+
+export function fetchItemById(itemId) {
+  return request(`/api/public/item/${itemId}`);
 }


### PR DESCRIPTION
### Motivation
- Provide iiko-like UX: open item as a modal with deep-link (`/i/<id>`) and restore back/close behavior (X/ESC/overlay/history).
- Separate content into two branches (products vs masterclasses) via `category.type` and `item.type` and support nested categories (parent/children).
- Enforce stock awareness so items with `stock_qty == 0` disable add-to-cart and qty controls, and optionally cap additions to `stock_qty`.
- Give admins easy access to public links (open/copy) for categories and items from AdminSite.

### Description
- DB & models: added `menu_categories.type` (ENUM-like check), `menu_categories.parent_id`, `menu_items.stock_qty`, indexes and constraints, and updated `init_db()` to add columns/indexes and set defaults via ALTER statements (`database.py`, `models/__init__.py`).
- Catalog & API: extended `services/menu_catalog.py` to support category `type`, nested category tree, `stock_qty` in serialized items, and added tree endpoints and item-by-id endpoint; exposed new public endpoints `/public/menu/tree`, `/api/public/menu/tree`, and `/api/public/item/{id}` and added `type` filters to existing menu endpoints (`webapi.py`, `services/menu_catalog.py`).
- AdminSite UI/API: updated admin payload schemas and AdminSite constructor UI to set `type`/`parent_id` for categories and `stock_qty` for items, show computed `public_url` for categories/items and add Open/Copy actions (`webapi.py`, `admin_panel/adminsite/static/adminsite/constructor.js`).
- Webapp & cart logic: implemented product/masterclass tabs, nested sidebar tree, item modal UI with history `pushState`/deep-link behavior and overlay close, stock-aware buttons/qty controls, and enforced stock limits when adding to cart via `services/cart.py` and `webapp/js/site_app.js`/`webapp/js/site_api.js`/`webapp/css/theme.css`/`webapp/index.html`.

### Testing
- Launched a local static server (`python -m http.server 8000` in `webapp/`) and captured a Playwright screenshot of `/index.html` to verify layout/tabs/modal UI (screenshot completed successfully).
- No unit/integration test suite was added or executed for the new API logic in this rollout.
- Existing FastAPI validation behavior (returning 422 for validation errors) remains in place and covers API payload validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961468c04d08326a6e340e46df67d69)