### PR TITLE
API: Telegram WebApp initData → JWT login

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1271,3 +1271,36 @@ API endpoint: POST /api/public/checkout/from-webapp
   { "ok": true, "order_id": 42, "message": "sent" }
 
 Deprecated: `POST /api/webapp/order` возвращает 410 и заменён на `/api/public/checkout/from-webapp`.
+
+Telegram WebApp initData login -> JWT
+------------------------------------
+- Новый endpoint: `POST /api/auth/telegram-webapp`.
+- Запрос:
+  ```json
+  { "initData": "<Telegram.WebApp.initData>" }
+  ```
+- Что делает backend:
+  1. Валидирует подпись `initData` по алгоритму Telegram WebApp через `BOT_TOKEN`.
+  2. Извлекает пользователя (`telegram_id`, `first_name`, `username`).
+  3. Создаёт или обновляет запись в `users` по `telegram_id`.
+  4. Возвращает JWT `access_token` с payload: `user_id`, `telegram_id`, `iat`, `exp`.
+- Ответ:
+  ```json
+  {
+    "access_token": "<jwt>",
+    "token_type": "bearer",
+    "user": {
+      "id": 1,
+      "telegram_id": 123456789,
+      "username": "demo",
+      "first_name": "Demo",
+      "last_name": null
+    }
+  }
+  ```
+- Для проверки токена добавлен `GET /api/auth/me` (ожидает заголовок `Authorization: Bearer <jwt>`).
+
+Важно про секреты
+-----------------
+- `BOT_TOKEN` и `JWT_SECRET` не хранятся в базе данных.
+- `JWT_SECRET` нужно задать вручную в окружении сервера (например, через systemd/секреты деплоя).

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+from fastapi import HTTPException
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from utils.jwt_auth import create_access_token, decode_access_token
+
+
+@pytest.fixture(autouse=True)
+def _set_jwt_secret(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+
+
+def test_create_and_decode_access_token_roundtrip():
+    token = create_access_token(user_id=123, telegram_id=456, ttl_seconds=60)
+    payload = decode_access_token(token)
+
+    assert payload["user_id"] == 123
+    assert payload["telegram_id"] == 456
+    assert payload["exp"] >= payload["iat"]
+
+
+def test_decode_access_token_rejects_tampered_token():
+    token = create_access_token(user_id=1, telegram_id=2, ttl_seconds=60)
+    tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
+
+    with pytest.raises(HTTPException) as exc_info:
+        decode_access_token(tampered)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "token_invalid"

--- a/utils/jwt_auth.py
+++ b/utils/jwt_auth.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from typing import Any
+
+from fastapi import Depends, Header, HTTPException, status
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import User
+
+ALGORITHM = "HS256"
+ACCESS_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 7
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _get_jwt_secret() -> str:
+    secret = os.getenv("JWT_SECRET", "").strip()
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="jwt_secret_missing",
+        )
+    return secret
+
+
+def _sign(signing_input: str, secret: str) -> str:
+    signature = hmac.new(secret.encode("utf-8"), signing_input.encode("utf-8"), hashlib.sha256)
+    return _b64url_encode(signature.digest())
+
+
+def create_access_token(
+    *,
+    user_id: int,
+    telegram_id: int,
+    ttl_seconds: int = ACCESS_TOKEN_TTL_SECONDS,
+) -> str:
+    if ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be positive")
+
+    secret = _get_jwt_secret()
+    now = int(time.time())
+    payload: dict[str, Any] = {
+        "user_id": int(user_id),
+        "telegram_id": int(telegram_id),
+        "iat": now,
+        "exp": now + int(ttl_seconds),
+    }
+
+    header_segment = _b64url_encode(json.dumps({"alg": ALGORITHM, "typ": "JWT"}, separators=(",", ":")).encode("utf-8"))
+    payload_segment = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_segment}.{payload_segment}"
+    signature_segment = _sign(signing_input, secret)
+    return f"{signing_input}.{signature_segment}"
+
+
+def decode_access_token(token: str) -> dict[str, Any]:
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_missing")
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_invalid")
+
+    header_segment, payload_segment, signature_segment = parts
+    secret = _get_jwt_secret()
+    expected_signature = _sign(f"{header_segment}.{payload_segment}", secret)
+    if not hmac.compare_digest(expected_signature, signature_segment):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_invalid")
+
+    try:
+        header = json.loads(_b64url_decode(header_segment))
+        payload = json.loads(_b64url_decode(payload_segment))
+    except (ValueError, json.JSONDecodeError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_invalid")
+
+    if header.get("alg") != ALGORITHM:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_invalid")
+
+    exp_raw = payload.get("exp")
+    try:
+        exp = int(exp_raw)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_invalid")
+
+    if exp < int(time.time()):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_expired")
+
+    return payload
+
+
+def _extract_bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_missing")
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_invalid")
+
+    return token.strip()
+
+
+def get_current_user_from_token(
+    authorization: str | None = Header(default=None, alias="Authorization"),
+    db: Session = Depends(get_db),
+) -> User:
+    token = _extract_bearer_token(authorization)
+    payload = decode_access_token(token)
+
+    telegram_id_raw = payload.get("telegram_id")
+    try:
+        telegram_id = int(telegram_id_raw)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="token_invalid")
+
+    user = db.query(User).filter(User.telegram_id == telegram_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="user_not_found")
+
+    return user


### PR DESCRIPTION
### Motivation
- Добавить серверную авторизацию Telegram WebApp через `initData` и выдачу JWT, чтобы WebApp мог получать `access_token` для дальнейших защищённых запросов. 
- Сохранять `BOT_TOKEN`/`JWT_SECRET` в окружении, а не в БД, и не менять существующую схему `users` (поле `telegram_id` уже есть). 
- Обеспечить простую dependency для проверки токена, чтобы в будущем защищать корзину/заказы.

### Description
- Добавлен `utils/jwt_auth.py` с простым HS256 JWT (создание `create_access_token`, валидация `decode_access_token` и dependency `get_current_user_from_token`) использующий `JWT_SECRET` из окружения. 
- В `routes_auth.py` вынесена логика upsert пользователя из WebApp в `_upsert_user_from_webapp_data`, добавлена нормализация `initData` и Pydantic alias `initData`. 
- Добавлен новый endpoint `POST /api/auth/telegram-webapp` (принимает JSON `{ "initData": "..." }`), который валидирует подпись через `BOT_TOKEN`, создаёт/обновляет `users` по `telegram_id` и возвращает `access_token` + `user`; также добавлен `GET /api/auth/me` как минимальная проверка токена. 
- Обновлён `README.txt` с описанием нового потока и требованием вручную задать `JWT_SECRET`; добавлены unit-тесты `tests/test_jwt_auth.py` для round-trip и проверки на подделку токена.

### Testing
- Код скомпилирован через `python -m compileall utils routes_auth.py tests/test_jwt_auth.py` без ошибок. 
- Запущены unit-тесты `pytest tests/test_jwt_auth.py` и все тесты прошли успешно (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974838c742c8326939a74d7f0ab7bba)