### PR TITLE
AdminSite: preview button, preserve draft/published state, fix modal backdrop and preserve ?type in links

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -42,6 +42,25 @@ AdminSite Task3: сохранение type в create/edit
   3. Перейти на `/adminsite/constructor?type=products` и убедиться, что категория не отображается.
   4. Создать категорию в продуктах и проверить, что она не появляется в мастер-классах.
 
+AdminSite: черновики, типы контента и предпросмотр
+-------------------------------------------------
+- Черновики страниц:
+  - `PUT /api/adminsite/pages/{pageKey}` сохраняет изменения в draft (public-версия не меняется).
+  - `POST /api/adminsite/pages/{pageKey}/publish` копирует draft → published и публикует страницу.
+  - Статус можно проверить через `GET /api/adminsite/health/page/{pageKey}` (флаг `hasUnpublishedChanges`).
+- Переключение типов контента в AdminSite:
+  - Тип задаётся параметром `?type=` (`products`, `masterclasses`, `courses`) и влияет на фильтр категорий/позиций.
+  - При переходе в соседние разделы (`Категории`, `Главная`, `Меню витрины`) активный `type` сохраняется в URL.
+- Предпросмотр:
+  - В разделе «Главная/настройки» есть кнопка «Предпросмотр» — открывает витрину в новой вкладке.
+  - Если есть несохранённые изменения или неопубликованные черновики, показывается предупреждение, что предпросмотр
+    откроет опубликованную версию.
+- Изменённые файлы:
+  - admin_panel/adminsite/templates/constructor.html
+  - admin_panel/adminsite/static/adminsite/constructor.js
+  - admin_panel/adminsite/static/adminsite/modals.js
+  - services/adminsite_pages.py
+
 Changelog / История изменений
 -----------------------------
 - 2026-06-XX: Корзина WebApp переведена на единое хранение в БД: браузер использует cookie `cart_session_id`, Telegram WebApp проходит серверную auth через `initData` и использует `tg_user_id`, маршруты `/api/cart*` больше не зависят от localStorage; кнопки корзины ведут на `/cart.html`.

--- a/admin_panel/adminsite/static/adminsite/modals.js
+++ b/admin_panel/adminsite/static/adminsite/modals.js
@@ -57,6 +57,7 @@ export class BaseModal {
         if (this.isOpen) return;
         this.isOpen = true;
         this.backdrop.hidden = false;
+        this.backdrop.style.pointerEvents = "auto";
         document.addEventListener('keydown', this.handleEscape);
     }
 
@@ -64,6 +65,7 @@ export class BaseModal {
         if (!this.isOpen) return;
         this.isOpen = false;
         this.backdrop.hidden = true;
+        this.backdrop.style.pointerEvents = "none";
         this.showMessage('');
         document.removeEventListener('keydown', this.handleEscape);
         if (typeof this.reset === 'function') {

--- a/admin_panel/adminsite/templates/constructor.html
+++ b/admin_panel/adminsite/templates/constructor.html
@@ -72,6 +72,7 @@
                 <p class="muted">Бренд, цвета, контакты и hero блок для витрины.</p>
             </div>
             <div class="actions">
+                <button class="btn-secondary" type="button" id="settings-preview">Предпросмотр</button>
                 <button class="btn-primary" type="button" id="settings-save">Сохранить</button>
             </div>
         </div>

--- a/services/adminsite_pages.py
+++ b/services/adminsite_pages.py
@@ -270,10 +270,14 @@ def update_page(payload: dict[str, Any], slug: str = DEFAULT_SLUG) -> dict[str, 
             else:
                 page.template_id = data.template_id or DEFAULT_TEMPLATE_ID
                 existing_blocks = page.blocks if isinstance(page.blocks, dict) else {}
-                published_state = existing_blocks.get("published") if isinstance(existing_blocks, dict) else None
+                published_state = (
+                    existing_blocks.get("published")
+                    if "published" in existing_blocks
+                    else None
+                )
                 page.blocks = {
                     "draft": draft_state,
-                    "published": published_state or draft_state,
+                    "published": published_state if published_state is not None else draft_state,
                 }
                 page.theme = {"draft": draft_theme, "published": published_theme}
                 page.updated_at = datetime.utcnow()


### PR DESCRIPTION
### Motivation
- Improve AdminSite authoring UX by adding a preview action for site settings while warning about unsaved drafts and unpublished changes.
- Prevent drafts saved via constructor from accidentally overwriting the published page state unless explicitly published.
- Fix a UI bug where modal backdrops could remain interactive and block clicks after closing.
- Ensure content-type (`?type=products|masterclasses|courses`) is preserved when navigating AdminSite subnav links so filtering stays stable.

### Description
- Added a "Предпросмотр" button to the settings panel in `constructor.html` and wired it to frontend logic to open the public site in a new tab with cache-bust and preview flags in `constructor.js`.
- Implemented settings snapshot/unsaved-change detection and a draft/unpublished warning flow before opening preview in `constructor.js` and added safe preview URL resolution using `base_url` from site settings.
- Updated frontend to propagate the active `type` into AdminSite subnav links so navigation preserves the selected content type in `constructor.js`.
- Hardened modal behavior by toggling `pointer-events` on modal backdrops when opening/closing to avoid "stuck overlay" that blocks clicks in `modals.js`.
- Changed server-side draft save logic in `services/adminsite_pages.py` to preserve an existing `published` state when updating `draft` (do not clobber published unless publish is called).
- Documented the draft/publish contract, type-switching behavior and preview usage in `README.txt`.

### Testing
- Bootstrapped a static preview of the constructor template using `python -m http.server 8000` and verified the new preview button renders; the static server started successfully.
- Captured a visual smoke-check screenshot of the constructor page with Playwright to confirm the new button/layout; the screenshot run completed successfully and produced an artifact.
- No unit or integration test suite was run as part of this change.

Changed files
- `admin_panel/adminsite/templates/constructor.html` — added "Предпросмотр" button to settings header.
- `admin_panel/adminsite/static/adminsite/constructor.js` — added preview handling, unsaved-settings snapshot, health check for unpublished changes, and subnav `?type` persistence.
- `admin_panel/adminsite/static/adminsite/modals.js` — ensure modal backdrop releases pointer events after close to avoid blocking clicks.
- `services/adminsite_pages.py` — preserve published page state when saving drafts (do not overwrite published unless publishing explicitly).
- `README.txt` — documented drafts/publish flow, type switching and preview usage.

What changed (short)
- Preview UX + warnings for settings; `type` preserved across AdminSite subnav; modals no longer leave blocking backdrops; draft saves no longer overwrite published content; README updated.

How to verify (steps)
1. Open `/adminsite/constructor?type=masterclasses` and navigate between "Товары/Категории/Курсы/Мастер-классы/Главная" to confirm `?type=` is preserved in URLs and filters reload accordingly.
2. Go to "Главная/настройки", modify a setting, click "Предпросмотр" and confirm the warning appears if changes are unsaved and the preview opens a new tab with `admin_preview=1`+cache-bust when confirmed.
3. Save settings and repeat preview; confirm no warning and preview opens.
4. Edit a page via `PUT /api/adminsite/pages/home` to create a draft and verify `GET /api/adminsite/health/page/home` shows `hasUnpublishedChanges=true`, then call `POST /api/adminsite/pages/home/publish` and confirm published state updates.

README.txt updated
- Yes — added a section describing draft/publish semantics, content-type switching behavior in AdminSite and how the preview button behaves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bde7b7dc883269d36b57e9b935cb2)