### PR TITLE
Auth v2: phone OTP (bot-delivered) + JWT and login_codes table

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -329,11 +329,11 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    telegram_id = Column(BigInteger, unique=True, nullable=False, index=True)
+    telegram_id = Column(BigInteger, unique=True, nullable=True, index=True)
     username = Column(String, nullable=True)
     first_name = Column(String, nullable=True)
     last_name = Column(String, nullable=True)
-    phone = Column(String, nullable=True)
+    phone = Column(String, unique=True, nullable=True, index=True)
     avatar_url = Column(Text, nullable=True)
     is_admin = Column(Boolean, default=False, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
@@ -554,6 +554,23 @@ class AuthSession(Base):
     token = Column(String, primary_key=True, index=True)
     telegram_id = Column(BigInteger, nullable=True, index=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class LoginCode(Base):
+    __tablename__ = "login_codes"
+
+    __table_args__ = (
+        Index("ix_login_codes_phone_created", "phone", "created_at"),
+    )
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    phone = Column(String(32), nullable=False, index=True)
+    code_hash = Column(String(128), nullable=False)
+    telegram_id = Column(BigInteger, nullable=True, index=True)
+    expires_at = Column(DateTime, nullable=False, index=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    used_at = Column(DateTime, nullable=True, index=True)
+    attempts = Column(Integer, nullable=False, default=0, server_default="0")
 
 
 class HomeBanner(Base):
@@ -857,6 +874,7 @@ __all__ = [
     "ProductReview",
     "PromoCode",
     "AuthSession",
+    "LoginCode",
     "ProductBasket",
     "ProductCourse",
     "UserBan",

--- a/services/users.py
+++ b/services/users.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import select
+from fastapi import HTTPException
+from sqlalchemy import select, or_
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from config import ADMIN_IDS_SET
 from database import get_session
 from initdb import init_db
 from models import User
+from utils.phone import normalize_phone
 
 
 def _extract_phone(data: dict[str, Any] | None) -> str | None:
@@ -17,7 +20,10 @@ def _extract_phone(data: dict[str, Any] | None) -> str | None:
         return None
     phone = data.get("phone") or data.get("phone_number")
     if phone:
-        return str(phone)
+        try:
+            return normalize_phone(str(phone))
+        except ValueError:
+            return None
     return None
 
 
@@ -40,12 +46,20 @@ def _get_or_create_user(
 ) -> User:
     is_admin_flag = telegram_id in ADMIN_IDS_SET
 
+    normalized_phone = None
+    if phone:
+        try:
+            normalized_phone = normalize_phone(phone)
+        except ValueError:
+            normalized_phone = None
+
     user = session.scalar(select(User).where(User.telegram_id == telegram_id))
     if user:
         user.username = username or user.username
         user.first_name = first_name or user.first_name
         user.last_name = last_name or user.last_name
-        user.phone = phone or user.phone
+        if normalized_phone:
+            user.phone = normalized_phone
         user.is_admin = is_admin_flag or user.is_admin
     else:
         user = User(
@@ -53,12 +67,87 @@ def _get_or_create_user(
             username=username,
             first_name=first_name,
             last_name=last_name,
-            phone=phone,
+            phone=normalized_phone,
             is_admin=is_admin_flag,
             created_at=datetime.utcnow(),
         )
         session.add(user)
         session.flush()
+    session.refresh(user)
+    return user
+
+
+def _merge_users(session: Session, target: User, source: User) -> User:
+    """Merge two user records, keeping the target user id."""
+
+    if source.id == target.id:
+        return target
+
+    if target.telegram_id is None and source.telegram_id is not None:
+        target.telegram_id = source.telegram_id
+    if not target.username and source.username:
+        target.username = source.username
+    if not target.first_name and source.first_name:
+        target.first_name = source.first_name
+    if not target.last_name and source.last_name:
+        target.last_name = source.last_name
+    if not target.phone and source.phone:
+        target.phone = source.phone
+    target.is_admin = target.is_admin or source.is_admin
+
+    session.delete(source)
+    session.flush()
+    session.refresh(target)
+    return target
+
+
+def get_or_create_user_by_phone(session: Session, phone: str) -> User:
+    """Find or create a user by normalized phone."""
+
+    normalized_phone = normalize_phone(phone)
+    user = session.scalar(select(User).where(User.phone == normalized_phone))
+    if user:
+        return user
+
+    user = User(phone=normalized_phone, created_at=datetime.utcnow())
+    session.add(user)
+    try:
+        session.flush()
+    except IntegrityError:
+        session.rollback()
+        user = session.scalar(select(User).where(User.phone == normalized_phone))
+        if not user:
+            raise
+    session.refresh(user)
+    return user
+
+
+def attach_telegram_id(
+    session: Session,
+    *,
+    user: User,
+    telegram_id: int,
+    username: str | None = None,
+    first_name: str | None = None,
+    last_name: str | None = None,
+) -> User:
+    """Attach a telegram_id to an existing user, merging duplicates if needed."""
+
+    telegram_id = int(telegram_id)
+    is_admin_flag = telegram_id in ADMIN_IDS_SET
+
+    other = session.scalar(select(User).where(User.telegram_id == telegram_id))
+    if other and other.id != user.id:
+        if other.phone and user.phone and other.phone != user.phone:
+            raise HTTPException(status_code=409, detail="telegram_id_conflict")
+        user = _merge_users(session, target=user, source=other)
+
+    user.telegram_id = telegram_id
+    user.username = username or user.username
+    user.first_name = first_name or user.first_name
+    user.last_name = last_name or user.last_name
+    user.is_admin = is_admin_flag or user.is_admin
+    session.flush()
     session.refresh(user)
     return user
 
@@ -112,7 +201,10 @@ def update_user_contact(telegram_id: int, phone: str | None) -> User:
         user = session.scalar(select(User).where(User.telegram_id == telegram_id))
         if not user:
             raise ValueError("User not found")
-        user.phone = phone
+        if phone:
+            user.phone = normalize_phone(phone)
+        else:
+            user.phone = None
         session.refresh(user)
         return user
 
@@ -121,6 +213,29 @@ def get_user_by_telegram_id(telegram_id: int) -> User | None:
     init_db()
     with get_session() as session:
         return session.scalar(select(User).where(User.telegram_id == telegram_id))
+
+
+def get_user_by_phone(phone: str) -> User | None:
+    init_db()
+    normalized_phone = normalize_phone(phone)
+    with get_session() as session:
+        return session.scalar(select(User).where(User.phone == normalized_phone))
+
+
+def get_user_by_phone_or_telegram(
+    session: Session,
+    *,
+    phone: str | None = None,
+    telegram_id: int | None = None,
+) -> User | None:
+    filters = []
+    if phone:
+        filters.append(User.phone == normalize_phone(phone))
+    if telegram_id is not None:
+        filters.append(User.telegram_id == int(telegram_id))
+    if not filters:
+        return None
+    return session.scalar(select(User).where(or_(*filters)))
 
 
 def is_admin(telegram_id: int) -> bool:

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -18,13 +18,21 @@ def _set_jwt_secret(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("JWT_SECRET", "test-secret")
 
 
-def test_create_and_decode_access_token_roundtrip():
+def test_create_and_decode_access_token_roundtrip_with_telegram_id():
     token = create_access_token(user_id=123, telegram_id=456, ttl_seconds=60)
     payload = decode_access_token(token)
 
     assert payload["user_id"] == 123
     assert payload["telegram_id"] == 456
     assert payload["exp"] >= payload["iat"]
+
+
+def test_create_and_decode_access_token_without_telegram_id():
+    token = create_access_token(user_id=321, ttl_seconds=60)
+    payload = decode_access_token(token)
+
+    assert payload["user_id"] == 321
+    assert "telegram_id" not in payload
 
 
 def test_decode_access_token_rejects_tampered_token():

--- a/utils/phone.py
+++ b/utils/phone.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import re
+
+
+def normalize_phone(phone: str) -> str:
+    """Normalize a phone number to a stable digits-only format."""
+
+    raw_value = (phone or "").strip()
+    digits = re.sub(r"\D", "", raw_value)
+    if not digits:
+        raise ValueError("phone_empty")
+
+    if len(digits) == 10:
+        digits = f"7{digits}"
+    elif len(digits) == 11 and digits.startswith("8"):
+        digits = f"7{digits[1:]}"
+
+    if len(digits) != 11:
+        raise ValueError("phone_invalid")
+
+    return digits


### PR DESCRIPTION
### Motivation
- Remove frontend dependency on Telegram WebApp `initData` for profile access by supporting a phone+OTP login flow issued by the bot.
- Provide a secure, minimal backend flow: request code -> bot sends code -> verify code -> issue JWT, while keeping existing Telegram-based auth for compatibility.
- Ensure users can be identified/linked by `phone` and `telegram_id` and prepare protected per-user APIs for orders/cart/addresses.

### Description
- Add phone normalization helper `utils/phone.py` and integrate it into user services for stable phone storage and lookup via `normalize_phone`.
- Extend `services/users.py` to support creating/finding users by phone, attaching/merging `telegram_id`, and safe phone normalization/unique constraints.
- Change `models` to make `users.telegram_id` nullable, add unique/indexed `phone`, and introduce `LoginCode` model (`login_codes`) to store hashed OTP records only.
- Update `initdb.py` to create the `login_codes` table and add unique partial indexes for `users(phone)` and `users(telegram_id)` so schema updates run via existing init path.
- Implement OTP endpoints in `routes_auth.py`: `POST /api/auth/request-code` (accepts phone, creates `login_codes` record, returns `{ok: true}`) and `POST /api/auth/verify-code` (accepts phone+code, validates hash/TTL/attempts, marks used, returns `access_token` + `user`), plus protected `GET /api/me/orders`, `GET /api/me/cart`, and `GET /api/me/addresses` resolved from the token.
- Make legacy `GET /api/me` accept `Authorization: Bearer <token>` (JWT) while preserving the old `telegram_id` query behavior when no token is supplied in `routes_public.py`.
- Update JWT utilities `utils/jwt_auth.py` to allow tokens without `telegram_id` (include optional `telegram_id` on creation), and resolve user by `user_id` first with `telegram_id` fallback when decoding tokens.
- Update `README.txt` with the new auth flow, curl examples, TTL/attempts notes and the requirement to set `JWT_SECRET`.
- Add/adjust tests: extend `tests/test_jwt_auth.py` to cover tokens with and without `telegram_id`.

### Testing
- Ran `pytest` (project tests): all tests passed (`7 passed`).
- Ran syntax checks with `python -m py_compile` on modified modules: success for `routes_auth.py`, `routes_public.py`, `services/users.py`, `utils/jwt_auth.py`, `utils/phone.py`, `models/__init__.py`, and `initdb.py`.
- No automated DB migration framework used; schema changes are applied via the existing `init_db()` path and verified by running the Python compile/tests above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974a901e42c8326ae991f76bbcbd8b9)