### PR TITLE
Прокидывать message_thread_id при ответах (фикс Telegram topics)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1502,3 +1502,30 @@ Telegram WebApp initData login -> JWT
     "cart": { "items": [...], "total": 1000 }
   }
 - Бот также поддерживает legacy формат: { telegram_id, items, total } (без type)
+
+Bot: Telegram topics — прокидывание message_thread_id
+-----------------------------------------------------
+- Исправлено падение `TelegramBadRequest: channel_direct_messages_topic must be specified` в чатах/каналах с включёнными топиками.
+- Добавлен единый хелпер `utils/telegram.py`, который автоматически прокидывает `message_thread_id`, если он есть у исходного сообщения и отправка идёт в тот же чат.
+- Все вызовы `message.answer(...)` и `bot.send_message(...)` в bot-части переведены на `answer_with_thread(...)` / `send_message_with_thread(...)`.
+
+Изменённые файлы
+----------------
+- `utils/telegram.py`
+- `handlers/__init__.py`
+- `handlers/start.py`
+- `handlers/help.py`
+- `handlers/cart.py`
+- `handlers/faq.py`
+- `handlers/admin.py`
+- `handlers/courses.py`
+- `handlers/login.py`
+- `handlers/site_chat.py`
+- `handlers/webapp.py`
+- `handlers/support.py`
+- `handlers/baskets.py`
+- `handlers/profile.py`
+- `handlers/checkout.py`
+- `handlers/payments.py`
+- `services/subscription.py`
+- `README.txt`

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -6,6 +6,7 @@ from aiogram.fsm.state import StatesGroup, State
 from aiogram.fsm.context import FSMContext
 
 from config import ADMIN_IDS_SET
+from utils.telegram import answer_with_thread, send_message_with_thread
 from services import admin_notes as admin_notes_service
 from services import bans as bans_service
 from services import orders as orders_service
@@ -100,17 +101,17 @@ def _build_orders_menu_kb() -> types.InlineKeyboardMarkup:
 
 
 async def _send_web_admin_redirect_message(target_message: types.Message) -> None:
-    await target_message.answer(WEB_ADMIN_REDIRECT_TEXT)
+    await answer_with_thread(target_message, WEB_ADMIN_REDIRECT_TEXT)
 
 
 async def _send_web_admin_redirect_callback(callback: types.CallbackQuery) -> None:
     if callback.message:
-        await callback.message.answer(WEB_ADMIN_REDIRECT_TEXT)
+        await answer_with_thread(callback.message, WEB_ADMIN_REDIRECT_TEXT)
     await callback.answer()
 
 
 async def _send_orders_menu(message: types.Message) -> None:
-    await message.answer(
+    await answer_with_thread(message,
         "📦 <b>Раздел заказов</b>\nВыберите, какие заказы показать:",
         reply_markup=_build_orders_menu_kb(),
     )
@@ -131,7 +132,7 @@ async def open_admin_panel(message: types.Message, state: FSMContext):
 
     await state.clear()
 
-    await message.answer(
+    await answer_with_thread(message,
         "⚙️ Админ-панель.\nВыберите категорию:", reply_markup=get_admin_menu()
     )
 
@@ -141,7 +142,7 @@ async def admin_client_menu_hint(message: types.Message):
     if not _is_admin(message.from_user.id):
         return
 
-    await message.answer(
+    await answer_with_thread(message,
         "Отправьте команду <code>/client &lt;telegram_id&gt;</code>, "
         "чтобы открыть профиль нужного клиента."
     )
@@ -152,7 +153,7 @@ async def admin_ban_menu_hint(message: types.Message):
     if not _is_admin(message.from_user.id):
         return
 
-    await message.answer(
+    await answer_with_thread(message,
         "Используйте команды:\n"
         "• <code>/ban &lt;user_id&gt; [причина]</code>\n"
         "• <code>/unban &lt;user_id&gt;</code>"
@@ -213,7 +214,7 @@ async def admin_notes_menu_hint(message: types.Message):
     if not _is_admin(message.from_user.id):
         return
 
-    await message.answer(
+    await answer_with_thread(message,
         "Работа с заметками:\n"
         "• <code>/note &lt;user_id&gt; &lt;текст&gt;</code> — добавить заметку\n"
         "• <code>/notes &lt;user_id&gt;</code> — посмотреть заметки"
@@ -268,7 +269,7 @@ async def admin_back_panel(callback: types.CallbackQuery, state: FSMContext):
     except Exception:
         pass
 
-    await callback.message.answer(
+    await answer_with_thread(callback.message,
         "⚙️ Админ-панель.\nВыберите категорию:", reply_markup=get_admin_menu()
     )
 
@@ -288,7 +289,7 @@ async def admin_home_cb(callback: types.CallbackQuery, state: FSMContext):
     except Exception:
         pass
 
-    await callback.message.answer(
+    await answer_with_thread(callback.message,
         "Главное меню:",
         reply_markup=_get_reply_menu(),
     )
@@ -326,7 +327,7 @@ async def _send_course_access_list(target_message: types.Message) -> None:
     courses = [{"id": item["id"], "name": item["title"]} for item in raw_courses]
     text = "🎓 Выберите курс для управления доступом:" if courses else "Пока нет курсов для управления доступом."
 
-    await target_message.answer(
+    await answer_with_thread(target_message,
         text,
         reply_markup=course_access_list_kb(courses),
     )
@@ -335,7 +336,7 @@ async def _send_course_access_list(target_message: types.Message) -> None:
 async def _send_course_access_info(target_message: types.Message, course_id: int) -> None:
     course = menu_catalog.get_item_by_id(course_id, include_inactive=False, item_type="course")
     if not course:
-        await target_message.answer("Курс не найден или недоступен.")
+        await answer_with_thread(target_message, "Курс не найден или недоступен.")
         return
 
     users = orders_service.get_course_users(course_id)
@@ -363,7 +364,7 @@ async def _send_course_access_info(target_message: types.Message, course_id: int
         if len(users) > 10:
             lines.append(f"… и ещё {len(users) - 10} пользователей")
 
-    await target_message.answer(
+    await answer_with_thread(target_message,
         "\n".join(lines).strip(),
         reply_markup=course_access_actions_kb(course_id),
     )
@@ -413,7 +414,7 @@ async def admin_course_access_grant(callback: types.CallbackQuery, state: FSMCon
     await state.update_data(course_id=course_id)
     await state.set_state(CourseAccessState.waiting_grant_user_id)
 
-    await callback.message.answer(
+    await answer_with_thread(callback.message,
         f"Введите user_id для выдачи доступа к курсу <b>{course['title']}</b> (ID: <code>{course_id}</code>):"
     )
     await callback.answer()
@@ -444,7 +445,7 @@ async def admin_course_access_revoke(callback: types.CallbackQuery, state: FSMCo
     await state.update_data(course_id=course_id)
     await state.set_state(CourseAccessState.waiting_revoke_user_id)
 
-    await callback.message.answer(
+    await answer_with_thread(callback.message,
         f"Введите user_id для отзыва доступа к курсу <b>{course['title']}</b> (ID: <code>{course_id}</code>):"
     )
     await callback.answer()
@@ -481,13 +482,13 @@ async def admin_course_access_grant_user(message: types.Message, state: FSMConte
 
     if not course_id:
         await state.clear()
-        await message.answer("Курс не найден в состоянии. Попробуйте снова.")
+        await answer_with_thread(message, "Курс не найден в состоянии. Попробуйте снова.")
         return
 
     try:
         user_id = int((message.text or "").strip())
     except ValueError:
-        await message.answer("Нужно ввести числовой user_id. Попробуйте ещё раз:")
+        await answer_with_thread(message, "Нужно ввести числовой user_id. Попробуйте ещё раз:")
         return
 
     success = orders_service.grant_course_access(
@@ -501,12 +502,12 @@ async def admin_course_access_grant_user(message: types.Message, state: FSMConte
     await state.clear()
 
     if success:
-        await message.answer(
+        await answer_with_thread(message,
             f"Доступ к курсу ID {course_id} выдан пользователю <code>{user_id}</code>."
         )
         await _send_course_access_info(message, course_id)
     else:
-        await message.answer("Не удалось выдать доступ. Попробуйте позже.")
+        await answer_with_thread(message, "Не удалось выдать доступ. Попробуйте позже.")
 
 
 @router.message(CourseAccessState.waiting_revoke_user_id)
@@ -520,13 +521,13 @@ async def admin_course_access_revoke_user(message: types.Message, state: FSMCont
 
     if not course_id:
         await state.clear()
-        await message.answer("Курс не найден в состоянии. Попробуйте снова.")
+        await answer_with_thread(message, "Курс не найден в состоянии. Попробуйте снова.")
         return
 
     try:
         user_id = int((message.text or "").strip())
     except ValueError:
-        await message.answer("Нужно ввести числовой user_id. Попробуйте ещё раз:")
+        await answer_with_thread(message, "Нужно ввести числовой user_id. Попробуйте ещё раз:")
         return
 
     success = orders_service.revoke_course_access(user_id=user_id, course_id=course_id)
@@ -534,12 +535,12 @@ async def admin_course_access_revoke_user(message: types.Message, state: FSMCont
     await state.clear()
 
     if success:
-        await message.answer(
+        await answer_with_thread(message,
             f"Доступ к курсу ID {course_id} отозван у пользователя <code>{user_id}</code>."
         )
         await _send_course_access_info(message, course_id)
     else:
-        await message.answer("Не удалось отозвать доступ. Возможно, его и так не было.")
+        await answer_with_thread(message, "Не удалось отозвать доступ. Возможно, его и так не было.")
 
 
 # =====================================================================
@@ -572,7 +573,7 @@ async def admin_debug_commands(message: types.Message) -> None:
     else:
         lines.append("(нет админских команд)")
 
-    await message.answer("\n".join(lines))
+    await answer_with_thread(message, "\n".join(lines))
 
 
 # =====================================================================
@@ -587,7 +588,7 @@ async def admin_ban_user(message: types.Message) -> None:
 
     parts = (message.text or "").split(maxsplit=2)
     if len(parts) < 2:
-        await message.answer(
+        await answer_with_thread(message,
             "Использование: <code>/ban &lt;user_id&gt; [причина]</code>"
         )
         return
@@ -595,7 +596,7 @@ async def admin_ban_user(message: types.Message) -> None:
     try:
         target_user_id = int(parts[1])
     except ValueError:
-        await message.answer(
+        await answer_with_thread(message,
             "Использование: <code>/ban &lt;user_id&gt; [причина]</code>"
         )
         return
@@ -608,7 +609,7 @@ async def admin_ban_user(message: types.Message) -> None:
     if reason:
         response += f" Причина: {reason}"
 
-    await message.answer(response)
+    await answer_with_thread(message, response)
 
 
 @router.message(Command("unban"))
@@ -618,18 +619,18 @@ async def admin_unban_user(message: types.Message) -> None:
 
     parts = (message.text or "").split(maxsplit=1)
     if len(parts) < 2:
-        await message.answer("Использование: <code>/unban &lt;user_id&gt;</code>")
+        await answer_with_thread(message, "Использование: <code>/unban &lt;user_id&gt;</code>")
         return
 
     try:
         target_user_id = int(parts[1])
     except ValueError:
-        await message.answer("Использование: <code>/unban &lt;user_id&gt;</code>")
+        await answer_with_thread(message, "Использование: <code>/unban &lt;user_id&gt;</code>")
         return
 
     bans_service.unban_user(target_user_id)
 
-    await message.answer(f"Пользователь {target_user_id} разбанен.")
+    await answer_with_thread(message, f"Пользователь {target_user_id} разбанен.")
 
 
 @router.message(Command("note"))
@@ -639,7 +640,7 @@ async def admin_add_note(message: types.Message) -> None:
 
     parts = (message.text or "").split(maxsplit=2)
     if len(parts) < 3:
-        await message.answer(
+        await answer_with_thread(message,
             "Использование: <code>/note &lt;user_id&gt; &lt;текст заметки&gt;</code>"
         )
         return
@@ -647,21 +648,21 @@ async def admin_add_note(message: types.Message) -> None:
     try:
         target_user_id = int(parts[1])
     except ValueError:
-        await message.answer(
+        await answer_with_thread(message,
             "Использование: <code>/note &lt;user_id&gt; &lt;текст заметки&gt;</code>"
         )
         return
 
     note_text = parts[2].strip()
     if not note_text:
-        await message.answer("Текст заметки не может быть пустым.")
+        await answer_with_thread(message, "Текст заметки не может быть пустым.")
         return
 
     admin_notes_service.add_note(
         user_id=target_user_id, admin_id=message.from_user.id, note=note_text
     )
 
-    await message.answer("Заметка добавлена.")
+    await answer_with_thread(message, "Заметка добавлена.")
 
 
 @router.message(Command("notes"))
@@ -671,22 +672,22 @@ async def admin_show_notes(message: types.Message) -> None:
 
     parts = (message.text or "").split(maxsplit=1)
     if len(parts) < 2:
-        await message.answer("Использование: <code>/notes &lt;user_id&gt;</code>")
+        await answer_with_thread(message, "Использование: <code>/notes &lt;user_id&gt;</code>")
         return
 
     try:
         target_user_id = int(parts[1])
     except ValueError:
-        await message.answer("Использование: <code>/notes &lt;user_id&gt;</code>")
+        await answer_with_thread(message, "Использование: <code>/notes &lt;user_id&gt;</code>")
         return
 
     notes = admin_notes_service.list_notes(target_user_id)
     if not notes:
-        await message.answer("Заметок для этого пользователя пока нет.")
+        await answer_with_thread(message, "Заметок для этого пользователя пока нет.")
         return
 
     notes_text = format_user_notes(notes)
-    await message.answer(
+    await answer_with_thread(message,
         "\n".join(
             [f"📝 Заметки для клиента <code>{target_user_id}</code>", "", notes_text]
         ).strip()
@@ -708,13 +709,13 @@ async def admin_client_profile(message: types.Message) -> None:
     usage_text = "Использование: <code>/client &lt;telegram_id_пользователя&gt;</code>"
     parts = (message.text or "").split(maxsplit=1)
     if len(parts) < 2:
-        await message.answer(usage_text)
+        await answer_with_thread(message, usage_text)
         return
 
     try:
         target_user_id = int(parts[1].strip())
     except ValueError:
-        await message.answer(usage_text)
+        await answer_with_thread(message, usage_text)
         return
 
     user_stats = user_stats_service.get_user_order_stats(target_user_id)
@@ -734,7 +735,7 @@ async def admin_client_profile(message: types.Message) -> None:
     )
 
     if not has_data:
-        await message.answer(
+        await answer_with_thread(message,
             "По этому пользователю пока нет данных (заказов и курсов не найдено)."
         )
         return
@@ -747,7 +748,7 @@ async def admin_client_profile(message: types.Message) -> None:
         notes=notes,
         notes_limit=5,
     )
-    await message.answer(text)
+    await answer_with_thread(message, text)
 
 
 # =====================================================================
@@ -801,7 +802,7 @@ async def admin_orders_filter(callback: types.CallbackQuery):
     try:
         await callback.message.edit_text(text, reply_markup=_build_orders_menu_kb())
     except Exception:
-        await callback.message.answer(text, reply_markup=_build_orders_menu_kb())
+        await answer_with_thread(callback.message, text, reply_markup=_build_orders_menu_kb())
 
     for order in orders:
         status = order.get("status", orders_service.STATUS_NEW)
@@ -813,7 +814,7 @@ async def admin_orders_filter(callback: types.CallbackQuery):
             f"user_id=<code>{user_id}</code>",
         ]
 
-        await callback.message.answer(
+        await answer_with_thread(callback.message,
             "\n".join(header_lines),
             reply_markup=_build_order_actions_kb(order_id, user_id),
         )
@@ -853,7 +854,7 @@ async def admin_order_open(callback: types.CallbackQuery) -> None:
         ]
     )
 
-    await callback.message.answer(format_order_detail_text(order), reply_markup=kb)
+    await answer_with_thread(callback.message, format_order_detail_text(order), reply_markup=kb)
     await callback.answer()
 
 
@@ -886,7 +887,7 @@ async def admin_order_paid(callback: types.CallbackQuery) -> None:
         if granted_count > 0:
             admin_text += f"\nОткрыт доступ к {granted_count} курсам пользователю."
 
-        await callback.message.answer(admin_text)
+        await answer_with_thread(callback.message, admin_text)
 
         # Уведомляем пользователя о статусе/доступе
         try:
@@ -908,15 +909,18 @@ async def admin_order_paid(callback: types.CallbackQuery) -> None:
 
             if user_text:
                 try:
-                    await callback.message.bot.send_message(
-                        chat_id=user_id, text=user_text
+                    await send_message_with_thread(
+                        callback.message.bot,
+                        chat_id=user_id,
+                        text=user_text,
+                        source_message=callback.message,
                     )
                 except Exception as e:
                     print(
                         f"Failed to notify user {user_id} about order {order_id}: {e}"
                     )
     else:
-        await callback.message.answer("Не удалось изменить статус заказа.")
+        await answer_with_thread(callback.message, "Не удалось изменить статус заказа.")
 
     await callback.answer()
 
@@ -941,7 +945,7 @@ async def admin_order_archive(callback: types.CallbackQuery) -> None:
         order_id, orders_service.STATUS_ARCHIVED
     )
     if success:
-        await callback.message.answer(f"Заказ №{order_id} отправлен в архив.")
+        await answer_with_thread(callback.message, f"Заказ №{order_id} отправлен в архив.")
 
         order = orders_service.get_order_by_id(order_id)
         try:
@@ -951,18 +955,20 @@ async def admin_order_archive(callback: types.CallbackQuery) -> None:
 
         if user_id:
             try:
-                await callback.message.bot.send_message(
+                await send_message_with_thread(
+                    callback.message.bot,
                     chat_id=user_id,
                     text=format_order_status_changed_for_user(
                         order_id, orders_service.STATUS_ARCHIVED
                     ),
+                    source_message=callback.message,
                 )
             except Exception as e:
                 print(
                     f"Failed to notify user {user_id} about order {order_id}: {e}"
                 )
     else:
-        await callback.message.answer("Не удалось изменить статус заказа.")
+        await answer_with_thread(callback.message, "Не удалось изменить статус заказа.")
 
     await callback.answer()
 
@@ -1000,7 +1006,7 @@ async def admin_order_client_profile(callback: types.CallbackQuery) -> None:
     )
 
     if not has_data:
-        await callback.message.answer(
+        await answer_with_thread(callback.message,
             "По этому пользователю пока нет данных (заказов и курсов не найдено)."
         )
         await callback.answer()
@@ -1014,7 +1020,7 @@ async def admin_order_client_profile(callback: types.CallbackQuery) -> None:
         notes=notes,
         notes_limit=5,
     )
-    await callback.message.answer(text)
+    await answer_with_thread(callback.message, text)
     await callback.answer()
 
 
@@ -1027,7 +1033,7 @@ async def admin_go_main(message: types.Message, state: FSMContext):
         return
 
     await state.clear()
-    await message.answer(
+    await answer_with_thread(message,
         "Главное меню:",
         reply_markup=_get_reply_menu(),
     )

--- a/handlers/baskets.py
+++ b/handlers/baskets.py
@@ -2,6 +2,7 @@ from aiogram import F, Router, types
 from aiogram.types import CallbackQuery
 
 from config import ADMIN_IDS
+from utils.telegram import answer_with_thread
 from services.subscription import ensure_subscribed
 
 router = Router()
@@ -21,7 +22,7 @@ async def show_baskets(message: types.Message) -> None:
     if not await ensure_subscribed(message, message.bot, is_admin=is_admin):
         return
 
-    await message.answer(WEBAPP_BASKETS_MESSAGE)
+    await answer_with_thread(message, WEBAPP_BASKETS_MESSAGE)
 
 
 @router.callback_query(F.data.startswith("catalog:"))
@@ -45,7 +46,7 @@ async def baskets_page_callback(callback: CallbackQuery) -> None:
         await callback.answer("Некорректные данные запроса 😕", show_alert=True)
         return
 
-    await callback.message.answer(WEBAPP_BASKETS_MESSAGE)
+    await answer_with_thread(callback.message, WEBAPP_BASKETS_MESSAGE)
     await callback.answer()
 
 
@@ -58,7 +59,7 @@ async def add_basket_to_cart(callback: CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_BASKETS_MESSAGE)
+    await answer_with_thread(callback.message, WEBAPP_BASKETS_MESSAGE)
     await callback.answer()
 
 
@@ -71,7 +72,7 @@ async def add_to_favorites(callback: CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_BASKETS_MESSAGE)
+    await answer_with_thread(callback.message, WEBAPP_BASKETS_MESSAGE)
     await callback.answer()
 
 
@@ -84,5 +85,5 @@ async def remove_from_favorites(callback: CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_BASKETS_MESSAGE)
+    await answer_with_thread(callback.message, WEBAPP_BASKETS_MESSAGE)
     await callback.answer()

--- a/handlers/cart.py
+++ b/handlers/cart.py
@@ -4,6 +4,7 @@ from aiogram.types import CallbackQuery
 from aiogram.fsm.context import FSMContext
 
 from config import ADMIN_IDS
+from utils.telegram import answer_with_thread
 from keyboards.cart_keyboards import cart_kb
 from services import cart as cart_service
 from services import menu_catalog
@@ -68,7 +69,7 @@ async def _send_cart(message: types.Message, *, edit: bool = False) -> None:
     if edit:
         await message.edit_text(text, reply_markup=keyboard)
     else:
-        await message.answer(text, reply_markup=keyboard)
+        await answer_with_thread(message, text, reply_markup=keyboard)
 
 
 @router.message(F.text == "🛒 Корзина")
@@ -91,7 +92,7 @@ async def clear_user_cart(message: types.Message) -> None:
         return
 
     cart_service.clear_cart(user_id)
-    await message.answer("Корзина очищена.")
+    await answer_with_thread(message, "Корзина очищена.")
 
 
 @router.callback_query(F.data == "cart:nop")

--- a/handlers/courses.py
+++ b/handlers/courses.py
@@ -2,6 +2,7 @@ from aiogram import F, Router, types
 from aiogram.types import CallbackQuery
 
 from config import ADMIN_IDS
+from utils.telegram import answer_with_thread
 from services.subscription import ensure_subscribed
 
 router = Router()
@@ -21,7 +22,7 @@ async def courses_entry(message: types.Message) -> None:
     if not await ensure_subscribed(message, message.bot, is_admin=is_admin):
         return
 
-    await message.answer(WEBAPP_COURSES_MESSAGE)
+    await answer_with_thread(message, WEBAPP_COURSES_MESSAGE)
 
 
 @router.callback_query(F.data.startswith("courses:list:"))
@@ -33,7 +34,7 @@ async def courses_list_callback(callback: CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_COURSES_MESSAGE)
+    await answer_with_thread(callback.message, WEBAPP_COURSES_MESSAGE)
     await callback.answer()
 
 
@@ -58,7 +59,7 @@ async def courses_catalog_callback(callback: CallbackQuery) -> None:
         await callback.answer("Некорректные данные запроса 😕", show_alert=True)
         return
 
-    await callback.message.answer(WEBAPP_COURSES_MESSAGE)
+    await answer_with_thread(callback.message, WEBAPP_COURSES_MESSAGE)
     await callback.answer()
 
 
@@ -71,5 +72,5 @@ async def add_course_to_cart(callback: CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_COURSES_MESSAGE)
+    await answer_with_thread(callback.message, WEBAPP_COURSES_MESSAGE)
     await callback.answer()

--- a/handlers/faq.py
+++ b/handlers/faq.py
@@ -5,6 +5,7 @@ import aiohttp
 from aiogram import F, Router, types
 
 from handlers.support import remember_user_question
+from utils.telegram import answer_with_thread
 
 API_BASE_URL = os.getenv("API_URL") or (os.getenv("BASE_URL", "http://localhost:8000").rstrip("/") + "/api")
 
@@ -53,7 +54,7 @@ def _truncate(text: str, limit: int = 60) -> str:
 async def show_faq_categories(message: types.Message):
     data = await _get_json("/faq") or []
     if not data:
-        await message.answer("База знаний пока пуста.")
+        await answer_with_thread(message, "База знаний пока пуста.")
         return
 
     categories = []
@@ -63,7 +64,7 @@ async def show_faq_categories(message: types.Message):
             categories.append(category)
 
     if not categories:
-        await message.answer("Категории не найдены.")
+        await answer_with_thread(message, "Категории не найдены.")
         return
 
     keyboard = types.InlineKeyboardMarkup(
@@ -72,7 +73,7 @@ async def show_faq_categories(message: types.Message):
             for category in categories
         ]
     )
-    await message.answer("Выберите раздел", reply_markup=keyboard)
+    await answer_with_thread(message, "Выберите раздел", reply_markup=keyboard)
 
 
 @faq_router.callback_query(F.data.startswith("faq:cat:"))
@@ -128,5 +129,5 @@ async def load_question(callback: types.CallbackQuery):
             ]
         ]
     )
-    await callback.message.answer(f"<b>{question}</b>\n\n{answer}", reply_markup=keyboard)
+    await answer_with_thread(callback.message, f"<b>{question}</b>\n\n{answer}", reply_markup=keyboard)
     await callback.answer()

--- a/handlers/help.py
+++ b/handlers/help.py
@@ -1,6 +1,7 @@
 from aiogram import Router, types, F
 from aiogram.filters import Command
 from aiogram.types import CallbackQuery
+from utils.telegram import answer_with_thread
 
 router = Router()
 
@@ -14,28 +15,28 @@ HELP_MESSAGE = (
 @router.message(Command("help"))
 @router.message(F.text == "❓ Помощь")
 async def cmd_help(message: types.Message) -> None:
-    await message.answer(HELP_MESSAGE)
+    await answer_with_thread(message, HELP_MESSAGE)
 
 
 @router.callback_query(F.data == "help:main")
 async def cb_help_main(callback: CallbackQuery) -> None:
-    await callback.message.answer(HELP_MESSAGE)
+    await answer_with_thread(callback.message, HELP_MESSAGE)
     await callback.answer()
 
 
 @router.callback_query(F.data == "help:order")
 async def cb_help_order(callback: CallbackQuery) -> None:
-    await callback.message.answer(HELP_MESSAGE)
+    await answer_with_thread(callback.message, HELP_MESSAGE)
     await callback.answer()
 
 
 @router.callback_query(F.data == "help:payment")
 async def cb_help_payment(callback: CallbackQuery) -> None:
-    await callback.message.answer(HELP_MESSAGE)
+    await answer_with_thread(callback.message, HELP_MESSAGE)
     await callback.answer()
 
 
 @router.callback_query(F.data == "help:course")
 async def cb_help_course(callback: CallbackQuery) -> None:
-    await callback.message.answer(HELP_MESSAGE)
+    await answer_with_thread(callback.message, HELP_MESSAGE)
     await callback.answer()

--- a/handlers/login.py
+++ b/handlers/login.py
@@ -9,6 +9,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 
 from config import get_settings
+from utils.telegram import answer_with_thread
 from services.subscription import ensure_subscribed
 
 router = Router()
@@ -71,7 +72,7 @@ async def login_entry(message: types.Message, state: FSMContext) -> None:
 
     await state.clear()
     await state.set_state(LoginState.waiting_for_phone)
-    await message.answer("Введите номер телефона в формате +7...")
+    await answer_with_thread(message, "Введите номер телефона в формате +7...")
 
 
 @router.message(LoginState.waiting_for_phone)
@@ -83,7 +84,7 @@ async def login_receive_phone(message: types.Message, state: FSMContext) -> None
         raw_phone = (message.text or "").strip()
 
     if not raw_phone:
-        await message.answer("Не вижу номер телефона. Отправьте его текстом или контактом.")
+        await answer_with_thread(message, "Не вижу номер телефона. Отправьте его текстом или контактом.")
         return
 
     phone = _normalize_phone(raw_phone)
@@ -103,7 +104,7 @@ async def login_receive_phone(message: types.Message, state: FSMContext) -> None
 
         if code:
             minutes = _format_minutes(expires_in_seconds)
-            await message.answer(
+            await answer_with_thread(message,
                 f"Код для входа: {code}. Действует {minutes} минут."
             )
             return
@@ -112,7 +113,7 @@ async def login_receive_phone(message: types.Message, state: FSMContext) -> None
 
     if status == 404:
         logger.error("Create-code endpoint not found: %s", CREATE_CODE_ENDPOINT)
-        await message.answer(
+        await answer_with_thread(message,
             "Не удалось получить код, попробуйте позже. "
             "Похоже, endpoint /api/bot/auth/create-code ещё не подключён — сообщите администратору."
         )
@@ -125,4 +126,4 @@ async def login_receive_phone(message: types.Message, state: FSMContext) -> None
     else:
         logger.error("Create-code API unexpected response status=%s response=%s", status, response)
 
-    await message.answer("Не удалось получить код, попробуйте позже")
+    await answer_with_thread(message, "Не удалось получить код, попробуйте позже")

--- a/handlers/payments.py
+++ b/handlers/payments.py
@@ -1,4 +1,5 @@
 from aiogram import Router
+from utils.telegram import answer_with_thread
 
 router = Router()
 

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -3,6 +3,7 @@ from aiogram.filters import Command
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
 
 from config import ADMIN_IDS, get_settings
+from utils.telegram import answer_with_thread
 from services.subscription import ensure_subscribed
 
 router = Router()
@@ -45,7 +46,7 @@ async def show_profile(message: types.Message) -> None:
     if banner:
         await message.answer_photo(photo=banner, caption="👤 Ваш профиль")
 
-    await message.answer(WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
+    await answer_with_thread(message, WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
 
 
 @router.message(F.text == "❤️ Избранное")
@@ -57,7 +58,7 @@ async def show_favorites(message: types.Message) -> None:
     if not await ensure_subscribed(message, message.bot, is_admin=is_admin):
         return
 
-    await message.answer(WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
+    await answer_with_thread(message, WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
 
 
 @router.callback_query(F.data == "profile:orders:active")
@@ -68,7 +69,7 @@ async def profile_orders_active(callback: types.CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
+    await answer_with_thread(callback.message, WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
     await callback.answer()
 
 
@@ -80,7 +81,7 @@ async def profile_orders_finished(callback: types.CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
+    await answer_with_thread(callback.message, WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
     await callback.answer()
 
 
@@ -92,7 +93,7 @@ async def profile_courses(callback: types.CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
+    await answer_with_thread(callback.message, WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
     await callback.answer()
 
 
@@ -104,5 +105,5 @@ async def profile_open_webapp(callback: types.CallbackQuery) -> None:
     if not await ensure_subscribed(callback, callback.message.bot, is_admin=is_admin):
         return
 
-    await callback.message.answer(WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
+    await answer_with_thread(callback.message, WEBAPP_PROFILE_MESSAGE, reply_markup=_build_profile_keyboard())
     await callback.answer()

--- a/handlers/site_chat.py
+++ b/handlers/site_chat.py
@@ -7,6 +7,7 @@ from aiogram import F, Router
 from aiogram.types import Message
 
 from config import get_settings
+from utils.telegram import answer_with_thread
 from utils import site_chat_storage
 
 API_BASE_URL = os.getenv("API_URL") or os.getenv("BASE_URL", "http://localhost:8000")
@@ -70,7 +71,7 @@ async def handle_manager_reply(message: Message):
             reply.message_id
         )
     if not session_id:
-        await message.answer(
+        await answer_with_thread(message,
             "❌ Не вижу номер чата (#ID). Ответь реплаем на уведомление о запросе."
         )
         return
@@ -81,14 +82,14 @@ async def handle_manager_reply(message: Message):
 
     text = message.text or message.caption
     if not text:
-        await message.answer("❌ Пустое сообщение.")
+        await answer_with_thread(message, "❌ Пустое сообщение.")
         return
 
     try:
         await _post_manager_reply(API_BASE_URL, session_id, text)
     except Exception as exc:
         logging.exception("Failed to send manager reply to backend")
-        await message.answer(f"❌ Ошибка отправки на сайт: {exc}")
+        await answer_with_thread(message, f"❌ Ошибка отправки на сайт: {exc}")
         return
 
-    await message.answer(f"✅ Отправлено на сайт (чат #{session_id})")
+    await answer_with_thread(message, f"✅ Отправлено на сайт (чат #{session_id})")

--- a/handlers/webapp.py
+++ b/handlers/webapp.py
@@ -11,6 +11,7 @@ from aiogram.types import (
 )
 
 from config import get_settings
+from utils.telegram import answer_with_thread, send_message_with_thread
 from services import menu_catalog, orders as orders_service, users as users_service
 from services.cart import add_to_cart
 from utils.texts import format_order_for_admin, format_price
@@ -203,7 +204,7 @@ async def _handle_adminsite_payload(message: Message, payload: dict) -> None:
         added_count += 1
 
     reply_markup = _build_adminsite_menu()
-    await message.answer(
+    await answer_with_thread(message,
         f"Добавлено: {added_count} позиций", reply_markup=reply_markup, disable_notification=True
     )
 
@@ -243,7 +244,7 @@ async def handle_webapp_data(message: Message) -> None:
         webapp_order = _parse_webapp_order_payload(data)
         if webapp_order is None:
             logging.warning("Не удалось распознать заказ из web_app_data: %s", data)
-            await message.answer("Не удалось распознать заказ. Попробуйте ещё раз из корзины.")
+            await answer_with_thread(message, "Не удалось распознать заказ. Попробуйте ещё раз из корзины.")
             return
         items, total = webapp_order
         user_name = (
@@ -281,7 +282,7 @@ async def handle_webapp_data(message: Message) -> None:
             )
         lines.append("")
         lines.append(f"Итого: <b>{format_price(total)}</b>")
-        await message.answer(
+        await answer_with_thread(message,
             "\n".join(lines),
             reply_markup=_build_order_user_keyboard(order_id),
         )
@@ -294,7 +295,12 @@ async def handle_webapp_data(message: Message) -> None:
             )
             for admin_id in admin_ids:
                 try:
-                    await message.bot.send_message(admin_id, admin_message)
+                    await send_message_with_thread(
+                        message.bot,
+                        admin_id,
+                        admin_message,
+                        source_message=message,
+                    )
                 except Exception:
                     logging.exception("Не удалось отправить заказ админу %s", admin_id)
         return
@@ -348,9 +354,9 @@ async def handle_webapp_data(message: Message) -> None:
     keyboard = _build_cart_keyboard()
     response_text = f"✅ Добавлено в корзину: {product_name} (x{qty_int}). Открыть корзину?"
     if keyboard:
-        await message.answer(response_text, reply_markup=keyboard)
+        await answer_with_thread(message, response_text, reply_markup=keyboard)
     else:
-        await message.answer(f"{response_text}\n\nНажми 🛒 Корзина")
+        await answer_with_thread(message, f"{response_text}\n\nНажми 🛒 Корзина")
 
 
 @router.callback_query(F.data.startswith("webapp:order:cancel:"))

--- a/services/subscription.py
+++ b/services/subscription.py
@@ -5,6 +5,7 @@ from aiogram import Bot
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from config import ADMIN_IDS, get_settings
+from utils.telegram import answer_with_thread
 from utils.texts import format_subscription_required_text
 
 
@@ -187,7 +188,7 @@ async def ensure_subscribed(
     text = format_subscription_required_text()
 
     if isinstance(message_or_callback, CallbackQuery):
-        await message_or_callback.message.answer(text, reply_markup=keyboard)
+        await answer_with_thread(message_or_callback.message, text, reply_markup=keyboard)
         try:
             await message_or_callback.answer(
                 "Подписка на канал обязательна для продолжения.", show_alert=True

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+from aiogram import types
+from aiogram.client.bot import Bot
+
+
+def _get_message_thread_id(message: types.Message | None) -> int | None:
+    if not message:
+        return None
+    thread_id = getattr(message, "message_thread_id", None)
+    return thread_id if thread_id is not None else None
+
+
+def _should_use_thread(source_message: types.Message | None, chat_id: int | None) -> bool:
+    if not source_message or chat_id is None:
+        return False
+    return bool(source_message.chat and source_message.chat.id == chat_id)
+
+
+def apply_message_thread_id(
+    source_message: types.Message | None,
+    chat_id: int | None,
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    if "message_thread_id" in kwargs:
+        return kwargs
+
+    if not _should_use_thread(source_message, chat_id):
+        return kwargs
+
+    thread_id = _get_message_thread_id(source_message)
+    if thread_id is None:
+        return kwargs
+
+    return {**kwargs, "message_thread_id": thread_id}
+
+
+async def answer_with_thread(message: types.Message, text: str, **kwargs: Any):
+    patched_kwargs = apply_message_thread_id(
+        message,
+        message.chat.id if message.chat else None,
+        kwargs,
+    )
+    return await message.answer(text, **patched_kwargs)
+
+
+async def answer_photo_with_thread(message: types.Message, **kwargs: Any):
+    patched_kwargs = apply_message_thread_id(
+        message,
+        message.chat.id if message.chat else None,
+        kwargs,
+    )
+    return await message.answer_photo(**patched_kwargs)
+
+
+async def send_message_with_thread(
+    bot: Bot,
+    chat_id: int,
+    text: str,
+    *,
+    source_message: types.Message | None = None,
+    **kwargs: Any,
+):
+    patched_kwargs = apply_message_thread_id(source_message, chat_id, kwargs)
+    return await bot.send_message(chat_id, text, **patched_kwargs)


### PR DESCRIPTION
### Motivation
- Исправить падение `TelegramBadRequest: channel_direct_messages_topic must be specified` при отправке сообщений в чаты/каналы с включёнными топиками.
- Обеспечить централизованную и безопасную отправку сообщений: если у исходного сообщения есть `message_thread_id`, то он должен передаваться при ответе или при вызове `bot.send_message` в тот же чат.

### Description
- Добавлен хелпер `utils/telegram.py` с функциями `apply_message_thread_id`, `answer_with_thread`, `answer_photo_with_thread` и `send_message_with_thread`, которые автоматически подставляют `message_thread_id` при необходимости.
- Все внутренние вызовы `message.answer(...)` и отправки админских/внешних уведомлений заменены на `answer_with_thread(...)` / `send_message_with_thread(...)`, а `_safe_answer` и `_safe_answer_photo` в `handlers/start.py` переведены на новые хелперы.
- Поправлены соответствующие хендлеры и сервис: обновлены файлы в `handlers/` (включая `start.py`, `admin.py`, `webapp.py`, `support.py`, и др.) и `services/subscription.py` для централизованной передачи `message_thread_id`.
- Обновлён `README.txt` с описанием фикса и списком изменённых файлов.

### Testing
- Собраны/скомпилированы модули командой `python -m compileall utils handlers services` без ошибок.
- Запущены unit tests `pytest -q`, все тесты успешно прошли (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e47b9ff88326832f2eb236be6f78)