### PR TITLE
AdminSite: preserve category/item type in create/edit and filter categories by type

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -31,6 +31,17 @@ AdminSite Task2: API type фильтр
   - admin_panel/adminsite/router.py
   - admin_panel/adminsite/service.py
 
+AdminSite Task3: сохранение type в create/edit
+---------------------------------------------
+- Изменённые файлы:
+  - admin_panel/adminsite/static/adminsite/constructor.js
+  - webapi.py
+- Как проверить:
+  1. Открыть `/adminsite/constructor?type=masterclasses`.
+  2. Создать категорию и убедиться, что после обновления страницы она остаётся в мастер-классах.
+  3. Перейти на `/adminsite/constructor?type=products` и убедиться, что категория не отображается.
+  4. Создать категорию в продуктах и проверить, что она не появляется в мастер-классах.
+
 Changelog / История изменений
 -----------------------------
 - 2026-06-XX: Корзина WebApp переведена на единое хранение в БД: браузер использует cookie `cart_session_id`, Telegram WebApp проходит серверную auth через `initData` и использует `tg_user_id`, маршруты `/api/cart*` больше не зависят от localStorage; кнопки корзины ведут на `/cart.html`.

--- a/admin_panel/adminsite/static/adminsite/constructor.js
+++ b/admin_panel/adminsite/static/adminsite/constructor.js
@@ -580,7 +580,8 @@ async function reorderItem(index, delta) {
 
 async function loadCategories() {
   try {
-    const typeParam = activeUrlType ? `?type=${encodeURIComponent(activeUrlType)}` : '';
+    const typeValue = activeItemType || '';
+    const typeParam = typeValue ? `?type=${encodeURIComponent(typeValue)}` : '';
     const response = await apiRequest(`${API_MENU_CATEGORIES}${typeParam}`, { method: 'GET' });
     categories = response.items || [];
     if (selectedCategory) {

--- a/webapi.py
+++ b/webapi.py
@@ -3211,16 +3211,22 @@ def _build_public_link(base_url: str | None, path: str) -> str:
 def admin_menu_categories(
     request: Request,
     include_inactive: bool = True,
+    type: str | None = None,
     db: Session = Depends(get_db),
 ):
     adminsite_service.ensure_admin(request, db)
     base_url = _resolve_public_base_url()
-    categories = menu_catalog.list_categories(include_inactive=include_inactive)
-    for category in categories:
-        category["public_url"] = _build_public_link(
-            base_url, f"/c/{category.get('slug')}"
+    try:
+        categories = menu_catalog.list_categories(
+            include_inactive=include_inactive, category_type=type
         )
-    return {"items": categories}
+        for category in categories:
+            category["public_url"] = _build_public_link(
+                base_url, f"/c/{category.get('slug')}"
+            )
+        return {"items": categories}
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
 
 
 @app.post("/api/admin/menu/categories")


### PR DESCRIPTION
### Motivation
- Categories must be scoped by their `type` so categories created in `masterclasses` don't appear in `products` and vice versa.
- The AdminSite UI should send the current type context when requesting or creating categories to ensure created entries are stored under the correct type.
- API should accept a `type` query parameter for admin category listing and validate unknown values with `422`.

### Description
- Updated the AdminSite constructor to include the active item type when loading categories by sending `?type=...` in `loadCategories` in `admin_panel/adminsite/static/adminsite/constructor.js`.
- Extended the admin endpoint `GET /api/admin/menu/categories` in `webapi.py` to accept `type` and forward it to `menu_catalog.list_categories`, returning `422` on invalid values.
- Documented the Task3 verification steps and modified files in `README.txt` under the new section `AdminSite Task3: сохранение type в create/edit`.

### Testing
- No automated tests were executed for this change.
- Manual verification steps were added to `README.txt` and can be used to smoke-test the behavior by creating categories under `/adminsite/constructor?type=masterclasses` and `/adminsite/constructor?type=products` to confirm separation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b3430e3d88326b6469d33984c5cab)