### PR TITLE
Bot: open category buttons via /c/<slug> WebApp links

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -323,6 +323,9 @@ ReplyKeyboard-меню из конструктора AdminBot
 - Новый раздел `/adminbot/menu-buttons` позволяет создавать, редактировать и выключать кнопки нижней клавиатуры.
 - Поля кнопки: `text`, `action_type` (node/command/url/webapp), `action_payload`, `row`, `position`, `is_active`.
 - Бот на /start и «Меню» запрашивает активные `menu_buttons` и строит ReplyKeyboard по row/position. Если список пуст — показывает только кнопку «Меню».
+- Кнопки `Мои товары` / `Мои работы` / `Мои мастер-классы` принудительно открываются как WebApp-ссылки на `https://miniden.ru/c/<slug>?type=...`, даже если в конструкторе указан другой тип действия.
+- Slug’и для этих кнопок настраиваются через переменные окружения `BOT_PRODUCTS_CATEGORY_SLUG`, `BOT_WORKS_CATEGORY_SLUG`, `BOT_MASTERCLASSES_CATEGORY_SLUG` (по умолчанию: `korzinki`, `works`, `masterclasses`), домен — `BOT_BASE_ORIGIN` (по умолчанию `https://miniden.ru`).
+- Для deep-link на конкретную позицию можно использовать формат `https://miniden.ru/i/<id>?type=product`.
 - Для URL/WebApp бот отправляет сообщение с inline-кнопкой открытия ссылки.
 - В форме узла добавлен флаг «Очищать чат перед показом узла» (`clear_chat`): при включении бот пытается удалить предыдущие сообщения бота перед новым экраном (best effort).
 

--- a/config.py
+++ b/config.py
@@ -43,6 +43,10 @@ class Settings:
     webapp_cart_url: str | None = None
     webapp_profile_url: str | None = None
     webapp_admin_url: str | None = None
+    bot_base_origin: str = "https://miniden.ru"
+    bot_products_category_slug: str = "korzinki"
+    bot_works_category_slug: str = "works"
+    bot_masterclasses_category_slug: str = "masterclasses"
 
     # 🔹 Новые поля для проверки подписки на канал
     required_channel_id: int | str | None = None  # username без @ или -1001234567890
@@ -149,6 +153,10 @@ def get_settings() -> Settings:
     webapp_cart_url = os.getenv("WEBAPP_CART_URL") or None
     webapp_profile_url = os.getenv("WEBAPP_PROFILE_URL") or None
     webapp_admin_url = os.getenv("WEBAPP_ADMIN_URL") or None
+    bot_base_origin = (os.getenv("BOT_BASE_ORIGIN") or "https://miniden.ru").strip() or "https://miniden.ru"
+    bot_products_category_slug = (os.getenv("BOT_PRODUCTS_CATEGORY_SLUG") or "korzinki").strip() or "korzinki"
+    bot_works_category_slug = (os.getenv("BOT_WORKS_CATEGORY_SLUG") or "works").strip() or "works"
+    bot_masterclasses_category_slug = (os.getenv("BOT_MASTERCLASSES_CATEGORY_SLUG") or "masterclasses").strip() or "masterclasses"
 
     return Settings(
         bot_token=token,
@@ -168,4 +176,8 @@ def get_settings() -> Settings:
         webapp_cart_url=webapp_cart_url,
         webapp_profile_url=webapp_profile_url,
         webapp_admin_url=webapp_admin_url,
+        bot_base_origin=bot_base_origin.rstrip("/"),
+        bot_products_category_slug=bot_products_category_slug,
+        bot_works_category_slug=bot_works_category_slug,
+        bot_masterclasses_category_slug=bot_masterclasses_category_slug,
     )


### PR DESCRIPTION
### Motivation
- Make main menu buttons open the real storefront pages so users can jump from Telegram to the site category pages `/c/<slug>` (and deep-link items) using WebApp links tied to the bot user.

### Description
- Added new bot settings in `config.py`: `bot_base_origin`, `bot_products_category_slug`, `bot_works_category_slug`, and `bot_masterclasses_category_slug` loaded from `BOT_BASE_ORIGIN` / `BOT_*_CATEGORY_SLUG` environment variables with sensible defaults.
- Implemented URL-building and special-case logic in `keyboards/main_menu.py` to detect `Мои товары`, `Мои работы` and `Мои мастер-классы` (normalized case-insensitive matching) and force those reply buttons to become `WebApp` buttons that open `https://<BOT_BASE_ORIGIN>/c/<slug>?type=...`.
- Added small helpers `_normalize_button_text`, `_build_category_url`, and `_special_menu_webapp_url` and used `urlencode` to attach the `type` query parameter when needed.
- Updated `README.txt` to document the new bot URLs, default slugs, env variables and the deep-link format for items (`/i/<id>?type=product`).

### Testing
- Compiled modified modules with `python -m compileall config.py keyboards handlers` and the compilation completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69748606e85883269d849ccf8cdbe83f)