### PR TITLE
Fix adminbot automation edit 500

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1026,6 +1026,15 @@ Front reset: theme-only + constructor-driven site
 - Восстановлена обработка OPEN_NODE: кнопки CONTACT/ABOUT с payload вида `OPEN_NODE CONTACT` корректно открывают узлы и логируют причины ошибок.
 - Исправлена зависимость DB для AdminSite API: в FastAPI используется `Depends(get_db)` (yield Session), а `database.get_session()` остаётся контекстным менеджером.
 
+## Фикс: Automations Edit 500
+- Что было: `/adminbot/automations/{id}/edit` отдавал 500 Internal Server Error при открытии страницы редактирования.
+- Что сделано: исправлен backend endpoint для edit (добавлены payload пресетов, 404 для отсутствующего правила, логирование загрузки/ошибок), добавлены безопасные сообщения об отсутствии правила.
+- Как проверить:
+  1. Откройте `/adminbot/automations`.
+  2. Нажмите «Редактировать» у правила — страница должна открыться без 500.
+  3. Откройте несуществующий ID (например `/adminbot/automations/999999/edit`) — должна появиться страница с текстом «Правило не найдено» (HTTP 404).
+- Где смотреть логи при проблемах: `admin_panel/routes/adminbot_automations.py`, обработчики `/adminbot/automations/{id}/edit` (GET/POST) пишут info-логи с `rule_id`.
+
 Важно: AdminSite / Версии / Кэш
 - Публичный эндпоинт `/api/site/home` должен отдавать заголовок Cache-Control: no-store (плюс совместимый Pragma: no-cache).
 - Админские эндпоинты сохранения/публикации страниц возвращают updatedAt/version, чтобы фронт мог отличать свежий ответ.

--- a/admin_panel/templates/adminbot_automation_edit.html
+++ b/admin_panel/templates/adminbot_automation_edit.html
@@ -38,9 +38,18 @@
     <a href="/adminbot/logs" class="button">Логи</a>
     <a href="/adminbot/logout" class="button" style="background:#dc2626;">Выйти</a>
 </header>
-<h2>{% if rule %}Редактирование правила{% else %}Новое правило{% endif %}</h2>
+<h2>
+    {% if missing_rule %}
+        Правило не найдено
+    {% elif rule %}
+        Редактирование правила
+    {% else %}
+        Новое правило
+    {% endif %}
+</h2>
 <div class="error" style="display:{% if error %}block{% else %}none{% endif %};">{{ error }}</div>
 
+{% if not missing_rule %}
 {% set initial_actions = form.actions if form else (rule.actions_json if rule and rule.actions_json else []) %}
 <form method="post" action="{% if rule %}/adminbot/automations/{{ rule.id }}/edit{% else %}/adminbot/automations/new{% endif %}">
     <div class="step">
@@ -393,5 +402,10 @@
         }
     });
 </script>
+{% else %}
+<div class="actions">
+    <a href="/adminbot/automations" class="button" style="background:#6b7280;">Назад к списку</a>
+</div>
+{% endif %}
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The edit page for automations (`/adminbot/automations/{id}/edit`) raised an Internal Server Error when a rule or its payload were missing, so the endpoint must return an HTML page with a clear status (404) and not crash.
- The UI/template expected `presets_payload` and other data to be present and the backend had to supply safe defaults and logging to diagnose issues without touching secrets or architecture.

### Description
- Added logging and defensive handling in `admin_panel/routes/adminbot_automations.py` so GET/POST edit handlers log the request, return a safe `TemplateResponse` with `missing_rule=True` and HTTP 404 when a rule is not found, and include `presets_payload` for the template. 
- Converted validation error responses from status `400` to `422` and added info logs for validation failures to avoid 500s on bad data. 
- Updated `admin_panel/templates/adminbot_automation_edit.html` so the template shows a friendly "Правило не найдено" page when `missing_rule` is set and avoids rendering the edit form and scripts in that case. 
- Added a regression test `test_automation_edit_missing_rule_returns_404` in `tests/test_static_uploads.py` and appended documentation about the fix to `README.txt`.

### Testing
- Ran the new test `pytest tests/test_static_uploads.py::test_automation_edit_missing_rule_returns_404` and it passed (1 passed). 
- Files changed: `admin_panel/routes/adminbot_automations.py`, `admin_panel/templates/adminbot_automation_edit.html`, `tests/test_static_uploads.py`, `README.txt`.
- How to verify manually: 1) Open `GET /adminbot/automations` and click "Редактировать" on an existing rule — the edit form should open without a 500; 2) Open a non-existent rule like `GET /adminbot/automations/999999/edit` — the page should render "Правило не найдено" and return HTTP 404; 3) Check application logs for `admin_panel/routes/adminbot_automations.py` info messages containing the `rule_id` for diagnostics.
- README updated: `README.txt` now contains a `## Фикс: Automations Edit 500` section describing the problem, the fix steps, how to verify and where to look at logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a2432c0b88326aa526de2db8ec8c6)