### PR TITLE
Update AdminSite constructor navigation to use type query

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,6 +7,16 @@ UI Upgrade витрины
 - Карточки товаров приведены к единой стабильной сетке с фиксированной высотой изображения и аккуратными hover-эффектами.
 - Подправлены header, боковая навигация и нижняя корзина для более компактной и ровной компоновки.
 
+AdminSite Task1: меню + type в URL
+---------------------------------
+- Изменённые файлы:
+  - admin_panel/adminsite/templates/base_adminsite.html
+  - admin_panel/adminsite/static/adminsite/constructor.js
+- Как проверить:
+  1. Открыть `/adminsite/constructor`.
+  2. Нажать в верхнем меню «Товары», «Мастер-классы» или «Курсы».
+  3. Убедиться, что URL меняется на `/adminsite/constructor?type=products|masterclasses|courses`, а список категорий перезагружается.
+
 Changelog / История изменений
 -----------------------------
 - 2026-06-XX: Корзина WebApp переведена на единое хранение в БД: браузер использует cookie `cart_session_id`, Telegram WebApp проходит серверную auth через `initData` и использует `tg_user_id`, маршруты `/api/cart*` больше не зависят от localStorage; кнопки корзины ведут на `/cart.html`.

--- a/admin_panel/adminsite/templates/base_adminsite.html
+++ b/admin_panel/adminsite/templates/base_adminsite.html
@@ -27,10 +27,10 @@
 </header>
 {% if user %}
 <nav class="adminsite-subnav" aria-label="Разделы AdminSite">
-    <a href="/adminsite/constructor?section=products">Товары</a>
+    <a href="/adminsite/constructor?type=products">Товары</a>
     <a href="/adminsite/constructor?section=categories">Категории</a>
-    <a href="/adminsite/constructor?section=courses">Курсы</a>
-    <a href="/adminsite/constructor?section=masterclasses">Мастер-классы</a>
+    <a href="/adminsite/constructor?type=courses">Курсы</a>
+    <a href="/adminsite/constructor?type=masterclasses">Мастер-классы</a>
     <a href="/adminsite/constructor?section=home">Главная</a>
     <a class="subnav-secondary" href="/adminsite/constructor?section=menu">Меню витрины</a>
 </nav>


### PR DESCRIPTION
### Motivation
- Fix top adminsite subnav so each section (Товары/Мастер-классы/Курсы) navigates to the single constructor page with a distinct `type` query so UI can switch contexts.
- Have the constructor UI read `type` from the URL and react to changes by clearing selection and reloading categories so switching types doesn't leave stale state.
- Prepare category/item requests to carry the `type` parameter so the UI is ready for backend filtering when supported.

### Description
- Updated `admin_panel/adminsite/templates/base_adminsite.html` to use `?type=products|courses|masterclasses` for the corresponding top menu links instead of `?section=...` for those entries.
- Extended `admin_panel/adminsite/static/adminsite/constructor.js` to parse `type` from the URL, added `activeUrlType`, `URL_TYPE_CONFIG`, `resolveUrlType`, `getUrlTypeConfig`, `resetMenuState`, and logic in `applySectionFromUrl` to detect type changes and reset state.
- Modified category loading in the constructor to include `?type=...` when calling `GET /api/admin/menu/categories`, and ensured `loadItems` continues to send `type` for item loads when relevant.
- Added a `popstate` handler so browser navigation (back/forward) that changes `type` triggers a reload of categories, and documented the changes in `README.txt` under "AdminSite Task1: меню + type в URL".

### Testing
- No automated tests were executed as part of this change.
- Manual verification steps are documented in `README.txt` and can be used to smoke-check the UX behavior (open `/adminsite/constructor`, click top menu items and observe URL and list reload).
- Static checks: repository files were committed and no runtime tests were run; please run the project locally and exercise the constructor to validate integration with backend filtering.
- If you want automated coverage, run the project test suite with `pytest` and/or start the webapp and check the network calls for `/api/admin/menu/categories?type=...`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b31e04e3883268a00e5d7e2e1dc0f)