### PR TITLE
Fix hidden checkout success modal display

### DIFF
--- a/webapp/css/theme.css
+++ b/webapp/css/theme.css
@@ -771,6 +771,10 @@ button.btn:disabled {
   color: var(--color-text-secondary);
 }
 
+[hidden] {
+  display: none !important;
+}
+
 .hidden {
   display: none !important;
 }


### PR DESCRIPTION
### Motivation

- На сайтах модалка «Заказ отправлен» отображалась постоянно, потому что элементы полагались на атрибут `hidden`, а глобальное CSS‑правило для `[hidden]` отсутствовало.  
- Нужно, чтобы success‑модалка появлялась только после успешного вызова `POST /api/public/checkout/from-webapp` и могла скрываться кликом по кнопке/фону.  
- Исправление должно быть минимальным и не менять архитектуру проекта.

### Description

- Добавлено правило CSS ` [hidden] { display: none !important; }` в файл `webapp/css/theme.css`, чтобы элементы с атрибутом `hidden` были действительно скрыты.  
- Изменение локально и минимально: модифицирован только `webapp/css/theme.css`, новые файлы не создавались.  
- Как проверить: откройте любую страницу — модалка «Заказ отправлен» не должна отображаться; добавьте товары и нажмите `Оформить` — модалка должна появиться; нажмите `Закрыть` или кликните по фону — модалка должна скрыться; при перезагрузке модалка не восстанавливается.  
- Изменённые файлы: `webapp/css/theme.css`.

### Testing

- Попытка автоматизированной проверки через Playwright (запуск headless браузера и скриншот) была выполнена, но завершилась ошибкой процесса браузера (SIGSEGV) и не дала скриншота.  
- Юнит/интеграционные автоматические тесты не запускались в этой правке.  
- Изменение носит визуальный характер; рекомендуется вручную проверить отображение модалки в браузере на страницах `index.html` и в процессе оформления заказа.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650cbf2c70832690285b6f2049f722)