### PR TITLE
WebApp: make 'Заказ отправлен' modal one-shot (sessionStorage + URL cleanup)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,6 +3,7 @@ MiniDeN — Telegram-бот и веб-магазин
 
 Changelog / История изменений
 -----------------------------
+- 2026-06-XX: WebApp success-модалка «Заказ отправлен» стала одноразовой: флаг хранится в sessionStorage (ключ `webapp_checkout_success`, TTL 10 минут), после показа/закрытия помечается как consumed и не всплывает при обновлениях; при наличии query-параметра success/order_sent он удаляется из URL без перезагрузки.
 - 2026-06-XX: WebApp получил фиксированную cart bar (кол-во, сумма, кнопки «Корзина»/«Оформить»). Кнопка «Оформить» шлёт содержимое корзины в Telegram через событие `webapp_checkout_created` и отправляет пользователю сообщение с кнопками. Добавлен endpoint `/api/public/checkout/from-webapp` и таблица `checkout_orders`.
 - 2026-06-XX: Карточки витрины получили iiko-like hover/focus: при наведении/фокусе карточка поднимается, описание и кнопка «В корзину» появляются без изменения высоты сетки; на touch-устройствах описание и кнопка видны всегда. Кнопка «В корзину» отключается при stock_qty=0, показывается бейдж «Нет в наличии».
 - 2026-06-XX: WebApp витрина приведена к iiko-like layout: единый контейнер, sticky header, фиксированный sidebar и отдельный скролл для main/sidebar; карточки и кнопки приведены к единой сетке и design tokens.
@@ -37,6 +38,7 @@ WebApp checkout → Telegram (adminbot)
 -------------------------------------
 - Витрина берёт `tg_user_id` из `Telegram.WebApp.initDataUnsafe.user.id` и показывает кнопку «Оформить» только для Telegram WebApp.
 - По клику «Оформить» отправляется `POST /api/public/checkout/from-webapp` с items/totals и клиентским контекстом.
+- Success-модалка «Заказ отправлен» показывается один раз: состояние фиксируется в `sessionStorage` (ключ `webapp_checkout_success`) с TTL 10 минут и пометкой consumed после показа/закрытия; при наличии `?success=1`/`?order_sent=1` параметр удаляется через `history.replaceState`.
 - Backend сохраняет запись в `checkout_orders` и диспатчит событие `webapp_checkout_created`.
 - Событие использует `bot_event_triggers` (дефолтный триггер создаётся при `init_db`) и отправляет пользователю сообщение со списком позиций и inline-кнопками («Связаться», «Открыть витрину»).
 - Обработчик inline-кнопки «Связаться» принимает callback `trigger:contact_manager` (см. `handlers/support.py`).


### PR DESCRIPTION
### Motivation
- The checkout success modal "Заказ отправлен" was reappearing after refresh/navigation, indicating the success flag persisted or was re-read on page load.
- Ensure the success modal is shown only once per checkout and that closing or opening the bot consumes the state so it does not reappear on F5 or navigating back.
- If a query flag (e.g. `?success=1` / `?order_sent=1`) is used to trigger the modal, remove it from the URL after first show to avoid repeated triggers.

### Description
- Added a sessionStorage-based one-shot state with key `webapp_checkout_success` and TTL 10 minutes, implemented helpers: `readCheckoutSuccessState`, `writeCheckoutSuccessState`, `recordCheckoutSuccess`, `consumeCheckoutSuccess`, `dismissCheckoutSuccess`, `restoreCheckoutSuccess` and `handleCheckoutSuccessFromUrl` to manage lifecycle and marking as `consumed`.
- On successful `POST /api/public/checkout/from-webapp` the code now records the order id into sessionStorage, shows the modal, and ensures the state is consumed after display/interaction; close and open-bot actions call `dismissCheckoutSuccess()` to hide and consume the state.
- If a URL query flag is present (keys checked: `success`, `order_sent`, `orderSent`, `checkout_success`), the param is removed via `history.replaceState` and the success is recorded and consumed so it won't re-trigger on refresh/back.
- Changed files: `webapp/js/site_app.js` (added storage+handlers + restore on bootstrap and consumption on close/open-bot) and `README.txt` (changelog entry documenting storage key, TTL and URL cleanup).
- How to verify (manual acceptance steps): make an order → modal appears; click `Закрыть` → modal hides and remains hidden after F5; click `Открыть бот` → Telegram opens and modal does not reappear; opening the site with `?success=1` shows the modal once and removes the query param without reload.

### Testing
- Automated tests: none were run as part of this change (no test suite modifications).
- README updated: Yes — changelog entry describing the `sessionStorage` key `webapp_checkout_success`, TTL (10 minutes) and URL param cleanup was added to `README.txt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d8cc63fc832685a180fb992af03c)